### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,31 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- _None yet._
+
+## [0.2.0] - 2026-03-31
+
 ### Breaking Changes
 
 - Typst selection is now compile-time gated behind `typst-math`. `Plot::typst(true)`, builder forwarding to `.typst(true)`, and `TextEngineMode::Typst` are unavailable unless the feature is enabled. If your crate makes Typst optional, guard those calls with `#[cfg(feature = "typst-math")]` instead of expecting a runtime `FeatureNotEnabled` error. Without the feature, `.typst(true)` now fails with a compile error such as `no method named 'typst' found`.
+
+### Added
+
+- Added experimental browser and `wasm32` support via the `ruviz-web` crate and the public npm `ruviz` SDK.
+- Added mixed-coordinate inset rendering so Cartesian plots can embed polar, pie, and radar series with configurable inset layout.
+- Added builder chaining parity for common continuation flows and styled annotations, removing explicit `end_series()` workarounds in the supported cases.
+
+### Changed
+
+- Unified browser package naming on `ruviz` and made the JS workspace Bun-first for build, lint, and packaging flows.
+- Aligned raster and SVG mixed-inset rendering behavior, including clipping, DPI-scaled strokes, and auto-placement spacing.
+- Restored and committed golden-image visual fixtures so release validation has stable baseline artifacts again.
+
+### Fixed
+
+- Stabilized interactive zoom/pan, wheel direction, context menu, and save/copy shortcuts across the interactive and GPUI paths.
+- Fixed ndarray view recursion and several export-path DPI, validation, and overwrite edge cases in PNG/SVG rendering.
+- Fixed browser session timing and destroy races, and kept wasm/browser builds continuously checked in CI.
 
 ## [0.1.5] - 2026-03-23
 
