### PR TITLE
Fix large-plot rendering blackout and expand coverage

### DIFF
--- a/demo/web/tests/browser.spec.js
+++ b/demo/web/tests/browser.spec.js
@@ -1036,6 +1036,220 @@ test("python widget bundle handles a single-point sine signal snapshot", async (
   expect(result.imageLength).toBeGreaterThan(0);
 });
 
+test("python widget bundle renders representative large snapshots without blacking out", async ({
+  page,
+}) => {
+  await waitForDemoReady(page);
+
+  const consoleErrors = [];
+  const pageErrors = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => {
+    pageErrors.push(String(error));
+  });
+
+  const result = await page.evaluate(async (widgetSource) => {
+    const demo = window.__ruvizDemo;
+    if (!demo?.sdk) {
+      throw new Error("SDK test hooks are unavailable");
+    }
+
+    const waitForNextPaint = () =>
+      new Promise((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(resolve);
+        });
+      });
+
+    const waitForCanvasChange = async (canvas, previousData) => {
+      for (let attempt = 0; attempt < 180; attempt += 1) {
+        await waitForNextPaint();
+        const currentData = canvas.toDataURL("image/png");
+        if (previousData === undefined) {
+          const blankCanvas = document.createElement("canvas");
+          blankCanvas.width = canvas.width;
+          blankCanvas.height = canvas.height;
+          if (currentData !== blankCanvas.toDataURL("image/png")) {
+            return currentData;
+          }
+          continue;
+        }
+        if (currentData !== previousData) {
+          return currentData;
+        }
+      }
+
+      throw new Error("widget canvas did not update for large snapshot");
+    };
+
+    const analyzeCanvas = (canvas) => {
+      const context = canvas.getContext("2d");
+      if (!context) {
+        throw new Error("widget canvas context is unavailable");
+      }
+      const { data } = context.getImageData(0, 0, canvas.width, canvas.height);
+      const total = data.length / 4;
+      let dark = 0;
+      let ink = 0;
+      for (let index = 0; index < data.length; index += 4) {
+        const r = data[index];
+        const g = data[index + 1];
+        const b = data[index + 2];
+        const a = data[index + 3];
+        if (r < 32 && g < 32 && b < 32) {
+          dark += 1;
+        }
+        if (a > 0 && (r < 248 || g < 248 || b < 248)) {
+          ink += 1;
+        }
+      }
+      return {
+        darkFraction: dark / total,
+        inkFraction: ink / total,
+      };
+    };
+
+    const x = Array.from({ length: 100_000 }, (_, index) => index * 0.0001);
+    const lineY = x.map((value) => Math.sin(value) + 0.2 * Math.cos(value * 3.0));
+    const heatmap = Array.from({ length: 320 }, (_, rowIndex) => {
+      const y = -1 + (2 * rowIndex) / 319;
+      return Array.from({ length: 320 }, (_, colIndex) => {
+        const xValue = -1 + (2 * colIndex) / 319;
+        const ridge = Math.exp(-(((xValue - 0.25) ** 2 + (y + 0.1) ** 2) * 9.0));
+        const waves = 0.35 * Math.sin(xValue * 8.0) * Math.cos(y * 6.0);
+        return ridge + waves;
+      });
+    });
+    const categories = Array.from({ length: 20_000 }, (_, index) => `c${index}`);
+    const barValues = Array.from(
+      { length: 20_000 },
+      (_, index) => 1 + 0.45 * Math.sin(index * 0.001) + 0.1 * Math.cos(index * 0.004),
+    );
+
+    const snapshots = [
+      {
+        slug: "line",
+        snapshot: demo.sdk
+          .createPlot()
+          .setSizePx(320, 200)
+          .setTicks(false)
+          .setTitle("large widget line")
+          .addLine({ x, y: lineY })
+          .toSnapshot(),
+      },
+      {
+        slug: "heatmap",
+        snapshot: demo.sdk
+          .createPlot()
+          .setSizePx(320, 200)
+          .setTicks(false)
+          .setTitle("large widget heatmap")
+          .heatmap(heatmap)
+          .toSnapshot(),
+      },
+      {
+        slug: "bar",
+        snapshot: demo.sdk
+          .createPlot()
+          .setSizePx(320, 200)
+          .setTicks(false)
+          .setTitle("large widget bar")
+          .bar({ categories, values: barValues })
+          .toSnapshot(),
+      },
+    ];
+
+    const listeners = new Map();
+    const model = {
+      snapshot: snapshots[0].snapshot,
+      get(name) {
+        return name === "snapshot" ? this.snapshot : undefined;
+      },
+      on(name, callback) {
+        const callbacks = listeners.get(name) ?? [];
+        callbacks.push(callback);
+        listeners.set(name, callbacks);
+      },
+      off(name, callback) {
+        const callbacks = listeners.get(name);
+        if (!callbacks) {
+          return;
+        }
+        listeners.set(
+          name,
+          callbacks.filter((registered) => registered !== callback),
+        );
+      },
+      setSnapshot(snapshot) {
+        this.snapshot = snapshot;
+        for (const callback of listeners.get("change:snapshot") ?? []) {
+          callback();
+        }
+      },
+    };
+
+    const mount = document.createElement("div");
+    mount.id = "python-widget-large-snapshots-host";
+    mount.style.width = "720px";
+    document.body.appendChild(mount);
+
+    const moduleUrl = URL.createObjectURL(new Blob([widgetSource], { type: "text/javascript" }));
+
+    try {
+      const mod = await import(moduleUrl);
+      const cleanup = mod.default.render({ model, el: mount });
+      const canvas = mount.querySelector("canvas");
+      const viewport = mount.querySelector("[data-ruviz-widget-viewport='true']");
+      if (!(canvas instanceof HTMLCanvasElement)) {
+        throw new Error("widget bundle did not create a canvas");
+      }
+      if (!(viewport instanceof HTMLDivElement)) {
+        throw new Error("widget bundle did not create a viewport");
+      }
+
+      const metrics = [];
+      let previousImage;
+      for (const entry of snapshots) {
+        if (entry !== snapshots[0]) {
+          model.setSnapshot(entry.snapshot);
+        }
+        previousImage = await waitForCanvasChange(canvas, previousImage);
+        metrics.push({
+          slug: entry.slug,
+          ...analyzeCanvas(canvas),
+          width: viewport.getBoundingClientRect().width,
+          height: viewport.getBoundingClientRect().height,
+        });
+      }
+
+      if (typeof cleanup === "function") {
+        cleanup();
+      }
+      mount.remove();
+      return metrics;
+    } finally {
+      URL.revokeObjectURL(moduleUrl);
+    }
+  }, PYTHON_WIDGET_BUNDLE);
+
+  expect(consoleErrors).toEqual([]);
+  expect(pageErrors).toEqual([]);
+
+  for (const entry of result) {
+    expect(entry.width, `${entry.slug} widget width`).toBeCloseTo(320, 0);
+    expect(entry.height, `${entry.slug} widget height`).toBeCloseTo(200, 0);
+    expect(entry.darkFraction, `${entry.slug} widget should not black out`).toBeLessThan(0.8);
+    expect(
+      entry.inkFraction,
+      `${entry.slug} widget should contain visible plot ink`,
+    ).toBeGreaterThan(0.001);
+  }
+});
+
 test("png and svg exports work for the demo panels", async ({ page }) => {
   await waitForDemoReady(page);
 

--- a/python/src/native_handle.rs
+++ b/python/src/native_handle.rs
@@ -11,7 +11,6 @@ use ruviz::{
         plot::{IntoPlotData, PlotData},
     },
     data::Observable,
-    export::write_rgba_png_atomic,
     render::Theme,
 };
 
@@ -20,8 +19,6 @@ use ruviz::interactive::show_interactive;
 
 #[cfg(not(feature = "native-interactive"))]
 use crate::NATIVE_INTERACTIVE_UNAVAILABLE_MESSAGE;
-
-const DEFAULT_PLOT_SIZE: (u32, u32) = (640, 480);
 
 #[derive(Clone)]
 enum NumericSourceState {
@@ -157,10 +154,6 @@ impl NativePlotState {
         }
 
         Ok(plot)
-    }
-
-    fn render_size(&self) -> (u32, u32) {
-        self.size_px.unwrap_or(DEFAULT_PLOT_SIZE)
     }
 }
 
