### PR TITLE
Fix GPUI Linux deps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,31 @@ jobs:
       - name: Check JS/TS formatting and lint
         run: bun run check:web
 
+      - name: Install GPUI Linux build dependencies
+        run: |
+          # Mirror the Ubuntu dependency subset required by upstream GPUI/Zed
+          # so Linux compile verification does not depend on the runner image.
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            clang \
+            cmake \
+            libasound2-dev \
+            libfontconfig-dev \
+            libglib2.0-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libva-dev \
+            libvulkan1 \
+            libwayland-dev \
+            libx11-xcb-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libzstd-dev \
+            musl-dev \
+            musl-tools \
+            pkg-config
+
       - name: Build release
         run: cargo build --release --all-features
 
@@ -236,6 +261,31 @@ jobs:
           else
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Install GPUI Linux build dependencies
+        if: steps.gpui-version.outputs.published != 'true'
+        run: |
+          # cargo publish verifies the package by building it first.
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            clang \
+            cmake \
+            libasound2-dev \
+            libfontconfig-dev \
+            libglib2.0-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libva-dev \
+            libvulkan1 \
+            libwayland-dev \
+            libx11-xcb-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libzstd-dev \
+            musl-dev \
+            musl-tools \
+            pkg-config
 
       - name: Wait for ruviz-gpui packaging to resolve against crates.io
         if: steps.gpui-version.outputs.published != 'true'


### PR DESCRIPTION
## Summary
- install the Linux system packages needed to compile `ruviz-gpui` in the release build job
- install the same packages in the `ruviz-gpui` publish job because `cargo publish` verifies by building
- keep the `v0.2.0` release unblocked without changing published package contents

## Testing
- git diff --check
- inspected the failed release logs for the missing `wayland-client` pkg-config dependency
- verified that `v0.2.0` has not been published to crates.io or GitHub Releases