@@ -93,7 +115,8 @@ All notable changes to this project will be documented in this file.
 - [@yonas](https://github.com/yonas) - FreeBSD support (#1)
 - [@Ameyanagi](https://github.com/Ameyanagi) - Cross-platform build fixes (#4)
 
-[Unreleased]: https://github.com/Ameyanagi/ruviz/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/Ameyanagi/ruviz/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/Ameyanagi/ruviz/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/Ameyanagi/ruviz/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/Ameyanagi/ruviz/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/Ameyanagi/ruviz/compare/v0.1.2...v0.1.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7450,7 +7450,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -7506,7 +7506,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-gpui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arboard",
  "core-foundation 0.10.0",
@@ -7523,7 +7523,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-web"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ gpui = { git = "https://github.com/Ameyanagi/zed", rev = "6e43ecd17f28afe6f55df3
 
 [package]
 name = "ruviz"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.87"
 authors = ["Ruviz Contributors"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - [Changelog](CHANGELOG.md)
 - [Release Notes Index](docs/releases/README.md)
-- [Latest Release Notes (v0.1.5)](docs/releases/v0.1.5.md)
+- [Latest Release Notes (v0.2.0)](docs/releases/v0.2.0.md)
 
 ## Quick Start
 
@@ -61,6 +61,7 @@ Need typeset math labels? See [Typst Text Mode](#typst-text-mode) below.
 - **Parallel rendering**: Multi-threaded for large datasets (rayon)
 - **GPU acceleration**: Optional wgpu backend (experimental)
 - **Interactive plots**: Optional winit window integration
+- **Mixed-coordinate insets**: Embed polar, pie, and radar plots inside Cartesian figures
 - **Browser runtime**: Experimental `ruviz-web` adapter and `ruviz` npm SDK for `wasm32` canvas rendering
 - **Animation**: GIF export with `record!` macro and easing functions
 - **Cross-platform**: Linux, macOS, Windows, and experimental browser/wasm targets
@@ -71,7 +72,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruviz = "0.1.5"
+ruviz = "0.2.0"
 ```
 
 ### Feature Flags
@@ -80,7 +81,7 @@ Choose features based on your needs:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel", "simd"] }
+ruviz = { version = "0.2.0", features = ["parallel", "simd"] }
 ```
 
 | Feature | Description | Use When |
@@ -126,7 +127,7 @@ Enable Typst text rendering:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["typst-math"] }
+ruviz = { version = "0.2.0", features = ["typst-math"] }
 ```
 
 Use `.typst(true)` on a plot to render all static text surfaces (titles, axis labels, ticks,
@@ -167,7 +168,7 @@ error[E0599]: no variant or associated item named `Typst` found for enum `TextEn
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", default-features = false }
+ruviz = { version = "0.2.0", default-features = false }
 
 [features]
 default = []
@@ -322,7 +323,7 @@ Enable the `animation` feature for this example:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["animation"] }
+ruviz = { version = "0.2.0", features = ["animation"] }
 ```
 
 ```rust
@@ -506,6 +507,6 @@ at your option.
 
 ---
 
-**Status**: v0.1.5 - Early development, API may change. Production use at your own risk.
+**Status**: v0.2.0 - Early development, API may change. Production use at your own risk.
 
 **Support**: [Open an issue](https://github.com/Ameyanagi/ruviz/issues) or [start a discussion](https://github.com/Ameyanagi/ruviz/discussions)

--- a/crates/ruviz-gpui/Cargo.toml
+++ b/crates/ruviz-gpui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-gpui"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ default = []
 gpu = ["ruviz/gpu"]
 
 [dependencies]
-ruviz = { version = "0.1.5", path = "../.." }
+ruviz = { version = "0.2.0", path = "../.." }
 image = "0.25"
 smallvec = "1.15"
 futures = "0.3"

--- a/crates/ruviz-web/Cargo.toml
+++ b/crates/ruviz-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-web"
-version = "0.1.5"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.87"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ readme = "README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ruviz = { version = "0.1.5", path = "../..", default-features = false }
+ruviz = { version = "0.2.0", path = "../..", default-features = false }
 js-sys = "0.3.92"
 wasm-bindgen = "0.2.105"
 console_error_panic_hook = "0.1.7"

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,14 +2,15 @@
 
 Get started with ruviz in less than 5 minutes!
 
-## What's New in v0.1.5
+## What's New in v0.2.0
 
-- New `ruviz-gpui` crate: GPUI component adapter for interactive and reactive plotting.
-- GPUI interactive session support and reactive plotting hooks for embedded and streaming use cases.
-- Default tick marks now render on all four sides of the plot frame (`.ticks_bottom_left()` restores the old layout).
+- Experimental browser and wasm support via `ruviz-web` and the npm `ruviz` SDK.
+- Mixed-coordinate inset rendering for pie, radar, and polar content inside Cartesian plots.
+- Typst APIs are now compile-time gated behind the `typst-math` feature.
+- Builder chaining parity fixes remove the need for explicit `end_series()` workarounds in common flows.
 
 See full details:
-- [Release notes for v0.1.5](releases/v0.1.5.md)
+- [Release notes for v0.2.0](releases/v0.2.0.md)
 - [Project changelog](../CHANGELOG.md)
 
 ## Installation
@@ -23,7 +24,7 @@ cd my_plot
 2. **Add ruviz to your `Cargo.toml`**:
 ```toml
 [dependencies]
-ruviz = "0.1.5"
+ruviz = "0.2.0"
 ```
 
 3. **Write your first plot** in `src/main.rs`:
@@ -62,8 +63,8 @@ an embedded interactive plot view:
 
 ```toml
 [dependencies]
-ruviz = "0.1.5"
-ruviz-gpui = "0.1.0"
+ruviz = "0.2.0"
+ruviz-gpui = "0.2.0"
 ```
 
 The embedded GPUI plot now supports the same core workflow as the standalone
@@ -85,7 +86,7 @@ If you want publication-style math in labels and titles, enable Typst text rende
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["typst-math"] }
+ruviz = { version = "0.2.0", features = ["typst-math"] }
 ```
 
 `.typst(true)` is only available when `typst-math` is enabled. Without it, the compile error is:
@@ -98,7 +99,7 @@ If you want Typst to stay optional in your own crate, forward a local feature fi
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", default-features = false }
+ruviz = { version = "0.2.0", default-features = false }
 
 [features]
 default = []
@@ -349,7 +350,7 @@ Plot::new()
 ### With polars (requires `polars_support` feature)
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["polars_support"] }
+ruviz = { version = "0.2.0", features = ["polars_support"] }
 polars = "0.35"
 ```
 
@@ -376,14 +377,14 @@ Plot::new()
 Enable parallel rendering:
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel"] }
+ruviz = { version = "0.2.0", features = ["parallel"] }
 ```
 
 ### For Very Large Datasets (>100K points)
 Enable SIMD optimization:
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel", "simd"] }
+ruviz = { version = "0.2.0", features = ["parallel", "simd"] }
 ```
 
 ### Large Dataset Export

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -62,14 +62,14 @@ Add ruviz to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruviz = "0.1.5"
+ruviz = "0.2.0"
 ```
 
 Or with specific features:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.2.0", features = ["ndarray_support", "parallel"] }
 ```
 
 ## Feature Flags
@@ -79,7 +79,7 @@ ruviz uses feature flags to enable optional functionality. Choose based on your 
 ### Default Features
 
 ```toml
-ruviz = "0.1.5"  # Includes: ndarray, parallel
+ruviz = "0.2.0"  # Includes: ndarray, parallel
 ```
 
 **Enabled by default**:
@@ -107,40 +107,40 @@ SVG export is available without an extra feature flag. The legacy `svg` feature 
 
 ```toml
 # High performance (parallel + SIMD)
-ruviz = { version = "0.1.5", features = ["performance"] }
+ruviz = { version = "0.2.0", features = ["performance"] }
 
 # Maximum capability (all features)
-ruviz = { version = "0.1.5", features = ["full"] }
+ruviz = { version = "0.2.0", features = ["full"] }
 
 # Minimal (no default features)
-ruviz = { version = "0.1.5", default-features = false }
+ruviz = { version = "0.2.0", default-features = false }
 ```
 
 ### Feature Combinations
 
 **Scientific Computing**:
 ```toml
-ruviz = { version = "0.1.5", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.2.0", features = ["ndarray_support", "parallel"] }
 ```
 
 **Data Analysis**:
 ```toml
-ruviz = { version = "0.1.5", features = ["polars_support", "performance"] }
+ruviz = { version = "0.2.0", features = ["polars_support", "performance"] }
 ```
 
 **Publication Quality**:
 ```toml
-ruviz = { version = "0.1.5", features = ["serde", "pdf"] }
+ruviz = { version = "0.2.0", features = ["serde", "pdf"] }
 ```
 
 **Real-time Visualization**:
 ```toml
-ruviz = { version = "0.1.5", features = ["interactive-gpu"] }
+ruviz = { version = "0.2.0", features = ["interactive-gpu"] }
 ```
 
 **Large Datasets**:
 ```toml
-ruviz = { version = "0.1.5", features = ["parallel", "simd", "gpu"] }
+ruviz = { version = "0.2.0", features = ["parallel", "simd", "gpu"] }
 ```
 
 ## Verification
@@ -273,7 +273,7 @@ rustup update
 
 ### Feature Conflicts
 
-**Problem**: `error: package ruviz v0.1.5 cannot be built because it requires rustc 1.87 or newer`
+**Problem**: `error: package ruviz v0.2.0 cannot be built because it requires rustc 1.87 or newer`
 
 **Solution**: Update Rust:
 ```bash
@@ -297,7 +297,7 @@ vulkaninfo
 
 Or disable GPU features:
 ```toml
-ruviz = { version = "0.1.5", default-features = false, features = ["parallel"] }
+ruviz = { version = "0.2.0", default-features = false, features = ["parallel"] }
 ```
 
 ### Memory Issues (Large Datasets)

--- a/docs/guide/03_first_plot.md
+++ b/docs/guide/03_first_plot.md
@@ -166,7 +166,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = "0.1.5"
+ruviz = "0.2.0"
 ```
 
 ## Customization Basics
@@ -304,7 +304,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["ndarray_support"] }
+ruviz = { version = "0.2.0", features = ["ndarray_support"] }
 ndarray = "0.15"
 ```
 

--- a/docs/guide/04_plot_types.md
+++ b/docs/guide/04_plot_types.md
@@ -621,7 +621,7 @@ use the same path as static data.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel"] }
+ruviz = { version = "0.2.0", features = ["parallel"] }
 ```
 
 ### Large Datasets (20K - 100K points)
@@ -630,7 +630,7 @@ consider downsampling where visual density is already saturated.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel", "simd"] }
+ruviz = { version = "0.2.0", features = ["parallel", "simd"] }
 ```
 
 ### Very Large Datasets (> 100K points)

--- a/docs/guide/07_backends.md
+++ b/docs/guide/07_backends.md
@@ -117,7 +117,7 @@ not change the chunk-size path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel"] }
+ruviz = { version = "0.2.0", features = ["parallel"] }
 ```
 
 ```rust
@@ -141,7 +141,7 @@ it helps the `render()` path when parallel rendering is active.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel", "simd"] }
+ruviz = { version = "0.2.0", features = ["parallel", "simd"] }
 ```
 
 ## What `save()` actually does
@@ -198,7 +198,7 @@ back to CPU rendering.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["gpu"] }
+ruviz = { version = "0.2.0", features = ["gpu"] }
 ```
 
 ```rust