@@ -373,12 +366,8 @@ impl NativePlotHandle {
 
     fn render_png_vec(&mut self) -> PyResult<Vec<u8>> {
         self.ensure_built()?;
-        let image = self
-            .prepared
-            .render_frame(self.state.render_size(), 1.0, 0.0)
-            .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
-        image
-            .encode_png()
+        self.plot
+            .render_png_bytes()
             .map_err(|err| PyRuntimeError::new_err(err.to_string()))
     }
 }
@@ -675,14 +664,11 @@ impl NativePlotHandle {
                 .clone()
                 .save_pdf(output)
                 .map_err(|err| PyRuntimeError::new_err(err.to_string())),
-            _ => {
-                let image = self
-                    .prepared
-                    .render_frame(self.state.render_size(), 1.0, 0.0)
-                    .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
-                write_rgba_png_atomic(output, &image)
-                    .map_err(|err| PyRuntimeError::new_err(err.to_string()))
-            }
+            _ => self
+                .plot
+                .clone()
+                .save(output)
+                .map_err(|err| PyRuntimeError::new_err(err.to_string())),
         }
     }
 

--- a/python/tests/test_api.py
+++ b/python/tests/test_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gc
+from functools import lru_cache
 import weakref
 from copy import copy, deepcopy
 from pathlib import Path
@@ -9,6 +10,157 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 import ruviz
+
+PNG_HEADER = b"\x89PNG\r\n\x1a\n"
+
+
+@lru_cache(maxsize=1)
+def _large_xy() -> tuple[np.ndarray, np.ndarray]:
+    x = np.linspace(0.0, 10.0, num=100_000, dtype=float)
+    y = np.sin(x) + 0.2 * np.cos(x * 3.0)
+    return x, y
+
+
+@lru_cache(maxsize=1)
+def _large_error_bar_xy() -> tuple[np.ndarray, np.ndarray]:
+    x = np.linspace(0.0, 10.0, num=25_000, dtype=float)
+    y = np.sin(x) + 0.2 * np.cos(x * 3.0)
+    return x, y
+
+
+@lru_cache(maxsize=1)
+def _large_scalars() -> np.ndarray:
+    x = np.linspace(0.0, 20.0, num=100_000, dtype=float)
+    return np.sin(x * 0.8) + 0.35 * np.cos(x * 1.7)
+
+
+@lru_cache(maxsize=1)
+def _large_heatmap() -> np.ndarray:
+    y = np.linspace(-1.0, 1.0, num=320, dtype=float)
+    x = np.linspace(-1.0, 1.0, num=320, dtype=float)
+    grid_x, grid_y = np.meshgrid(x, y)
+    ridge = np.exp(-((grid_x - 0.25) ** 2 + (grid_y + 0.1) ** 2) * 9.0)
+    waves = 0.35 * np.sin(grid_x * 8.0) * np.cos(grid_y * 6.0)
+    return ridge + waves
+
+
+@lru_cache(maxsize=1)
+def _large_contour() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    x = np.linspace(-2.0, 2.0, num=320, dtype=float)
+    y = np.linspace(-2.0, 2.0, num=320, dtype=float)
+    grid_x, grid_y = np.meshgrid(x, y)
+    z = (grid_x**2 - grid_y**2) + 0.25 * np.sin(grid_x * 3.0) * np.cos(grid_y * 2.0)
+    return x, y, z.reshape(-1)
+
+
+@lru_cache(maxsize=1)
+def _large_categories() -> list[str]:
+    return [f"c{index}" for index in range(20_000)]
+
+
+@lru_cache(maxsize=1)
+def _large_bar_values() -> np.ndarray:
+    x = np.linspace(0.0, 15.0, num=20_000, dtype=float)
+    return 1.0 + 0.45 * np.sin(x) + 0.1 * np.cos(x * 4.0)
+
+
+def _base_large_plot() -> ruviz.Plot:
+    return ruviz.plot().size_px(320, 200).ticks(False)
+
+
+def _build_large_line_plot() -> ruviz.Plot:
+    x, y = _large_xy()
+    return _base_large_plot().line(x, y)
+
+
+def _build_large_scatter_plot() -> ruviz.Plot:
+    x, y = _large_xy()
+    return _base_large_plot().scatter(x, y)
+
+
+def _build_large_bar_plot() -> ruviz.Plot:
+    return _base_large_plot().bar(_large_categories(), _large_bar_values())
+
+
+def _build_large_histogram_plot() -> ruviz.Plot:
+    return _base_large_plot().histogram(_large_scalars())
+
+
+def _build_large_boxplot_plot() -> ruviz.Plot:
+    return _base_large_plot().boxplot(_large_scalars())
+
+
+def _build_large_heatmap_plot() -> ruviz.Plot:
+    return _base_large_plot().heatmap(_large_heatmap())
+
+
+def _build_large_error_bars_plot() -> ruviz.Plot:
+    x, y = _large_error_bar_xy()
+    y_errors = 0.03 + 0.01 * np.abs(np.sin(x * 0.7))
+    return _base_large_plot().error_bars(x, y, y_errors)
+
+
+def _build_large_error_bars_xy_plot() -> ruviz.Plot:
+    x, y = _large_error_bar_xy()
+    x_errors = 0.02 + 0.008 * np.abs(np.cos(x * 0.9))
+    y_errors = 0.03 + 0.01 * np.abs(np.sin(x * 0.7))
+    return _base_large_plot().error_bars_xy(x, y, x_errors, y_errors)
+
+
+def _build_large_kde_plot() -> ruviz.Plot:
+    return _base_large_plot().kde(_large_scalars())
+
+
+def _build_large_ecdf_plot() -> ruviz.Plot:
+    return _base_large_plot().ecdf(_large_scalars())
+
+
+def _build_large_contour_plot() -> ruviz.Plot:
+    x, y, z = _large_contour()
+    return _base_large_plot().contour(x, y, z)
+
+
+def _build_large_violin_plot() -> ruviz.Plot:
+    return _base_large_plot().violin(_large_scalars())
+
+
+def _build_large_polar_line_plot() -> ruviz.Plot:
+    theta = np.linspace(0.0, np.pi * 20.0, num=100_000, dtype=float)
+    r = 1.0 + 0.25 * np.sin(theta * 2.0) + 0.1 * np.cos(theta * 7.0)
+    return _base_large_plot().polar_line(r, theta)
+
+
+LARGE_RASTER_CASES = [
+    ("line", _build_large_line_plot),
+    ("scatter", _build_large_scatter_plot),
+    ("bar", _build_large_bar_plot),
+    ("histogram", _build_large_histogram_plot),
+    ("boxplot", _build_large_boxplot_plot),
+    ("heatmap", _build_large_heatmap_plot),
+    ("error-bars", _build_large_error_bars_plot),
+    ("error-bars-xy", _build_large_error_bars_xy_plot),
+    ("kde", _build_large_kde_plot),
+    ("ecdf", _build_large_ecdf_plot),
+    ("contour", _build_large_contour_plot),
+    ("violin", _build_large_violin_plot),
+    ("polar-line", _build_large_polar_line_plot),
+]
+
+LARGE_VECTOR_CASES = [
+    ("line", _build_large_line_plot),
+    ("histogram", _build_large_histogram_plot),
+    ("heatmap", _build_large_heatmap_plot),
+]
+
+LARGE_WIDGET_CASES = [
+    ("line", _build_large_line_plot),
+    ("histogram", _build_large_histogram_plot),
+    ("heatmap", _build_large_heatmap_plot),
+]
+
+
+def _svg_has_graphics_markup(svg: str) -> bool:
+    return any(token in svg for token in ("<path", "<polyline", "<rect", "<circle", "<image"))
 
 
 def test_render_svg_smoke() -> None:
@@ -50,7 +202,7 @@ def test_empty_plot_repr_png_succeeds() -> None:
 
     png = plot._repr_png_()
 
-    assert png.startswith(b"\x89PNG\r\n\x1a\n")
+    assert png.startswith(PNG_HEADER)
 
 
 def test_render_png_uses_native_handle_not_snapshot_json() -> None:
@@ -59,7 +211,7 @@ def test_render_png_uses_native_handle_not_snapshot_json() -> None:
     with patch.object(plot, "_snapshot_json", side_effect=AssertionError("snapshot path should not run")):
         png = plot.render_png()
 
-    assert png.startswith(b"\x89PNG\r\n\x1a\n")
+    assert png.startswith(PNG_HEADER)
 
 
 def test_render_svg_uses_native_handle_not_snapshot_json() -> None:
@@ -89,8 +241,67 @@ def test_clone_rebuilds_native_plot_from_mixed_series_shapes() -> None:
 
     clone = plot.clone()
 
-    assert clone.render_png().startswith(b"\x89PNG\r\n\x1a\n")
+    assert clone.render_png().startswith(PNG_HEADER)
     assert clone.to_snapshot() == plot.to_snapshot()
+
+
+@pytest.mark.parametrize(("name", "builder"), LARGE_RASTER_CASES, ids=[name for name, _ in LARGE_RASTER_CASES])
+def test_large_plot_public_png_paths(name: str, builder: object, tmp_path: Path) -> None:
+    plot = builder()
+
+    png = plot.render_png()
+    assert png.startswith(PNG_HEADER)
+    assert len(png) > 2_048
+
+    output = plot.save(tmp_path / f"{name}.png")
+    saved = output.read_bytes()
+    assert saved.startswith(PNG_HEADER)
+    assert saved == png
+
+
+@pytest.mark.parametrize(("name", "builder"), LARGE_VECTOR_CASES, ids=[name for name, _ in LARGE_VECTOR_CASES])
+def test_large_plot_public_vector_paths(name: str, builder: object, tmp_path: Path) -> None:
+    plot = builder()
+
+    svg = plot.render_svg()
+    assert svg.startswith("<?xml")
+    assert "<svg" in svg
+    assert _svg_has_graphics_markup(svg)
+
+    svg_path = plot.save(tmp_path / f"{name}.svg")
+    saved_svg = svg_path.read_text(encoding="utf-8")
+    assert saved_svg == svg
+
+    pdf_path = plot.save(tmp_path / f"{name}.pdf")
+    assert pdf_path.is_file()
+    assert pdf_path.stat().st_size > 1_024
+
+
+@pytest.mark.parametrize(("name", "builder"), LARGE_WIDGET_CASES, ids=[name for name, _ in LARGE_WIDGET_CASES])
+def test_large_plot_widget_snapshot_smoke(name: str, builder: object) -> None:
+    plot = builder()
+
+    widget = plot.widget()
+
+    assert len(widget.snapshot["series"]) == 1
+    assert widget.snapshot["series"][0]["kind"] == name
+
+
+@pytest.mark.parametrize(("name", "builder"), LARGE_WIDGET_CASES, ids=[name for name, _ in LARGE_WIDGET_CASES])
+def test_large_plot_show_uses_static_image_in_notebooks(name: str, builder: object) -> None:
+    plot = builder()
+
+    with (
+        patch("ruviz._api._is_notebook", return_value=True),
+        patch("IPython.display.display") as display,
+    ):
+        result = plot.show()
+
+    assert result is None
+    display.assert_called_once()
+    image = display.call_args.args[0]
+    assert image.data.startswith(PNG_HEADER)
+    assert len(image.data) > 2_048
 
 
 def test_clone_keeps_observable_series_static() -> None:

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -132,6 +132,40 @@ where
     found.then_some((min_x, min_y, max_x, max_y))
 }
 
