### PR TITLE
Surface npm verifier subprocess output

### DIFF
--- a/packages/ruviz-web/scripts/verify-npm-package.mjs
+++ b/packages/ruviz-web/scripts/verify-npm-package.mjs
@@ -21,11 +21,35 @@ const requiredInstalledFiles = [
 ];
 
 function run(command, args, cwd) {
-  return execFileSync(command, args, {
-    cwd,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  try {
+    return execFileSync(command, args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    if (!(error instanceof Error)) {
+      throw error;
+    }
+
+    const stdout = typeof error.stdout === "string" ? error.stdout.trim() : "";
+    const stderr = typeof error.stderr === "string" ? error.stderr.trim() : "";
+    const status = typeof error.status === "number" ? error.status : "unknown";
+    const details = [
+      `Command failed: ${command} ${args.join(" ")}`,
+      `exit status: ${status}`,
+    ];
+
+    if (stdout.length > 0) {
+      details.push(`stdout:\n${stdout}`);
+    }
+
+    if (stderr.length > 0) {
+      details.push(`stderr:\n${stderr}`);
+    }
+
+    throw new Error(details.join("\n\n"));
+  }
 }
 
 function assertFilesExist(baseDir, relativePaths, scope) {


### PR DESCRIPTION
## Summary
- include the failing command, exit code, stdout, and stderr when the npm package verifier subprocess fails
- keep the tarball content and local bun install checks unchanged

## Validation
- `bun run --cwd packages/ruviz-web verify:pack`
- `git diff --check`