@@ -233,7 +233,7 @@ dependency for you.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["interactive"] }
+ruviz = { version = "0.2.0", features = ["interactive"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 ```
 

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -33,7 +33,7 @@ They do **not** currently use identical execution paths.
 
 ```toml
 [dependencies]
-ruviz = "0.1.5"
+ruviz = "0.2.0"
 ```
 
 Useful opt-in features:
@@ -60,7 +60,7 @@ streaming sources can still benefit from the same parallel/DataShader decisions.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel"] }
+ruviz = { version = "0.2.0", features = ["parallel"] }
 ```
 
 ```rust
@@ -84,7 +84,7 @@ override every internal condition used by the parallel renderer.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["parallel", "simd"] }
+ruviz = { version = "0.2.0", features = ["parallel", "simd"] }
 ```
 
 The `simd` feature is used inside the parallel renderer, so it helps when the
@@ -106,7 +106,7 @@ The current `save()` implementation does **not** call the dedicated
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["gpu"] }
+ruviz = { version = "0.2.0", features = ["gpu"] }
 ```
 
 ```rust

--- a/docs/guide/09_data_integration.md
+++ b/docs/guide/09_data_integration.md
@@ -64,7 +64,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["ndarray_support"] }
+ruviz = { version = "0.2.0", features = ["ndarray_support"] }
 ndarray = "0.15"
 ```
 
@@ -183,7 +183,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["nalgebra_support"] }
+ruviz = { version = "0.2.0", features = ["nalgebra_support"] }
 nalgebra = "0.32"
 ```
 
