### PR TITLE
release: v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,74 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Architecture Refactoring
+## [0.1.2] - 2026-01-30
 
-Major internal refactoring to improve code organization and maintainability.
+### Platform Fixes
 
-#### Plot Decomposition
+- Fixed macOS and Windows platform build errors (#4)
+- Added FreeBSD support (#1)
+- Added cross-platform CI build checks for Linux, macOS, Windows, and FreeBSD
+- Pinned cross to v0.2.5 with `--locked` for reproducible CI builds
 
-The `Plot` struct has been decomposed into focused component managers:
+### Contributors
 
-- **PlotConfiguration** (`src/core/plot/configuration.rs`) - Display settings (title, labels, dimensions, theme)
-- **SeriesManager** (`src/core/plot/series_manager.rs`) - Data series storage and auto-coloring
-- **LayoutManager** (`src/core/plot/layout_manager.rs`) - Legend, grid, ticks, margins, axis limits
-- **RenderPipeline** (`src/core/plot/render_pipeline.rs`) - Backend selection, parallel/pooled rendering
-
-The public API remains unchanged - this is purely an internal refactoring.
-
-#### PlotBuilder API Enhancements
-
-Added missing methods to `PlotBuilder<C>` for better API consistency:
-
-- `legend(Position)` - Set legend position
-- `xscale(AxisScale)` / `yscale(AxisScale)` - Set axis scales
-- `backend(BackendType)` - Set rendering backend
-- `gpu(bool)` - Enable GPU acceleration (requires `gpu` feature)
-- `style(LineStyle)` - Set line style (for `LineConfig`)
-- `get_backend_name()` - Get current backend name
-- `export_svg(path)` - Export to SVG file
-- `save_pdf(path)` - Export to PDF file (requires `pdf` feature)
-- `save_with_size(path, width, height)` - Save with specific dimensions
-
-#### Code Quality Improvements
-
-- Unified coordinate transform logic via `CoordinateTransform` struct
-- Consolidated style re-exports via `ruviz::style` module
-- Terminal method macro (`impl_terminal_methods!`) reduces boilerplate
-- PlotBuilder now implements `Clone`
-
-### API Changes
-
-#### Deprecated (still work, will warn)
-
-- `Plot::dimensions(w, h)` → Use `size(w, h)` or `size_px(w, h)` instead
-- `PlotBuilder::end_series()` → Series finalize automatically; use `.save()` directly
-
-#### Method Renames
-
-- `.width()` on line builders → `.line_width()` for clarity
-
-### Migration Guide
-
-```rust
-// Before (deprecated but still works)
-Plot::new()
-    .line(&x, &y)
-    .width(2.0)
-    .end_series()
-    .dimensions(800, 600)
-    .save("plot.png")?;
-
-// After (recommended)
-Plot::new()
-    .line(&x, &y)
-    .line_width(2.0)
-    .size_px(800, 600)
-    .save("plot.png")?;
-```
-
-### Testing
-
-- 761 library tests passing with `--all-features`
-- 132 doctests passing
-- All benchmarks verified with no performance regression
+- [@yonas](https://github.com/yonas) - FreeBSD support (#1)
+- [@Ameyanagi](https://github.com/Ameyanagi) - Cross-platform build fixes (#4)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 rust-version = "1.87"
 authors = ["Ruviz Contributors"]


### PR DESCRIPTION
## Summary
- Bump version to 0.1.2 in Cargo.toml
- Update CHANGELOG.md with platform fixes and contributors from PRs #1 and #4