### PR TITLE
Fix npm tarball to include wasm runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,47 @@ jobs:
               )
           PY
 
+  npm-package:
+    name: NPM Package
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-npm-package-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-npm-package-
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Cache Bun
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Install JS workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify npm tarball contents and bun installability
+        run: bun run --cwd packages/ruviz-web verify:pack
+
   platform-build:
     name: Build (${{ matrix.platform.name }})
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
             --timeout 2400 \
             --interval 15 \
             --check "Test Fast Lane" \
+            --check "NPM Package" \
             --check "Python" \
             --check "Python Packaging"
 
@@ -189,11 +190,8 @@ jobs:
       - name: Verify ruviz-gpui examples compile
         run: cargo check -p ruviz-gpui --examples
 
-      - name: Build JS/TS web package
-        run: bun run --cwd packages/ruviz-web build
-
       - name: Validate npm tarball
-        run: bun run --cwd packages/ruviz-web pack:dry
+        run: bun run --cwd packages/ruviz-web verify:pack
 
   build-python-sdist:
     name: Build Python sdist
@@ -652,11 +650,8 @@ jobs:
             exit 1
           fi
 
-      - name: Build npm package
-        run: bun run --cwd packages/ruviz-web build
-
       - name: Validate npm tarball
-        run: bun run --cwd packages/ruviz-web pack:dry
+        run: bun run --cwd packages/ruviz-web verify:pack
 
       - name: Detect published npm package version
         id: npm-version

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "preview:web": "bun run --cwd demo/web preview",
     "test:web": "bun run --cwd demo/web test:e2e",
     "install:web-browsers": "cd demo/web && bunx playwright install --with-deps chromium firefox webkit",
-    "pack:web-sdk": "bun run --cwd packages/ruviz-web pack:dry"
+    "pack:web-sdk": "bun run --cwd packages/ruviz-web verify:pack"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/packages/ruviz-web/.npmignore
+++ b/packages/ruviz-web/.npmignore
@@ -1,0 +1,4 @@
+# Use the package.json "files" allowlist as the source of truth for npm
+# packaging. Without a package-local .npmignore, npm falls back to the repo
+# root .gitignore, which excludes generated/ and strips the wasm runtime from
+# the published tarball.

--- a/packages/ruviz-web/package.json
+++ b/packages/ruviz-web/package.json
@@ -55,12 +55,14 @@
     "build:wasm": "bash ./scripts/build-wasm.sh",
     "build:js": "tsc -p tsconfig.json",
     "build": "bun run build:wasm && bun run build:js",
+    "prepack": "bun run build",
     "docs:api": "typedoc",
     "docs:dev": "bun run build:wasm && bun run docs:api && vitepress dev docs",
     "docs:build": "bun run build:wasm && bun run docs:api && bun run docs:build:preview",
     "docs:build:preview": "RUVIZ_WEB_DOCS_BASE=./ vitepress build docs --outDir ../../generated/web/docs",
     "docs:preview": "vitepress preview docs",
-    "pack:dry": "bun pm pack --dry-run"
+    "verify:pack": "node ./scripts/verify-npm-package.mjs",
+    "pack:dry": "bun run verify:pack"
   },
   "devDependencies": {
     "typedoc": "^0.28.14",

--- a/packages/ruviz-web/scripts/build-raw.sh
+++ b/packages/ruviz-web/scripts/build-raw.sh
@@ -30,3 +30,8 @@ wasm-bindgen \
   --target web \
   --out-dir "${RAW_OUT_DIR}" \
   --out-name ruviz_web_raw
+
+cat >"${RAW_OUT_DIR}/.npmignore" <<'EOF'
+# Prevent npm from inheriting wasm-bindgen's generated .gitignore during
+# package creation. The package.json "files" allowlist is the source of truth.
+EOF

--- a/packages/ruviz-web/scripts/build-wasm.sh
+++ b/packages/ruviz-web/scripts/build-wasm.sh
@@ -30,3 +30,8 @@ if [[ "${RUVIZ_WASM_PACK_NO_OPT:-0}" == "1" ]]; then
 fi
 
 "${WASM_PACK_BIN}" "${WASM_PACK_ARGS[@]}"
+
+cat >"${PACKAGE_DIR}/generated/raw/.npmignore" <<'EOF'
+# Prevent npm from inheriting wasm-pack's generated .gitignore during package
+# creation. The package.json "files" allowlist is the source of truth.
+EOF

--- a/packages/ruviz-web/scripts/verify-npm-package.mjs
+++ b/packages/ruviz-web/scripts/verify-npm-package.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageDir = resolve(scriptDir, "..");
+const requiredTarballFiles = [
+  "dist/index.js",
+  "generated/raw/ruviz_web_raw.d.ts",
+  "generated/raw/ruviz_web_raw.js",
+  "generated/raw/ruviz_web_raw_bg.wasm",
+];
+const requiredInstalledFiles = [
+  "dist/index.js",
+  "generated/raw/ruviz_web_raw.js",
+  "generated/raw/ruviz_web_raw_bg.wasm",
+];
+
+function run(command, args, cwd) {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function assertFilesExist(baseDir, relativePaths, scope) {
+  const missing = relativePaths.filter((relativePath) => !existsSync(join(baseDir, relativePath)));
+  if (missing.length > 0) {
+    throw new Error(`${scope} is missing required files:\n${missing.map((path) => `- ${path}`).join("\n")}`);
+  }
+}
+
+const tempRoot = mkdtempSync(join(tmpdir(), "ruviz-web-pack-"));
+let keepTemp = false;
+
+try {
+  const packDir = join(tempRoot, "pack");
+  mkdirSync(packDir, { recursive: true });
+
+  const packOutput = run("npm", ["pack", "--json", "--pack-destination", packDir], packageDir);
+  const packEntries = JSON.parse(packOutput);
+  if (!Array.isArray(packEntries) || packEntries.length !== 1) {
+    throw new Error(`Expected one npm pack result, received: ${packOutput}`);
+  }
+
+  const packEntry = packEntries[0];
+  const tarballFiles = new Set(packEntry.files.map((entry) => entry.path));
+  const missingTarballFiles = requiredTarballFiles.filter((relativePath) => !tarballFiles.has(relativePath));
+  if (missingTarballFiles.length > 0) {
+    throw new Error(
+      `npm pack tarball is missing required files:\n${missingTarballFiles.map((path) => `- ${path}`).join("\n")}`,
+    );
+  }
+
+  const tarballPath = join(packDir, packEntry.filename);
+  const installDir = join(tempRoot, "install");
+  mkdirSync(installDir, { recursive: true });
+  writeFileSync(join(installDir, "package.json"), JSON.stringify({ name: "ruviz-pack-verify", private: true }, null, 2));
+
+  run("bun", ["add", tarballPath], installDir);
+
+  const installedPackageDir = join(installDir, "node_modules", packEntry.name);
+  assertFilesExist(installedPackageDir, requiredInstalledFiles, "Installed package");
+
+  console.log(
+    `Verified ${packEntry.name}@${packEntry.version} tarball contains wasm runtime assets and survives local bun install.`,
+  );
+} catch (error) {
+  keepTemp = true;
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(message);
+  console.error(`Preserved debug artifacts at ${tempRoot}`);
+  process.exitCode = 1;
+} finally {
+  if (!keepTemp) {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## Summary
- fix the published npm tarball so it includes the wasm runtime under `generated/raw`
- validate the real `npm pack` tarball and smoke-install it with `bun add`
- gate release on the new npm packaging check

## Validation
- `bun run --cwd packages/ruviz-web verify:pack`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`