@@ -216,7 +216,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.1.5", features = ["polars_support"] }
+ruviz = { version = "0.2.0", features = ["polars_support"] }
 polars = "0.35"
 ```
 

--- a/docs/guide/10_export.md
+++ b/docs/guide/10_export.md
@@ -518,7 +518,7 @@ Plot::new()
 ### PDF Export
 
 ```rust
-// Requires: ruviz = { version = "0.1.5", features = ["pdf"] }
+// Requires: ruviz = { version = "0.2.0", features = ["pdf"] }
 use ruviz::prelude::*;
 
 Plot::new()

--- a/docs/releases/README.md
+++ b/docs/releases/README.md
@@ -6,13 +6,13 @@ Versioned release notes are stored in this directory using the tag name format:
 
 Examples:
 
-- `v0.1.5.md`
+- `v0.2.0.md`
 
 ## Workflow Integration
 
 The release workflow (`.github/workflows/release.yml`) automatically:
 
-1. Resolves the pushed tag name (for example, `v0.1.5`)
+1. Resolves the pushed tag name (for example, `v0.2.0`)
 2. Looks for `docs/releases/<tag>.md`
 3. Uses that file as the GitHub Release body when found
 4. Falls back to a minimal generated release body when missing

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,57 @@
+# ruviz v0.2.0
+
+Released: 2026-03-31
+
+## Highlights
+
+- Added experimental browser and `wasm32` support via the `ruviz-web` crate and the public npm `ruviz` SDK.
+- Added mixed-coordinate inset rendering so Cartesian plots can embed polar, pie, and radar content.
+- Fixed builder chaining parity so common continuations no longer require explicit `end_series()` workarounds.
+- Tightened output parity and release confidence with restored visual fixtures, mixed-inset visual coverage, and broader CI checks.
+
+## Browser And Workspace Packages
+
+This release aligns the published workspace packages on one version:
+
+- `ruviz` `0.2.0`
+- `ruviz-web` `0.2.0`
+- `ruviz-gpui` `0.2.0`
+- npm `ruviz` `0.2.0`
+
+Browser-facing additions in this release:
+
+- `ruviz-web` provides the Rust-side browser runtime adapter for canvas rendering.
+- The npm `ruviz` package ships the JS/TS browser SDK and wasm packaging flow.
+- The JS workspace is Bun-first for install, lint, build, and packaging commands.
+
+## Plotting And Compatibility Notes
+
+- Mixed-coordinate figures can now render polar, pie, and radar series as insets inside Cartesian plots.
+- Supported builder continuation gaps such as `.line(...).vline_styled(...)` no longer need an explicit `.end_series()`.
+- Typst APIs are now compile-time gated behind `typst-math`.
+
+If Typst is optional in your own crate, forward a local feature and guard `.typst(true)` with `#[cfg(feature = "typst-math")]`.
+
+## Quality And Validation
+
+This release was validated with the standard CI lanes plus release packaging checks:
+
+- Rustfmt
+- Clippy
+- MSRV (1.87)
+- Documentation build
+- Test Fast Lane
+- Multi-platform build (Linux, macOS, Windows, FreeBSD)
+- WASM + Web build
+- Release build
+- npm tarball validation
+- `ruviz-gpui` compile verification
+
+## References
+
+- Changelog: [`CHANGELOG.md`](../../CHANGELOG.md)
+- Browser/wasm support PR: [#27](https://github.com/Ameyanagi/ruviz/pull/27)
+- Typst gating PR: [#28](https://github.com/Ameyanagi/ruviz/pull/28)
+- Builder chaining parity PR: [#29](https://github.com/Ameyanagi/ruviz/pull/29)
+- Mixed-coordinate inset rendering PR: [#30](https://github.com/Ameyanagi/ruviz/pull/30)
+- Release workflow: [`.github/workflows/release.yml`](../../.github/workflows/release.yml)

--- a/packages/ruviz-web/package.json
+++ b/packages/ruviz-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruviz",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "Browser-first JS/TS SDK for ruviz WebAssembly rendering",
   "type": "module",
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## Summary
- bump the workspace packages to v0.2.0
- add v0.2.0 release notes and changelog entries
- refresh version-pinned docs and install snippets

## Validation
- cargo fmt --all -- --check
- cargo clippy -- -D warnings
- cargo test
- cargo check -p ruviz-gpui
- cargo build --release --all-features
- cargo doc --no-deps --all-features
- bun install --frozen-lockfile
- bun run check:web
- bun run build:web
- bun run --cwd packages/ruviz-web pack:dry