+fn dark_pixel_fraction(image: &Image) -> f64 {
+    let total = image.pixels.chunks_exact(4).len() as f64;
+    let dark = image
+        .pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[0] < 32 && pixel[1] < 32 && pixel[2] < 32)
+        .count() as f64;
+    dark / total
+}
+
+fn non_background_fraction(image: &Image) -> f64 {
+    let total = image.pixels.chunks_exact(4).len() as f64;
+    let non_background = image
+        .pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[3] > 0 && (pixel[0] < 248 || pixel[1] < 248 || pixel[2] < 248))
+        .count() as f64;
+    non_background / total
+}
+
+fn assert_surface_base_visually_sane(name: &str, image: &Image) {
+    let dark_fraction = dark_pixel_fraction(image);
+    let ink_fraction = non_background_fraction(image);
+
+    assert!(
+        dark_fraction < 0.8,
+        "{name} surface frame should not black out: dark_fraction={dark_fraction:.4}"
+    );
+    assert!(
+        ink_fraction > 0.001,
+        "{name} surface frame should contain visible plot ink: ink_fraction={ink_fraction:.4}"
+    );
+}
+
 #[test]
 fn test_dirty_domains_mark_and_clear() {
     let mut dirty = DirtyDomains::default();
@@ -435,6 +469,88 @@ fn test_unsupported_surface_series_fall_back_to_image_capability() {
         .expect("fallback surface frame should render");
 
     assert_eq!(frame.surface_capability, SurfaceCapability::FallbackImage);
+}
+
+#[test]
+fn test_large_dataset_surface_frames_render_without_blackout() {
+    let x: Vec<f64> = (0..100_000).map(|index| index as f64 * 0.0001).collect();
+    let y: Vec<f64> = x
+        .iter()
+        .map(|value| value.sin() + 0.2 * (value * 3.0).cos())
+        .collect();
+    let histogram_samples: Vec<f64> = (0..100_000)
+        .map(|index| {
+            let value = index as f64 * 0.0002;
+            value.sin() + 0.35 * (value * 1.7).cos()
+        })
+        .collect();
+    let heatmap: Vec<Vec<f64>> = (0..320)
+        .map(|row| {
+            let y = -1.0 + 2.0 * row as f64 / 319.0;
+            (0..320)
+                .map(|col| {
+                    let x = -1.0 + 2.0 * col as f64 / 319.0;
+                    let ridge = (-((x - 0.25).powi(2) + (y + 0.1).powi(2)) * 9.0).exp();
+                    let waves = 0.35 * (x * 8.0).sin() * (y * 6.0).cos();
+                    ridge + waves
+                })
+                .collect()
+        })
+        .collect();
+    let categories: Vec<String> = (0..20_000).map(|index| format!("c{index}")).collect();
+    let bar_values: Vec<f64> = (0..20_000)
+        .map(|index| {
+            let value = index as f64 * 0.001;
+            1.0 + 0.45 * value.sin() + 0.1 * (value * 4.0).cos()
+        })
+        .collect();
+
+    let line: Plot = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .line(&x, &y)
+        .into();
+    let line_session = line.prepare_interactive();
+    let line_frame = line_session
+        .render_to_surface(render_target())
+        .expect("large line surface frame should render");
+    assert_surface_base_visually_sane("large line", line_frame.layers.base.as_ref());
+
+    let histogram: Plot = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .histogram(&histogram_samples, None)
+        .into();
+    let histogram_session = histogram.prepare_interactive();
+    let histogram_frame = histogram_session
+        .render_to_surface(render_target())
+        .expect("large histogram surface frame should render");
+    assert_surface_base_visually_sane("large histogram", histogram_frame.layers.base.as_ref());
+
+    let heatmap_plot: Plot = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .heatmap(
+            &heatmap,
+            Some(crate::plots::heatmap::HeatmapConfig::new().colorbar(false)),
+        )
+        .into();
+    let heatmap_session = heatmap_plot.prepare_interactive();
+    let heatmap_frame = heatmap_session
+        .render_to_surface(render_target())
+        .expect("large heatmap surface frame should render");
+    assert_surface_base_visually_sane("large heatmap", heatmap_frame.layers.base.as_ref());
+
+    let bar: Plot = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .bar(&categories, &bar_values)
+        .into();
+    let bar_session = bar.prepare_interactive();
+    let bar_frame = bar_session
+        .render_to_surface(render_target())
+        .expect("large bar surface frame should render");
+    assert_surface_base_visually_sane("large bar", bar_frame.layers.base.as_ref());
 }
 
 #[test]

--- a/src/core/plot/mixed_render.rs
+++ b/src/core/plot/mixed_render.rs
@@ -42,10 +42,7 @@ impl Plot {
     }
 
     pub(super) fn series_supports_auto_datashader(series: &PlotSeries) -> bool {
-        matches!(
-            series.series_type,
-            SeriesType::Scatter { .. } | SeriesType::Histogram { .. }
-        )
+        matches!(series.series_type, SeriesType::Scatter { .. })
     }
 
     pub(super) fn is_non_cartesian_series(series: &PlotSeries) -> bool {
@@ -108,30 +105,6 @@ impl Plot {
                 SeriesType::Scatter { x_data, y_data } => {
                     let x_data = x_data.resolve(0.0);
                     let y_data = y_data.resolve(0.0);
-                    let mut datashader = DataShader::with_canvas_size(
-                        series_area.width() as usize,
-                        series_area.height() as usize,
-                    );
-
-                    datashader.aggregate_with_bounds(
-                        &x_data,
-                        &y_data,
-                        series_bounds.0,
-                        series_bounds.1,
-                        series_bounds.2,
-                        series_bounds.3,
-                    )?;
-                    let image = datashader.render();
-                    renderer.draw_datashader_image(&image, series_area)?;
-                }
-                SeriesType::Histogram { .. } => {
-                    let hist_data = series.series_type.histogram_data_at(0.0)?;
-                    let x_data: Vec<f64> = hist_data
-                        .bin_edges
-                        .windows(2)
-                        .map(|w| (w[0] + w[1]) / 2.0)
-                        .collect();
-                    let y_data: Vec<f64> = hist_data.counts;
                     let mut datashader = DataShader::with_canvas_size(
                         series_area.width() as usize,
                         series_area.height() as usize,

--- a/src/core/plot/mixed_render.rs
+++ b/src/core/plot/mixed_render.rs
@@ -75,6 +75,96 @@ impl Plot {
         series_list.is_empty() || Self::has_cartesian_series(series_list)
     }
 
+    pub(super) fn render_series_collection_auto_datashader(
+        &self,
+        series_list: &[PlotSeries],
+        renderer: &mut SkiaRenderer,
+        plot_area: tiny_skia::Rect,
+        x_min: f64,
+        x_max: f64,
+        y_min: f64,
+        y_max: f64,
+        render_scale: RenderScale,
+    ) -> Result<bool> {
+        if Self::has_mixed_coordinate_series(series_list) {
+            return Ok(false);
+        }
+
+        let total_points = Self::calculate_total_points_for_series(series_list);
+        if !Self::should_auto_use_datashader(series_list, total_points) {
+            return Ok(false);
+        }
+
+        let inset_rects = self.inset_rects_for_series(series_list, plot_area, render_scale)?;
+
+        for (idx, series) in series_list.iter().enumerate() {
+            let (series_area, series_bounds) = if let Some(inset_rect) = inset_rects[idx] {
+                (inset_rect, self.raw_bounds_for_single_series(series)?)
+            } else {
+                (plot_area, (x_min, x_max, y_min, y_max))
+            };
+
+            match &series.series_type {
+                SeriesType::Scatter { x_data, y_data } => {
+                    let x_data = x_data.resolve(0.0);
+                    let y_data = y_data.resolve(0.0);
+                    let mut datashader = DataShader::with_canvas_size(
+                        series_area.width() as usize,
+                        series_area.height() as usize,
+                    );
+
+                    datashader.aggregate_with_bounds(
+                        &x_data,
+                        &y_data,
+                        series_bounds.0,
+                        series_bounds.1,
+                        series_bounds.2,
+                        series_bounds.3,
+                    )?;
+                    let image = datashader.render();
+                    renderer.draw_datashader_image(&image, series_area)?;
+                }
+                SeriesType::Histogram { .. } => {
+                    let hist_data = series.series_type.histogram_data_at(0.0)?;
+                    let x_data: Vec<f64> = hist_data
+                        .bin_edges
+                        .windows(2)
+                        .map(|w| (w[0] + w[1]) / 2.0)
+                        .collect();
+                    let y_data: Vec<f64> = hist_data.counts;
+                    let mut datashader = DataShader::with_canvas_size(
+                        series_area.width() as usize,
+                        series_area.height() as usize,
+                    );
+
+                    datashader.aggregate_with_bounds(
+                        &x_data,
+                        &y_data,
+                        series_bounds.0,
+                        series_bounds.1,
+                        series_bounds.2,
+                        series_bounds.3,
+                    )?;
+                    let image = datashader.render();
+                    renderer.draw_datashader_image(&image, series_area)?;
+                }
+                _ => {
+                    self.render_series_normal(
+                        series,
+                        renderer,
+                        series_area,
+                        series_bounds.0,
+                        series_bounds.1,
+                        series_bounds.2,
+                        series_bounds.3,
+                    )?;
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
     pub(super) fn empty_cartesian_bounds(&self) -> (f64, f64, f64, f64) {
         self.apply_manual_axis_limits((0.0, 1.0, 0.0, 1.0))
     }

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -45,14 +45,6 @@ impl Plot {
             );
         }
 
-        let use_datashader = !has_mixed_coordinates
-            && Self::should_auto_use_datashader(&snapshot_series, total_points);
-
-        if use_datashader {
-            // Use DataShader for large datasets
-            return self.render_with_datashader(&snapshot_series);
-        }
-
         // Check if parallel processing should be used.
         // Reactive plots are resolved into a static snapshot above, so they can
         // reuse the normal backend-selection path here.
@@ -288,7 +280,7 @@ impl Plot {
             }
         }
 
-        self.render_series_collection_normal(
+        if !self.render_series_collection_auto_datashader(
             &snapshot_series,
             &mut renderer,
             plot_area,
@@ -297,7 +289,18 @@ impl Plot {
             y_min,
             y_max,
             render_scale,
-        )?;
+        )? {
+            self.render_series_collection_normal(
+                &snapshot_series,
+                &mut renderer,
+                plot_area,
+                x_min,
+                x_max,
+                y_min,
+                y_max,
+                render_scale,
+            )?;
+        }
 
         // Convert renderer output to Image
         Ok(renderer.into_image())
@@ -344,7 +347,22 @@ impl Plot {
 
     /// Render the plot and encode it as PNG bytes.
     pub fn render_png_bytes(&self) -> Result<Vec<u8>> {
-        self.render()?.encode_png()
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let reactive = self.is_reactive();
+            let result = self
+                .save_png_bytes_with_backend()
+                .map(|(png_bytes, _)| png_bytes);
+            if result.is_ok() && reactive {
+                self.mark_reactive_sources_rendered();
+            }
+            result
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.render()?.encode_png()
+        }
     }
 
     /// Check if this plot contains any reactive data (Signal or Observable).
@@ -1831,59 +1849,16 @@ impl Plot {
         const GPU_THRESHOLD: usize = 5_000;
 
         #[cfg(feature = "gpu")]
-        let backend_used = if !has_mixed_coordinates
-            && Self::should_auto_use_datashader(&snapshot_series, total_points)
-        {
-            use crate::data::DataShader;
-
-            for series in &snapshot_series {
-                match &series.series_type {
-                    SeriesType::Scatter { x_data, y_data } => {
-                        let x_data = x_data.resolve(0.0);
-                        let y_data = y_data.resolve(0.0);
-                        let mut datashader = DataShader::with_canvas_size(
-                            plot_area.width() as usize,
-                            plot_area.height() as usize,
-                        );
-
-                        datashader
-                            .aggregate_with_bounds(&x_data, &y_data, x_min, x_max, y_min, y_max)?;
-                        let image = datashader.render();
-                        renderer.draw_datashader_image(&image, plot_area)?;
-                    }
-                    SeriesType::Histogram { .. } => {
-                        let hist_data = series.series_type.histogram_data_at(0.0)?;
-                        let x_data: Vec<f64> = hist_data
-                            .bin_edges
-                            .windows(2)
-                            .map(|w| (w[0] + w[1]) / 2.0)
-                            .collect();
-                        let y_data: Vec<f64> = hist_data.counts;
-
-                        let mut datashader = DataShader::with_canvas_size(
-                            plot_area.width() as usize,
-                            plot_area.height() as usize,
-                        );
-
-                        datashader
-                            .aggregate_with_bounds(&x_data, &y_data, x_min, x_max, y_min, y_max)?;
-                        let image = datashader.render();
-                        renderer.draw_datashader_image(&image, plot_area)?;
-                    }
-                    _ => {
-                        self.render_series_normal(
-                            series,
-                            &mut renderer,
-                            plot_area,
-                            x_min,
-                            x_max,
-                            y_min,
-                            y_max,
-                        )?;
-                    }
-                }
-            }
-
+        let backend_used = if self.render_series_collection_auto_datashader(
+            &snapshot_series,
+            &mut renderer,
+            plot_area,
+            x_min,
+            x_max,
+            y_min,
+            y_max,
+            render_scale,
+        )? {
             "datashader"
         } else {
             let use_gpu_rendering =
@@ -1942,59 +1917,16 @@ impl Plot {
         };
 
         #[cfg(not(feature = "gpu"))]
-        let backend_used = if !has_mixed_coordinates
-            && Self::should_auto_use_datashader(&snapshot_series, total_points)
-        {
-            use crate::data::DataShader;
-
-            for series in &snapshot_series {
-                match &series.series_type {
-                    SeriesType::Scatter { x_data, y_data } => {
-                        let x_data = x_data.resolve(0.0);
-                        let y_data = y_data.resolve(0.0);
-                        let mut datashader = DataShader::with_canvas_size(
-                            plot_area.width() as usize,
-                            plot_area.height() as usize,
-                        );
-
-                        datashader
-                            .aggregate_with_bounds(&x_data, &y_data, x_min, x_max, y_min, y_max)?;
-                        let image = datashader.render();
-                        renderer.draw_datashader_image(&image, plot_area)?;
-                    }
-                    SeriesType::Histogram { .. } => {
-                        let hist_data = series.series_type.histogram_data_at(0.0)?;
-                        let x_data: Vec<f64> = hist_data
-                            .bin_edges
-                            .windows(2)
-                            .map(|w| (w[0] + w[1]) / 2.0)
-                            .collect();
-                        let y_data: Vec<f64> = hist_data.counts;
-
-                        let mut datashader = DataShader::with_canvas_size(
-                            plot_area.width() as usize,
-                            plot_area.height() as usize,
-                        );
-
-                        datashader
-                            .aggregate_with_bounds(&x_data, &y_data, x_min, x_max, y_min, y_max)?;
-                        let image = datashader.render();
-                        renderer.draw_datashader_image(&image, plot_area)?;
-                    }
-                    _ => {
-                        self.render_series_normal(
-                            series,
-                            &mut renderer,
-                            plot_area,
-                            x_min,
-                            x_max,
-                            y_min,
-                            y_max,
-                        )?;
-                    }
-                }
-            }
-
+        let backend_used = if self.render_series_collection_auto_datashader(
+            &snapshot_series,
+            &mut renderer,
+            plot_area,
+            x_min,
+            x_max,
+            y_min,
+            y_max,
+            render_scale,
+        )? {
             "datashader"
         } else {
             self.render_series_collection_normal(

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -612,7 +612,7 @@ impl Plot {
             }
         }
 
-        self.render_series_collection_normal(
+        if !self.render_series_collection_auto_datashader(
             &snapshot_series,
             renderer,
             plot_area,
@@ -621,7 +621,18 @@ impl Plot {
             y_min,
             y_max,
             RenderScale::new(dpi),
-        )?;
+        )? {
+            self.render_series_collection_normal(
+                &snapshot_series,
+                renderer,
+                plot_area,
+                x_min,
+                x_max,
+                y_min,
+                y_max,
+                RenderScale::new(dpi),
+            )?;
+        }
 
         // Draw annotations after data series but before legend
         if !self.annotations.is_empty() {

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -1001,6 +1001,20 @@ fn test_auto_datashader_policy_keeps_large_scatter_series_eligible() {
 }
 
 #[test]
+fn test_auto_datashader_policy_excludes_large_histogram_series() {
+    let samples: Vec<f64> = (0..100_000).map(|i| (i as f64 * 0.0002).sin()).collect();
+    let plot = Plot::new().histogram(&samples, None).end_series();
+    let snapshot_series = plot.snapshot_series(0.0);
+    let total_points = Plot::calculate_total_points_for_series(&snapshot_series);
+
+    assert!(DataShader::should_activate(total_points));
+    assert!(!Plot::should_auto_use_datashader(
+        &snapshot_series,
+        total_points
+    ));
+}
+
+#[test]
 fn test_prepared_frame_large_line_stays_off_auto_datashader() {
     let x: Vec<f64> = (0..100_000).map(|i| i as f64).collect();
     let y: Vec<f64> = x.iter().map(|x| x.sin()).collect();
@@ -2068,6 +2082,17 @@ fn test_benchmark_save_png_bytes_uses_datashader_for_large_scatter() {
     let (_, backend) = plot.benchmark_save_png_bytes().unwrap();
 
     assert_eq!(backend, "datashader");
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_benchmark_save_png_bytes_keeps_large_histogram_on_skia() {
+    let samples: Vec<f64> = (0..100_000).map(|i| (i as f64 * 0.0002).sin()).collect();
+
+    let plot = Plot::new().histogram(&samples, None).end_series();
+    let (_, backend) = plot.benchmark_save_png_bytes().unwrap();
+
+    assert_eq!(backend, "skia");
 }
 
 #[test]

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -249,6 +249,19 @@ fn blank_large_plot_png() -> Vec<u8> {
         .expect("blank large-plot baseline should render")
 }
 
+#[cfg(not(target_arch = "wasm32"))]
+fn render_plot_to_renderer_png(plot: &Plot, width: u32, height: u32) -> Vec<u8> {
+    let mut renderer =
+        crate::render::SkiaRenderer::new(width, height, crate::render::Theme::default())
+            .expect("renderer should be created");
+    plot.render_to_renderer(&mut renderer, 96.0)
+        .expect("plot should render to external renderer");
+    renderer
+        .into_image()
+        .encode_png()
+        .expect("renderer output should encode as PNG")
+}
+
 fn assert_large_plot_png_and_save(name: &str, plot: &Plot) {
     let blank_png = blank_large_plot_png();
     let rendered_png = plot
@@ -2125,6 +2138,27 @@ fn test_render_large_scatter_source_png_preserves_background() {
         .render_png_bytes()
         .expect("source-backed large scatter should render as PNG");
     assert_png_background_preserved("source-backed large scatter", &png);
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_render_to_renderer_large_scatter_stays_visually_sane() {
+    let (x, y) = large_xy_data();
+    let blank = Plot::new().size_px(320, 200).ticks(false).into_plot();
+    let plot = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .scatter(&x, &y)
+        .into_plot();
+
+    let blank_png = render_plot_to_renderer_png(&blank, 320, 200);
+    let rendered_png = render_plot_to_renderer_png(&plot, 320, 200);
+
+    assert_png_visual_sane_against_blank(
+        "render_to_renderer large scatter",
+        &rendered_png,
+        &blank_png,
+    );
 }
 
 #[test]

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::core::FigureConfig;
+use tempfile::tempdir;
 
 #[derive(Debug)]
 struct FailingIngestionData;
@@ -93,10 +94,30 @@ fn dark_pixel_fraction(pixels: &[u8]) -> f64 {
     dark / total
 }
 
+fn non_background_fraction(pixels: &[u8]) -> f64 {
+    let total = pixels.chunks_exact(4).len() as f64;
+    let non_background = pixels
+        .chunks_exact(4)
+        .filter(|px| px[3] > 0 && (px[0] < 248 || px[1] < 248 || px[2] < 248))
+        .count() as f64;
+    non_background / total
+}
+
 fn decode_png_rgba(png_bytes: &[u8]) -> ::image::RgbaImage {
     ::image::load_from_memory(png_bytes)
         .expect("PNG bytes should decode")
         .to_rgba8()
+}
+
+fn mean_normalized_rgba_diff(lhs: &::image::RgbaImage, rhs: &::image::RgbaImage) -> f64 {
+    assert_eq!(lhs.dimensions(), rhs.dimensions());
+
+    lhs.as_raw()
+        .iter()
+        .zip(rhs.as_raw().iter())
+        .map(|(left, right)| (*left as f64 - *right as f64).abs() / 255.0)
+        .sum::<f64>()
+        / lhs.as_raw().len() as f64
 }
 
 fn assert_png_background_preserved(name: &str, png_bytes: &[u8]) {
@@ -112,6 +133,136 @@ fn assert_png_background_preserved(name: &str, png_bytes: &[u8]) {
         dark_fraction < 0.25,
         "{name} PNG unexpectedly blacks out the canvas: dark_fraction={dark_fraction:.4}"
     );
+}
+
+fn assert_png_visual_sane_against_blank(name: &str, png_bytes: &[u8], blank_png_bytes: &[u8]) {
+    let image = decode_png_rgba(png_bytes);
+    let blank = decode_png_rgba(blank_png_bytes);
+    let dark_fraction = dark_pixel_fraction(image.as_raw());
+    let ink_fraction = non_background_fraction(image.as_raw());
+    let diff = mean_normalized_rgba_diff(&image, &blank);
+
+    assert!(
+        dark_fraction < 0.8,
+        "{name} PNG is unexpectedly dominated by near-black pixels: dark_fraction={dark_fraction:.4}"
+    );
+    assert!(
+        ink_fraction > 0.001,
+        "{name} PNG does not appear to contain visible plot ink: ink_fraction={ink_fraction:.4}"
+    );
+    assert!(
+        diff > 0.002,
+        "{name} PNG is too close to a blank baseline render: diff={diff:.6}"
+    );
+}
+
+fn large_xy_data() -> (Vec<f64>, Vec<f64>) {
+    let x: Vec<f64> = (0..100_000).map(|index| index as f64 * 0.0001).collect();
+    let y: Vec<f64> = x
+        .iter()
+        .map(|value| value.sin() + 0.2 * (value * 3.0).cos())
+        .collect();
+    (x, y)
+}
+
+fn large_error_bar_xy_data() -> (Vec<f64>, Vec<f64>) {
+    let x: Vec<f64> = (0..25_000).map(|index| index as f64 * 0.0004).collect();
+    let y: Vec<f64> = x
+        .iter()
+        .map(|value| value.sin() + 0.2 * (value * 3.0).cos())
+        .collect();
+    (x, y)
+}
+
+fn large_scalar_samples() -> Vec<f64> {
+    (0..100_000)
+        .map(|index| {
+            let value = index as f64 * 0.0002;
+            value.sin() + 0.35 * (value * 1.7).cos()
+        })
+        .collect()
+}
+
+fn large_bar_data() -> (Vec<String>, Vec<f64>) {
+    let categories = (0..20_000).map(|index| format!("c{index}")).collect();
+    let values = (0..20_000)
+        .map(|index| {
+            let value = index as f64 * 0.00015;
+            1.0 + 0.45 * value.sin() + 0.1 * (value * 4.0).cos()
+        })
+        .collect();
+    (categories, values)
+}
+
+fn large_heatmap_matrix() -> Vec<Vec<f64>> {
+    let rows = 320usize;
+    let cols = 320usize;
+    (0..rows)
+        .map(|row| {
+            let y = -1.0 + 2.0 * row as f64 / (rows.saturating_sub(1)) as f64;
+            (0..cols)
+                .map(|col| {
+                    let x = -1.0 + 2.0 * col as f64 / (cols.saturating_sub(1)) as f64;
+                    let ridge = (-((x - 0.25).powi(2) + (y + 0.1).powi(2)) * 9.0).exp();
+                    let waves = 0.35 * (x * 8.0).sin() * (y * 6.0).cos();
+                    ridge + waves
+                })
+                .collect()
+        })
+        .collect()
+}
+
+fn large_contour_axes() -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+    let x: Vec<f64> = (0..320)
+        .map(|index| -2.0 + 4.0 * index as f64 / 319.0)
+        .collect();
+    let y: Vec<f64> = (0..320)
+        .map(|index| -2.0 + 4.0 * index as f64 / 319.0)
+        .collect();
+    let mut z = Vec::with_capacity(x.len() * y.len());
+    for y_value in &y {
+        for x_value in &x {
+            let saddle = x_value.powi(2) - y_value.powi(2);
+            let ripple = 0.25 * (x_value * 3.0).sin() * (y_value * 2.0).cos();
+            z.push(saddle + ripple);
+        }
+    }
+    (x, y, z)
+}
+
+fn large_polar_data() -> (Vec<f64>, Vec<f64>) {
+    let theta: Vec<f64> = (0..100_000)
+        .map(|index| index as f64 * std::f64::consts::TAU / 10_000.0)
+        .collect();
+    let r: Vec<f64> = theta
+        .iter()
+        .map(|value| 1.0 + 0.25 * (value * 2.0).sin() + 0.1 * (value * 7.0).cos())
+        .collect();
+    (r, theta)
+}
+
+fn blank_large_plot_png() -> Vec<u8> {
+    Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .render_png_bytes()
+        .expect("blank large-plot baseline should render")
+}
+
+fn assert_large_plot_png_and_save(name: &str, plot: &Plot) {
+    let blank_png = blank_large_plot_png();
+    let rendered_png = plot
+        .render_png_bytes()
+        .unwrap_or_else(|err| panic!("{name} should render as PNG: {err}"));
+    assert_png_visual_sane_against_blank(name, &rendered_png, &blank_png);
+
+    let tempdir = tempdir().expect("tempdir should be created");
+    let output = tempdir.path().join(format!("{name}.png"));
+    plot.clone()
+        .save(&output)
+        .unwrap_or_else(|err| panic!("{name} should save as PNG: {err}"));
+    let saved_png = std::fs::read(&output).expect("saved PNG should be readable");
+    assert_png_visual_sane_against_blank(&format!("{name} saved"), &saved_png, &blank_png);
 }
 
 #[test]
@@ -1971,6 +2122,130 @@ fn test_render_large_line_and_histogram_png_preserve_background() {
         .render_png_bytes()
         .expect("large histogram should render as PNG");
     assert_png_background_preserved("large histogram", &histogram_png);
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_large_xy_family_png_and_save_paths_stay_visually_sane() {
+    let (x, y) = large_xy_data();
+    let (error_x, error_y) = large_error_bar_xy_data();
+    let y_errors: Vec<f64> = error_x
+        .iter()
+        .map(|value| 0.03 + 0.01 * (value * 0.7).sin().abs())
+        .collect();
+    let x_errors: Vec<f64> = error_x
+        .iter()
+        .map(|value| 0.02 + 0.008 * (value * 0.9).cos().abs())
+        .collect();
+    let (r, theta) = large_polar_data();
+
+    let line = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .line(&x, &y)
+        .into_plot();
+    assert_large_plot_png_and_save("large-line-family-line", &line);
+
+    let scatter = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .scatter(&x, &y)
+        .into_plot();
+    assert_large_plot_png_and_save("large-line-family-scatter", &scatter);
+
+    let error_bars = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .error_bars(&error_x, &error_y, &y_errors)
+        .into_plot();
+    assert_large_plot_png_and_save("large-line-family-error-bars", &error_bars);
+
+    let error_bars_xy = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .error_bars_xy(&error_x, &error_y, &x_errors, &y_errors)
+        .into_plot();
+    assert_large_plot_png_and_save("large-line-family-error-bars-xy", &error_bars_xy);
+
+    let polar = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .polar_line(&r, &theta)
+        .into_plot();
+    assert_large_plot_png_and_save("large-line-family-polar-line", &polar);
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_large_distribution_and_categorical_png_and_save_paths_stay_visually_sane() {
+    let samples = large_scalar_samples();
+    let (categories, values) = large_bar_data();
+
+    let histogram = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .histogram(&samples, None)
+        .into_plot();
+    assert_large_plot_png_and_save("large-distribution-histogram", &histogram);
+
+    let boxplot = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .boxplot(&samples, None)
+        .into_plot();
+    assert_large_plot_png_and_save("large-distribution-boxplot", &boxplot);
+
+    let violin = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .violin(&samples)
+        .into_plot();
+    assert_large_plot_png_and_save("large-distribution-violin", &violin);
+
+    let kde = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .kde(&samples)
+        .into_plot();
+    assert_large_plot_png_and_save("large-distribution-kde", &kde);
+
+    let ecdf = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .ecdf(&samples)
+        .into_plot();
+    assert_large_plot_png_and_save("large-distribution-ecdf", &ecdf);
+
+    let bar = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .bar(&categories, &values)
+        .into_plot();
+    assert_large_plot_png_and_save("large-distribution-bar", &bar);
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_large_grid_family_png_and_save_paths_stay_visually_sane() {
+    let heatmap_values = large_heatmap_matrix();
+    let (contour_x, contour_y, contour_z) = large_contour_axes();
+
+    let heatmap = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .heatmap(
+            &heatmap_values,
+            Some(crate::plots::heatmap::HeatmapConfig::new().colorbar(false)),
+        )
+        .into_plot();
+    assert_large_plot_png_and_save("large-grid-heatmap", &heatmap);
+
+    let contour = Plot::new()
+        .size_px(320, 200)
+        .ticks(false)
+        .contour(&contour_x, &contour_y, &contour_z)
+        .into_plot();
+    assert_large_plot_png_and_save("large-grid-contour", &contour);
 }
 
 // ========================================================================

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -74,6 +74,46 @@ fn extract_svg_group_translate_xy(svg: &str, text: &str) -> (f32, f32) {
     (x, y)
 }
 
+fn mean_rgb(pixels: &[u8]) -> (f64, f64, f64) {
+    let total = pixels.chunks_exact(4).len() as f64;
+    let (r, g, b) = pixels
+        .chunks_exact(4)
+        .fold((0_u64, 0_u64, 0_u64), |(r, g, b), px| {
+            (r + px[0] as u64, g + px[1] as u64, b + px[2] as u64)
+        });
+    (r as f64 / total, g as f64 / total, b as f64 / total)
+}
+
+fn dark_pixel_fraction(pixels: &[u8]) -> f64 {
+    let total = pixels.chunks_exact(4).len() as f64;
+    let dark = pixels
+        .chunks_exact(4)
+        .filter(|px| px[0] < 32 && px[1] < 32 && px[2] < 32)
+        .count() as f64;
+    dark / total
+}
+
+fn decode_png_rgba(png_bytes: &[u8]) -> ::image::RgbaImage {
+    ::image::load_from_memory(png_bytes)
+        .expect("PNG bytes should decode")
+        .to_rgba8()
+}
+
+fn assert_png_background_preserved(name: &str, png_bytes: &[u8]) {
+    let image = decode_png_rgba(png_bytes);
+    let (mean_r, mean_g, mean_b) = mean_rgb(image.as_raw());
+    let dark_fraction = dark_pixel_fraction(image.as_raw());
+
+    assert!(
+        mean_r > 180.0 && mean_g > 180.0 && mean_b > 180.0,
+        "{name} PNG unexpectedly dark: mean=({mean_r:.2}, {mean_g:.2}, {mean_b:.2})"
+    );
+    assert!(
+        dark_fraction < 0.25,
+        "{name} PNG unexpectedly blacks out the canvas: dark_fraction={dark_fraction:.4}"
+    );
+}
+
 #[test]
 fn test_plot_series_static_source_helpers_materialize_values() {
     let mut series = PlotSeries {
@@ -1877,6 +1917,60 @@ fn test_benchmark_save_png_bytes_uses_datashader_for_large_scatter() {
     let (_, backend) = plot.benchmark_save_png_bytes().unwrap();
 
     assert_eq!(backend, "datashader");
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_render_large_scatter_png_preserves_background() {
+    let x_data: Vec<f64> = (0..100_000).map(|i| i as f64 * 0.00001).collect();
+    let y_data: Vec<f64> = x_data.iter().map(|x| x.sin()).collect();
+
+    let png = Plot::new()
+        .size_px(640, 480)
+        .title("large scatter")
+        .xlabel("x")
+        .ylabel("y")
+        .scatter(&x_data, &y_data)
+        .render_png_bytes()
+        .expect("large scatter should render as PNG");
+    assert_png_background_preserved("large scatter", &png);
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_render_large_scatter_source_png_preserves_background() {
+    let x_data: Vec<f64> = (0..100_000).map(|i| i as f64 * 0.00001).collect();
+    let y_data: Vec<f64> = x_data.iter().map(|x| x.sin()).collect();
+
+    let png = Plot::new()
+        .size_px(640, 480)
+        .scatter_source(x_data.clone(), y_data)
+        .into_plot()
+        .render_png_bytes()
+        .expect("source-backed large scatter should render as PNG");
+    assert_png_background_preserved("source-backed large scatter", &png);
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn test_render_large_line_and_histogram_png_preserve_background() {
+    let x_data: Vec<f64> = (0..100_000).map(|i| i as f64 * 0.00001).collect();
+    let y_data: Vec<f64> = x_data.iter().map(|x| x.sin()).collect();
+
+    let line_png = Plot::new()
+        .size_px(640, 480)
+        .line(&x_data, &y_data)
+        .render_png_bytes()
+        .expect("large line should render as PNG");
+    assert_png_background_preserved("large line", &line_png);
+
+    let histogram_input: Vec<f64> = (0..100_000).map(|i| (i as f64 * 0.0001).sin()).collect();
+    let histogram_png = Plot::new()
+        .size_px(640, 480)
+        .histogram(&histogram_input, None)
+        .render_png_bytes()
+        .expect("large histogram should render as PNG");
+    assert_png_background_preserved("large histogram", &histogram_png);
 }
 
 // ========================================================================

--- a/src/data/datashader_simple.rs
+++ b/src/data/datashader_simple.rs
@@ -193,8 +193,9 @@ impl DataShaderCanvas {
         let max_log = f64::from(max_count).ln_1p();
 
         for y in 0..self.height {
+            let source_y = self.height - 1 - y;
             for x in 0..self.width {
-                let idx = y * self.width + x;
+                let idx = source_y * self.width + x;
                 let count = self.canvas[idx].load(Ordering::Relaxed);
 
                 // Empty bins stay transparent so the normal plot background shows through.
@@ -512,6 +513,33 @@ mod tests {
         assert!(
             transparent_bins > 0,
             "large scatter datashader render should keep empty bins transparent"
+        );
+    }
+
+    #[test]
+    fn test_datashader_render_flips_y_axis_into_screen_space() {
+        let mut ds = DataShader::with_canvas_size(4, 4);
+        ds.aggregate_with_bounds(&[0.5, 0.5], &[0.0, 1.0], 0.0, 1.0, 0.0, 1.0)
+            .unwrap();
+
+        let image = ds.render();
+        let top_row_alpha: Vec<u8> = image.pixels[0..(4 * 4)]
+            .chunks_exact(4)
+            .map(|px| px[3])
+            .collect();
+        let bottom_row_start = (image.height - 1) * image.width * 4;
+        let bottom_row_alpha: Vec<u8> = image.pixels[bottom_row_start..bottom_row_start + (4 * 4)]
+            .chunks_exact(4)
+            .map(|px| px[3])
+            .collect();
+
+        assert!(
+            top_row_alpha.iter().any(|alpha| *alpha > 0),
+            "y_max should land in the top image row after render"
+        );
+        assert!(
+            bottom_row_alpha.iter().any(|alpha| *alpha > 0),
+            "y_min should land in the bottom image row after render"
         );
     }
 

--- a/src/data/datashader_simple.rs
+++ b/src/data/datashader_simple.rs
@@ -186,28 +186,34 @@ impl DataShaderCanvas {
         }
     }
 
-    /// Create image data as simple grayscale
+    /// Create image data as a density mask.
     pub fn to_image_data(&self) -> Vec<u8> {
         let max_count = self.max_count();
         let mut pixels = Vec::with_capacity(self.width * self.height * 4);
+        let max_log = f64::from(max_count).ln_1p();
 
         for y in 0..self.height {
             for x in 0..self.width {
                 let idx = y * self.width + x;
                 let count = self.canvas[idx].load(Ordering::Relaxed);
 
-                // Normalize to grayscale
-                let intensity = if max_count > 0 {
-                    ((count as f64 / max_count as f64) * 255.0) as u8
-                } else {
+                // Empty bins stay transparent so the normal plot background shows through.
+                let alpha = if count == 0 || max_count == 0 {
                     0
+                } else {
+                    let normalized = if max_log > 0.0 {
+                        f64::from(count).ln_1p() / max_log
+                    } else {
+                        1.0
+                    };
+                    (normalized * 255.0).round().clamp(24.0, 255.0) as u8
                 };
 
-                // RGBA
-                pixels.push(intensity); // R
-                pixels.push(intensity); // G  
-                pixels.push(intensity); // B
-                pixels.push(255); // A
+                // Store density in alpha only. The renderer tints it with the active theme.
+                pixels.push(0); // R
+                pixels.push(0); // G
+                pixels.push(0); // B
+                pixels.push(alpha); // A
             }
         }
 
@@ -473,6 +479,40 @@ mod tests {
         assert_eq!(image.width, 10);
         assert_eq!(image.height, 10);
         assert_eq!(image.pixels.len(), 10 * 10 * 4); // RGBA
+    }
+
+    #[test]
+    fn test_datashader_render_keeps_empty_bins_transparent() {
+        let mut ds = DataShader::with_canvas_size(8, 8);
+        ds.aggregate(&[0.5], &[0.5]).unwrap();
+
+        let image = ds.render();
+
+        assert!(
+            image.pixels.chunks_exact(4).any(|px| px[3] == 0),
+            "empty bins should remain transparent so DataShader does not overwrite the plot background"
+        );
+        assert!(
+            image.pixels.chunks_exact(4).any(|px| px[3] > 0),
+            "occupied bins should remain visible after density shading"
+        );
+    }
+
+    #[test]
+    fn test_large_scatter_datashader_render_retains_empty_bins() {
+        let x_data: Vec<f64> = (0..100_000).map(|i| i as f64 * 0.00001).collect();
+        let y_data: Vec<f64> = x_data.iter().map(|x| x.sin()).collect();
+        let mut ds = DataShader::with_canvas_size(512, 384);
+        ds.aggregate_with_bounds(&x_data, &y_data, 0.0, 1.0, -1.0, 1.0)
+            .unwrap();
+
+        let image = ds.render();
+        let transparent_bins = image.pixels.chunks_exact(4).filter(|px| px[3] == 0).count();
+
+        assert!(
+            transparent_bins > 0,
+            "large scatter datashader render should keep empty bins transparent"
+        );
     }
 
     #[test]

--- a/src/render/skia.rs
+++ b/src/render/skia.rs
@@ -596,19 +596,18 @@ impl SkiaRenderer {
             ));
         }
 
-        // Convert RGBA u8 data to tiny-skia's format
+        let tint = self.theme.foreground;
+
+        // Convert the density mask to tiny-skia's native tinted premultiplied format.
         let pixmap_data = datashader_pixmap.data_mut();
         for (i, chunk) in image.pixels.chunks_exact(4).enumerate() {
-            let r = chunk[0];
-            let g = chunk[1];
-            let b = chunk[2];
             let a = chunk[3];
 
             // tiny-skia uses premultiplied alpha BGRA format
             let alpha_f = a as f32 / 255.0;
-            let premult_r = (r as f32 * alpha_f) as u8;
-            let premult_g = (g as f32 * alpha_f) as u8;
-            let premult_b = (b as f32 * alpha_f) as u8;
+            let premult_r = (tint.r as f32 * alpha_f).round() as u8;
+            let premult_g = (tint.g as f32 * alpha_f).round() as u8;
+            let premult_b = (tint.b as f32 * alpha_f).round() as u8;
 
             // BGRA order for tiny-skia
             pixmap_data[i * 4] = premult_b;

--- a/src/render/skia/tests.rs
+++ b/src/render/skia/tests.rs
@@ -346,6 +346,36 @@ fn test_draw_datashader_image_scales_into_plot_area() {
     assert!(!pixel_is_bright_rgba(&rendered, 50, 45));
 }
 
+#[test]
+fn test_draw_datashader_image_preserves_transparent_bins() {
+    let theme = Theme::light();
+    let mut renderer = SkiaRenderer::new(20, 10, theme).unwrap();
+    renderer.clear();
+
+    let image = crate::data::DataShaderImage::new(
+        2,
+        1,
+        vec![
+            0, 0, 0, 0, // Transparent bin
+            0, 0, 0, 255, // Fully occupied bin
+        ],
+    );
+    let plot_area = Rect::from_xywh(0.0, 0.0, 20.0, 10.0).unwrap();
+
+    renderer.draw_datashader_image(&image, plot_area).unwrap();
+
+    let png = renderer.encode_png_bytes().unwrap();
+    let rendered = image::load_from_memory(&png).unwrap().to_rgba8();
+    assert!(
+        pixel_is_bright_rgba(&rendered, 2, 5),
+        "transparent bins should preserve the white plot background"
+    );
+    assert!(
+        !pixel_is_bright_rgba(&rendered, 17, 5),
+        "occupied bins should still draw a visible foreground tint"
+    );
+}
+
 #[cfg(feature = "typst-math")]
 #[test]
 fn test_typst_raster_uses_native_1x_scale() {


### PR DESCRIPTION
## Summary
- fix the large-dataset Python PNG blackout by routing the export path through the direct plot renderer and composing auto-datashader output correctly
- keep datashader empty bins transparent and tint occupied bins with the active theme foreground
- add broad large-dataset regressions across the remaining Python plot families, notebook widget rendering, and representative interactive surface rendering

## Validation
- cargo test -p ruviz --no-default-features --features pdf,svg test_large_ -- --nocapture
- uv run python -m pytest tests/test_api.py -k large_plot
- bun run --cwd demo/web test:e2e --grep "python widget bundle renders representative large snapshots without blacking out"