### PR TITLE
Fix log-axis legends and Typst rendering

### DIFF
--- a/src/axes/tick_layout.rs
+++ b/src/axes/tick_layout.rs
@@ -47,17 +47,15 @@ impl TickLayout {
         // Generate tick positions in data coordinates
         let data_positions = generate_ticks_for_scale(data_min, data_max, target_ticks, scale);
 
-        // Convert to pixel coordinates
-        let data_range = data_max - data_min;
         let pixel_range = pixel_max - pixel_min;
 
         let pixel_positions: Vec<f32> = data_positions
             .iter()
             .map(|&data_pos| {
-                if data_range.abs() < f64::EPSILON {
+                if (data_max - data_min).abs() < f64::EPSILON {
                     pixel_min
                 } else {
-                    let normalized = (data_pos - data_min) / data_range;
+                    let normalized = scale.normalized_position(data_pos, data_min, data_max);
                     pixel_min + (normalized as f32) * pixel_range
                 }
             })
@@ -89,18 +87,16 @@ impl TickLayout {
         // Generate tick positions in data coordinates
         let data_positions = generate_ticks_for_scale(data_min, data_max, target_ticks, scale);
 
-        // Convert to pixel coordinates (inverted for Y-axis)
-        let data_range = data_max - data_min;
         let pixel_range = pixel_bottom - pixel_top;
 
         let pixel_positions: Vec<f32> = data_positions
             .iter()
             .map(|&data_pos| {
-                if data_range.abs() < f64::EPSILON {
+                if (data_max - data_min).abs() < f64::EPSILON {
                     pixel_bottom
                 } else {
                     // Invert: higher data values -> lower pixel values
-                    let normalized = (data_pos - data_min) / data_range;
+                    let normalized = scale.normalized_position(data_pos, data_min, data_max);
                     pixel_bottom - (normalized as f32) * pixel_range
                 }
             })
@@ -228,6 +224,28 @@ mod tests {
         assert!(!layout.is_empty());
         assert_eq!(layout.data_positions.len(), layout.pixel_positions.len());
         assert_eq!(layout.data_positions.len(), layout.labels.len());
+    }
+
+    #[test]
+    fn test_log_tick_layout_uses_log_pixel_positions() {
+        let layout = TickLayout::compute(1.0, 1000.0, 0.0, 300.0, &AxisScale::Log, 4);
+
+        assert_eq!(layout.data_positions, vec![1.0, 10.0, 100.0, 1000.0]);
+        assert!((layout.pixel_positions[0] - 0.0).abs() < 0.1);
+        assert!((layout.pixel_positions[1] - 100.0).abs() < 0.1);
+        assert!((layout.pixel_positions[2] - 200.0).abs() < 0.1);
+        assert!((layout.pixel_positions[3] - 300.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_log_y_tick_layout_uses_inverted_log_pixel_positions() {
+        let layout = TickLayout::compute_y_axis(1.0, 1000.0, 0.0, 300.0, &AxisScale::Log, 4);
+
+        assert_eq!(layout.data_positions, vec![1.0, 10.0, 100.0, 1000.0]);
+        assert!((layout.pixel_positions[0] - 300.0).abs() < 0.1);
+        assert!((layout.pixel_positions[1] - 200.0).abs() < 0.1);
+        assert!((layout.pixel_positions[2] - 100.0).abs() < 0.1);
+        assert!((layout.pixel_positions[3] - 0.0).abs() < 0.1);
     }
 
     #[test]

--- a/src/core/plot/annotations.rs
+++ b/src/core/plot/annotations.rs
@@ -50,7 +50,7 @@ impl Plot {
             LegendPosition::LowerCenter => Position::BottomCenter,
             LegendPosition::UpperCenter => Position::TopCenter,
             LegendPosition::Center => Position::Center,
-            LegendPosition::Best => Position::TopRight, // Default, actual best calculated at render time
+            LegendPosition::Best => Position::Best,
             LegendPosition::OutsideRight
             | LegendPosition::OutsideLeft
             | LegendPosition::OutsideUpper
@@ -88,7 +88,7 @@ impl Plot {
     /// ```
     pub fn legend_best(mut self) -> Self {
         self.layout.legend.enabled = true;
-        self.layout.legend.position = Position::TopRight; // Actual best computed at render time
+        self.layout.legend.position = Position::Best;
         self
     }
 

--- a/src/core/plot/annotations.rs
+++ b/src/core/plot/annotations.rs
@@ -92,7 +92,9 @@ impl Plot {
         self
     }
 
-    /// Set legend font size
+    /// Set legend font size in typographic points.
+    ///
+    /// The renderers convert this value to pixels using the configured output DPI.
     pub fn legend_font_size(mut self, size: f32) -> Self {
         self.layout.legend.font_size = Some(size);
         self

--- a/src/core/plot/builder.rs
+++ b/src/core/plot/builder.rs
@@ -750,7 +750,7 @@ where
         self
     }
 
-    /// Set legend font size
+    /// Set legend font size in typographic points.
     ///
     /// This method forwards to the inner Plot.
     pub fn legend_font_size(mut self, size: f32) -> Self {

--- a/src/core/plot/layout_manager.rs
+++ b/src/core/plot/layout_manager.rs
@@ -94,7 +94,7 @@ impl LayoutManager {
         self.legend.position
     }
 
-    /// Set legend font size
+    /// Set legend font size in typographic points.
     pub fn set_legend_font_size(&mut self, size: f32) {
         self.legend.font_size = Some(size);
     }

--- a/src/core/plot/mixed_render.rs
+++ b/src/core/plot/mixed_render.rs
@@ -396,8 +396,16 @@ impl Plot {
                     .iter()
                     .zip(y_data.iter())
                     .map(|(&x, &y)| {
-                        crate::render::skia::map_data_to_pixels(
-                            x, y, x_min, x_max, y_min, y_max, plot_area,
+                        crate::render::skia::map_data_to_pixels_scaled(
+                            x,
+                            y,
+                            x_min,
+                            x_max,
+                            y_min,
+                            y_max,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                     })
                     .collect();
@@ -417,8 +425,16 @@ impl Plot {
                 let marker_style = series.marker_style.unwrap_or(MarkerStyle::Circle);
                 let marker_size = render_scale.points_to_pixels(series.marker_size.unwrap_or(6.0));
                 for (&x, &y) in x_data.iter().zip(y_data.iter()) {
-                    let (px, py) = crate::render::skia::map_data_to_pixels(
-                        x, y, x_min, x_max, y_min, y_max, plot_area,
+                    let (px, py) = crate::render::skia::map_data_to_pixels_scaled(
+                        x,
+                        y,
+                        x_min,
+                        x_max,
+                        y_min,
+                        y_max,
+                        plot_area,
+                        &self.layout.x_scale,
+                        &self.layout.y_scale,
                     );
                     svg.draw_marker(px, py, marker_size, marker_style, color);
                 }

--- a/src/core/plot/parallel_render.rs
+++ b/src/core/plot/parallel_render.rs
@@ -3,6 +3,7 @@ use crate::core::Point2f;
 use crate::core::plot::raster_fast_path::{
     canonicalize_line_points_exact, reduce_line_points_for_raster, should_reduce_line_series,
 };
+use crate::render::skia::map_data_to_pixels_scaled;
 
 impl Plot {
     /// Render plot using parallel processing for multiple series
@@ -32,6 +33,21 @@ impl Plot {
         } else {
             self.effective_data_bounds()?
         };
+        self.validate_axis_scale_ranges_for_render(
+            &self.series_mgr.series,
+            bounds.0,
+            bounds.1,
+            bounds.2,
+            bounds.3,
+        )?;
+
+        let bar_categories: Option<Vec<String>> = self.series_mgr.series.iter().find_map(|s| {
+            if let SeriesType::Bar { categories, .. } = &s.series_type {
+                Some(categories.clone())
+            } else {
+                None
+            }
+        });
 
         // Compute content-driven layout FIRST for consistent positioning
         let content = self.create_plot_content(bounds.2, bounds.3);
@@ -74,13 +90,39 @@ impl Plot {
         let x_tick_pixels: Vec<f32> = x_ticks
             .iter()
             .map(|&tick| {
-                map_data_to_pixels(tick, 0.0, bounds.0, bounds.1, bounds.2, bounds.3, plot_area).0
+                Self::scaled_x_pixel(tick, bounds.0, bounds.1, plot_area, &self.layout.x_scale)
             })
             .collect();
         let y_tick_pixels: Vec<f32> = y_ticks
             .iter()
             .map(|&tick| {
-                map_data_to_pixels(0.0, tick, bounds.0, bounds.1, bounds.2, bounds.3, plot_area).1
+                Self::scaled_y_pixel(tick, bounds.2, bounds.3, plot_area, &self.layout.y_scale)
+            })
+            .collect();
+        let x_minor_ticks = Self::minor_tick_values_for_scale(
+            &x_ticks,
+            bounds.0,
+            bounds.1,
+            &self.layout.x_scale,
+            self.layout.tick_config.minor_ticks_x,
+        );
+        let y_minor_ticks = Self::minor_tick_values_for_scale(
+            &y_ticks,
+            bounds.2,
+            bounds.3,
+            &self.layout.y_scale,
+            self.layout.tick_config.minor_ticks_y,
+        );
+        let x_minor_tick_pixels: Vec<f32> = x_minor_ticks
+            .iter()
+            .map(|&tick| {
+                Self::scaled_x_pixel(tick, bounds.0, bounds.1, plot_area, &self.layout.x_scale)
+            })
+            .collect();
+        let y_minor_tick_pixels: Vec<f32> = y_minor_ticks
+            .iter()
+            .map(|&tick| {
+                Self::scaled_y_pixel(tick, bounds.2, bounds.3, plot_area, &self.layout.y_scale)
             })
             .collect();
 
@@ -88,9 +130,19 @@ impl Plot {
         // Skip grid for non-Cartesian plots (Pie, Radar, Polar)
         if self.layout.grid_style.visible && self.needs_cartesian_axes() {
             let grid_color = self.layout.grid_style.effective_color();
-            renderer.draw_grid(
+            let grid_x_pixels = Self::grid_tick_pixels(
                 &x_tick_pixels,
+                &x_minor_tick_pixels,
+                &self.layout.tick_config.grid_mode,
+            );
+            let grid_y_pixels = Self::grid_tick_pixels(
                 &y_tick_pixels,
+                &y_minor_tick_pixels,
+                &self.layout.tick_config.grid_mode,
+            );
+            renderer.draw_grid(
+                &grid_x_pixels,
+                &grid_y_pixels,
                 plot_area,
                 grid_color,
                 self.layout.grid_style.line_style.clone(),
@@ -98,12 +150,30 @@ impl Plot {
             )?;
         }
 
+        let categorical_x_tick_pixels = Self::categorical_x_tick_pixels(
+            plot_area,
+            bounds.0,
+            bounds.1,
+            bar_categories.as_ref().map(Vec::len),
+            &[],
+        );
+
         // Draw axes (sequential - UI elements) - only for Cartesian plots
         if self.needs_cartesian_axes() && self.layout.tick_config.enabled {
-            renderer.draw_axes(
+            let x_axis_ticks = categorical_x_tick_pixels
+                .as_deref()
+                .unwrap_or(x_tick_pixels.as_slice());
+            let x_axis_minor_ticks = if categorical_x_tick_pixels.is_some() {
+                &[][..]
+            } else {
+                x_minor_tick_pixels.as_slice()
+            };
+            renderer.draw_axes_with_minor_ticks(
                 plot_area,
-                &x_tick_pixels,
+                x_axis_ticks,
                 &y_tick_pixels,
+                x_axis_minor_ticks,
+                &y_minor_tick_pixels,
                 &self.layout.tick_config.direction,
                 &self.layout.tick_config.sides,
                 self.display.theme.foreground,
@@ -141,11 +211,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 x_data,
                                 y_data,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         // Process line segments in parallel
@@ -192,11 +264,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 x_data,
                                 y_data,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         // Process markers in parallel
@@ -225,11 +299,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &x_data,
                                 values,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         // Bar width as fraction of category spacing (0.8 = 80%, matching matplotlib)
@@ -238,8 +314,16 @@ impl Plot {
                         let pixels_per_unit = parallel_plot_area.width() / data_range;
                         let bar_width = bar_width_fraction * pixels_per_unit;
 
-                        let baseline_y = map_data_to_pixels(
-                            0.0, 0.0, bounds.0, bounds.1, bounds.2, bounds.3, plot_area,
+                        let baseline_y = map_data_to_pixels_scaled(
+                            0.0,
+                            0.0,
+                            bounds.0,
+                            bounds.1,
+                            bounds.2,
+                            bounds.3,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                         .1;
 
@@ -282,11 +366,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 x_data,
                                 y_data,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         let markers = self.render.parallel_renderer.process_markers_parallel(
@@ -314,16 +400,26 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &x_data,
                                 &hist_data.counts,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         // Create bar instances for histogram
-                        let baseline_y = map_data_to_pixels(
-                            0.0, 0.0, bounds.0, bounds.1, bounds.2, bounds.3, plot_area,
+                        let baseline_y = map_data_to_pixels_scaled(
+                            0.0,
+                            0.0,
+                            bounds.0,
+                            bounds.1,
+                            bounds.2,
+                            bounds.3,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                         .1;
 
@@ -369,60 +465,78 @@ impl Plot {
                         let box_width = 0.3; // Box width
 
                         // Map Y coordinates to plot area
-                        let q1_y = map_data_to_pixels(
+                        let q1_y = map_data_to_pixels_scaled(
+                            0.0,
                             box_data.q1,
-                            0.0,
                             bounds.0,
                             bounds.1,
                             bounds.2,
                             bounds.3,
                             plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                         .1;
-                        let median_y = map_data_to_pixels(
+                        let median_y = map_data_to_pixels_scaled(
+                            0.0,
                             box_data.median,
-                            0.0,
                             bounds.0,
                             bounds.1,
                             bounds.2,
                             bounds.3,
                             plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                         .1;
-                        let q3_y = map_data_to_pixels(
+                        let q3_y = map_data_to_pixels_scaled(
+                            0.0,
                             box_data.q3,
-                            0.0,
                             bounds.0,
                             bounds.1,
                             bounds.2,
                             bounds.3,
                             plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                         .1;
-                        let lower_whisker_y = map_data_to_pixels(
+                        let lower_whisker_y = map_data_to_pixels_scaled(
+                            0.0,
                             box_data.min,
-                            0.0,
                             bounds.0,
                             bounds.1,
                             bounds.2,
                             bounds.3,
                             plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                         .1;
-                        let upper_whisker_y = map_data_to_pixels(
-                            box_data.max,
+                        let upper_whisker_y = map_data_to_pixels_scaled(
                             0.0,
+                            box_data.max,
                             bounds.0,
                             bounds.1,
                             bounds.2,
                             bounds.3,
                             plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                         .1;
 
                         // Map X coordinate
-                        let x_center_px = map_data_to_pixels(
-                            x_center, 0.0, bounds.0, bounds.1, bounds.2, bounds.3, plot_area,
+                        let x_center_px = map_data_to_pixels_scaled(
+                            x_center,
+                            0.0,
+                            bounds.0,
+                            bounds.1,
+                            bounds.2,
+                            bounds.3,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
                         )
                         .0;
                         let box_left = x_center_px - box_width * plot_area.width() * 0.5;
@@ -431,8 +545,16 @@ impl Plot {
                         // Transform outliers
                         let mut outliers = Vec::new();
                         for &outlier in &box_data.outliers {
-                            let outlier_y = map_data_to_pixels(
-                                outlier, 0.0, bounds.0, bounds.1, bounds.2, bounds.3, plot_area,
+                            let outlier_y = map_data_to_pixels_scaled(
+                                0.0,
+                                outlier,
+                                bounds.0,
+                                bounds.1,
+                                bounds.2,
+                                bounds.3,
+                                plot_area,
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )
                             .1;
                             outliers.push(crate::core::types::Point2f {
@@ -525,11 +647,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &kde_data.x,
                                 &kde_data.y,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         // Process line segments in parallel
@@ -551,11 +675,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &step_x,
                                 &step_y,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         // Process line segments in parallel
@@ -586,11 +712,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &poly_x,
                                 &poly_y,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         let segments = self.render.parallel_renderer.process_polyline_parallel(
@@ -622,11 +750,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &poly_x,
                                 &poly_y,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         let segments = self.render.parallel_renderer.process_polyline_parallel(
@@ -653,11 +783,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &poly_x,
                                 &poly_y,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         let segments = self.render.parallel_renderer.process_polyline_parallel(
@@ -689,11 +821,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &poly_x,
                                 &poly_y,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         let segments = self.render.parallel_renderer.process_polyline_parallel(
@@ -713,11 +847,13 @@ impl Plot {
                         let points = self
                             .render
                             .parallel_renderer
-                            .transform_coordinates_parallel(
+                            .transform_coordinates_parallel_scaled(
                                 &poly_x,
                                 &poly_y,
                                 data_bounds.clone(),
                                 parallel_plot_area.clone(),
+                                &self.layout.x_scale,
+                                &self.layout.y_scale,
                             )?;
 
                         let segments = self.render.parallel_renderer.process_polyline_parallel(
@@ -931,22 +1067,43 @@ impl Plot {
         // Draw tick labels (only for Cartesian plots)
         if self.needs_cartesian_axes() {
             let tick_size_px = pt_to_px(self.display.config.typography.tick_size(), dpi);
-            renderer.draw_axis_labels_at(
-                &layout.plot_area,
-                bounds.0,
-                bounds.1,
-                bounds.2,
-                bounds.3,
-                &x_ticks,
-                &y_ticks,
-                layout.xtick_baseline_y,
-                layout.ytick_right_x,
-                tick_size_px,
-                self.display.theme.foreground,
-                dpi,
-                self.layout.tick_config.enabled,
-                !self.layout.tick_config.enabled,
-            )?;
+            if let Some(ref categories) = bar_categories {
+                renderer.draw_axis_labels_at_categorical(
+                    &layout.plot_area,
+                    categories,
+                    bounds.0,
+                    bounds.1,
+                    bounds.2,
+                    bounds.3,
+                    &y_ticks,
+                    layout.xtick_baseline_y,
+                    layout.ytick_right_x,
+                    tick_size_px,
+                    self.display.theme.foreground,
+                    dpi,
+                    self.layout.tick_config.enabled,
+                    !self.layout.tick_config.enabled,
+                )?;
+            } else {
+                renderer.draw_axis_labels_at_scaled(
+                    &layout.plot_area,
+                    bounds.0,
+                    bounds.1,
+                    bounds.2,
+                    bounds.3,
+                    &x_ticks,
+                    &y_ticks,
+                    layout.xtick_baseline_y,
+                    layout.ytick_right_x,
+                    tick_size_px,
+                    self.display.theme.foreground,
+                    dpi,
+                    self.layout.tick_config.enabled,
+                    !self.layout.tick_config.enabled,
+                    &self.layout.x_scale,
+                    &self.layout.y_scale,
+                )?;
+            }
         }
 
         // Draw title if present

--- a/src/core/plot/parallel_render.rs
+++ b/src/core/plot/parallel_render.rs
@@ -1132,6 +1132,15 @@ impl Plot {
             }
         }
 
+        let legend_items = self.collect_legend_items();
+        if !legend_items.is_empty() && self.layout.legend.enabled {
+            let legend = self
+                .layout
+                .legend
+                .to_legend(self.display.config.typography.legend_size());
+            renderer.draw_legend_full(&legend_items, &legend, plot_area, None)?;
+        }
+
         // Record performance statistics
         let duration = start_time.elapsed();
         let total_points = self.calculate_total_points();

--- a/src/core/plot/raster_batches.rs
+++ b/src/core/plot/raster_batches.rs
@@ -256,13 +256,15 @@ pub(super) fn project_xy_points(
     y_min: f64,
     y_max: f64,
     plot_area: tiny_skia::Rect,
+    x_scale: &crate::axes::AxisScale,
+    y_scale: &crate::axes::AxisScale,
 ) -> Arc<[Point2f]> {
     x_data
         .iter()
         .zip(y_data.iter())
         .map(|(&x, &y)| {
-            let (px, py) = crate::render::skia::map_data_to_pixels(
-                x, y, x_min, x_max, y_min, y_max, plot_area,
+            let (px, py) = crate::render::skia::map_data_to_pixels_scaled(
+                x, y, x_min, x_max, y_min, y_max, plot_area, x_scale, y_scale,
             );
             Point2f::new(px, py)
         })

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -17,6 +17,129 @@ impl Plot {
             .map(|(image, _)| image)
     }
 
+    fn validate_axis_scale_ranges_for_render(
+        &self,
+        series_list: &[PlotSeries],
+        x_min: f64,
+        x_max: f64,
+        y_min: f64,
+        y_max: f64,
+    ) -> Result<()> {
+        if !Self::needs_cartesian_axes_for_series(series_list) {
+            return Ok(());
+        }
+
+        self.layout
+            .x_scale
+            .validate_range(x_min, x_max)
+            .map_err(|message| {
+                PlottingError::InvalidInput(format!("Invalid x-axis range: {message}"))
+            })?;
+        self.layout
+            .y_scale
+            .validate_range(y_min, y_max)
+            .map_err(|message| {
+                PlottingError::InvalidInput(format!("Invalid y-axis range: {message}"))
+            })?;
+        Ok(())
+    }
+
+    fn scaled_x_pixel(
+        value: f64,
+        min: f64,
+        max: f64,
+        plot_area: tiny_skia::Rect,
+        scale: &AxisScale,
+    ) -> f32 {
+        if (max - min).abs() < f64::EPSILON {
+            plot_area.left() + plot_area.width() * 0.5
+        } else {
+            let normalized = scale.normalized_position(value, min, max);
+            plot_area.left() + normalized as f32 * plot_area.width()
+        }
+    }
+
+    fn scaled_y_pixel(
+        value: f64,
+        min: f64,
+        max: f64,
+        plot_area: tiny_skia::Rect,
+        scale: &AxisScale,
+    ) -> f32 {
+        if (max - min).abs() < f64::EPSILON {
+            plot_area.top() + plot_area.height() * 0.5
+        } else {
+            let normalized = scale.normalized_position(value, min, max);
+            plot_area.bottom() - normalized as f32 * plot_area.height()
+        }
+    }
+
+    pub(crate) fn minor_tick_values_for_scale(
+        major_ticks: &[f64],
+        min: f64,
+        max: f64,
+        scale: &AxisScale,
+        requested_count: usize,
+    ) -> Vec<f64> {
+        let (range_min, range_max) = if min <= max { (min, max) } else { (max, min) };
+        let mut ticks = match scale {
+            AxisScale::Log => Self::log_minor_tick_values_for_range(range_min, range_max),
+            AxisScale::Linear | AxisScale::SymLog { .. } => {
+                crate::axes::generate_minor_ticks(major_ticks, requested_count)
+            }
+        };
+
+        ticks.retain(|tick| {
+            tick.is_finite()
+                && *tick >= range_min
+                && *tick <= range_max
+                && !major_ticks
+                    .iter()
+                    .any(|major| Self::tick_values_overlap(*major, *tick))
+        });
+        ticks.sort_by(|left, right| left.partial_cmp(right).unwrap());
+        ticks.dedup_by(|left, right| Self::tick_values_overlap(*left, *right));
+        ticks
+    }
+
+    fn log_minor_tick_values_for_range(min: f64, max: f64) -> Vec<f64> {
+        if min <= 0.0 || max <= 0.0 || min >= max {
+            return Vec::new();
+        }
+
+        let min_exp = min.log10().floor() as i32;
+        let max_exp = max.log10().ceil() as i32;
+        let mut ticks = Vec::new();
+
+        for exp in min_exp..=max_exp {
+            let decade = 10.0_f64.powi(exp);
+            for multiplier in 2..=9 {
+                let tick = decade * multiplier as f64;
+                if tick >= min && tick <= max {
+                    ticks.push(tick);
+                }
+            }
+        }
+
+        ticks
+    }
+
+    fn tick_values_overlap(left: f64, right: f64) -> bool {
+        (left - right).abs() <= left.abs().max(right.abs()).max(1.0) * 1e-10
+    }
+
+    fn grid_tick_pixels(major_pixels: &[f32], minor_pixels: &[f32], mode: &GridMode) -> Vec<f32> {
+        match mode {
+            GridMode::MajorOnly => major_pixels.to_vec(),
+            GridMode::MinorOnly => minor_pixels.to_vec(),
+            GridMode::Both => major_pixels
+                .iter()
+                .chain(minor_pixels.iter())
+                .copied()
+                .collect(),
+        }
+    }
+
     pub(super) fn render_image_with_mode_and_series_renderer<F>(
         &self,
         mode: RenderExecutionMode,
@@ -103,6 +226,7 @@ impl Plot {
 
         let (x_min, x_max, y_min, y_max) =
             self.effective_main_panel_bounds_for_series(&snapshot_series)?;
+        self.validate_axis_scale_ranges_for_render(&snapshot_series, x_min, x_max, y_min, y_max)?;
 
         let bar_categories: Option<Vec<String>> = self.series_mgr.series.iter().find_map(|s| {
             if let SeriesType::Bar { categories, .. } = &s.series_type {
@@ -155,20 +279,52 @@ impl Plot {
 
         let x_tick_pixels: Vec<f32> = x_ticks
             .iter()
-            .map(|&tick| map_data_to_pixels(tick, 0.0, x_min, x_max, y_min, y_max, plot_area).0)
+            .map(|&tick| Self::scaled_x_pixel(tick, x_min, x_max, plot_area, &self.layout.x_scale))
             .collect();
         let y_tick_pixels: Vec<f32> = y_ticks
             .iter()
-            .map(|&tick| map_data_to_pixels(0.0, tick, x_min, x_max, y_min, y_max, plot_area).1)
+            .map(|&tick| Self::scaled_y_pixel(tick, y_min, y_max, plot_area, &self.layout.y_scale))
+            .collect();
+        let x_minor_ticks = Self::minor_tick_values_for_scale(
+            &x_ticks,
+            x_min,
+            x_max,
+            &self.layout.x_scale,
+            self.layout.tick_config.minor_ticks_x,
+        );
+        let y_minor_ticks = Self::minor_tick_values_for_scale(
+            &y_ticks,
+            y_min,
+            y_max,
+            &self.layout.y_scale,
+            self.layout.tick_config.minor_ticks_y,
+        );
+        let x_minor_tick_pixels: Vec<f32> = x_minor_ticks
+            .iter()
+            .map(|&tick| Self::scaled_x_pixel(tick, x_min, x_max, plot_area, &self.layout.x_scale))
+            .collect();
+        let y_minor_tick_pixels: Vec<f32> = y_minor_ticks
+            .iter()
+            .map(|&tick| Self::scaled_y_pixel(tick, y_min, y_max, plot_area, &self.layout.y_scale))
             .collect();
 
         let draw_axes = Self::needs_cartesian_axes_for_series(&snapshot_series);
         if self.layout.grid_style.visible && draw_axes {
             let grid_color = self.layout.grid_style.effective_color();
             let grid_width_px = self.line_width_px(self.layout.grid_style.line_width);
-            renderer.draw_grid(
+            let grid_x_pixels = Self::grid_tick_pixels(
                 &x_tick_pixels,
+                &x_minor_tick_pixels,
+                &self.layout.tick_config.grid_mode,
+            );
+            let grid_y_pixels = Self::grid_tick_pixels(
                 &y_tick_pixels,
+                &y_minor_tick_pixels,
+                &self.layout.tick_config.grid_mode,
+            );
+            renderer.draw_grid(
+                &grid_x_pixels,
+                &grid_y_pixels,
                 plot_area,
                 grid_color,
                 self.layout.grid_style.line_style.clone(),
@@ -189,10 +345,17 @@ impl Plot {
             let x_axis_ticks = categorical_x_tick_pixels
                 .as_deref()
                 .unwrap_or(x_tick_pixels.as_slice());
-            renderer.draw_axes(
+            let x_axis_minor_ticks = if categorical_x_tick_pixels.is_some() {
+                &[][..]
+            } else {
+                x_minor_tick_pixels.as_slice()
+            };
+            renderer.draw_axes_with_minor_ticks(
                 plot_area,
                 x_axis_ticks,
                 &y_tick_pixels,
+                x_axis_minor_ticks,
+                &y_minor_tick_pixels,
                 &self.layout.tick_config.direction,
                 &self.layout.tick_config.sides,
                 self.display.theme.foreground,
@@ -238,7 +401,7 @@ impl Plot {
                     !draw_ticks,
                 )?;
             } else {
-                renderer.draw_axis_labels_at(
+                renderer.draw_axis_labels_at_scaled(
                     &layout.plot_area,
                     x_min,
                     x_max,
@@ -253,6 +416,8 @@ impl Plot {
                     dpi,
                     self.layout.tick_config.enabled,
                     !draw_ticks,
+                    &self.layout.x_scale,
+                    &self.layout.y_scale,
                 )?;
             }
         }
@@ -290,6 +455,15 @@ impl Plot {
             render_scale,
             mode,
         )?;
+
+        let legend_items = self.collect_legend_items();
+        if !legend_items.is_empty() && self.layout.legend.enabled {
+            let legend = self
+                .layout
+                .legend
+                .to_legend(self.display.config.typography.legend_size());
+            renderer.draw_legend_full(&legend_items, &legend, plot_area, None)?;
+        }
 
         let diagnostics = renderer.render_diagnostics().clone();
         Ok((renderer.into_image(), diagnostics))
@@ -1361,6 +1535,7 @@ impl Plot {
 
         let (x_min, x_max, y_min, y_max) =
             self.effective_main_panel_bounds_for_series(&snapshot_series)?;
+        self.validate_axis_scale_ranges_for_render(&snapshot_series, x_min, x_max, y_min, y_max)?;
 
         // Use the same content-driven layout path as PNG rendering.
         let content = self.create_plot_content(y_min, y_max);
@@ -1432,6 +1607,46 @@ impl Plot {
             &self.layout.y_scale,
             self.layout.tick_config.major_ticks_y,
         );
+        let x_tick_layout = if bar_categories.is_none() {
+            Some(TickLayout::compute(
+                x_min,
+                x_max,
+                plot_left,
+                plot_right,
+                &self.layout.x_scale,
+                self.layout.tick_config.major_ticks_x,
+            ))
+        } else {
+            None
+        };
+        let y_minor_ticks = Self::minor_tick_values_for_scale(
+            &y_tick_layout.data_positions,
+            y_min,
+            y_max,
+            &self.layout.y_scale,
+            self.layout.tick_config.minor_ticks_y,
+        );
+        let y_minor_tick_pixels: Vec<f32> = y_minor_ticks
+            .iter()
+            .map(|&tick| Self::scaled_y_pixel(tick, y_min, y_max, plot_area, &self.layout.y_scale))
+            .collect();
+        let x_minor_tick_pixels: Vec<f32> = x_tick_layout
+            .as_ref()
+            .map(|layout| {
+                Self::minor_tick_values_for_scale(
+                    &layout.data_positions,
+                    x_min,
+                    x_max,
+                    &self.layout.x_scale,
+                    self.layout.tick_config.minor_ticks_x,
+                )
+                .iter()
+                .map(|&tick| {
+                    Self::scaled_x_pixel(tick, x_min, x_max, plot_area, &self.layout.x_scale)
+                })
+                .collect()
+            })
+            .unwrap_or_default();
 
         // Draw grid lines (only horizontal for bar charts) - using unified GridStyle
         // Skip grid for non-Cartesian plots (Pie, Radar, Polar)
@@ -1439,11 +1654,16 @@ impl Plot {
         if self.layout.grid_style.visible && draw_axes {
             let grid_color = self.layout.grid_style.effective_color();
             let grid_width_px = self.line_width_px(self.layout.grid_style.line_width);
+            let grid_y_pixels = Self::grid_tick_pixels(
+                &y_tick_layout.pixel_positions,
+                &y_minor_tick_pixels,
+                &self.layout.tick_config.grid_mode,
+            );
             if bar_categories.is_some() {
                 // For bar charts, only draw horizontal grid lines
                 svg.draw_grid(
                     &[], // no vertical grid lines for bar charts
-                    &y_tick_layout.pixel_positions,
+                    &grid_y_pixels,
                     plot_left,
                     plot_right,
                     plot_top,
@@ -1454,17 +1674,17 @@ impl Plot {
                 );
             } else {
                 // For other charts, compute X-axis ticks and draw full grid
-                let x_tick_layout = TickLayout::compute(
-                    x_min,
-                    x_max,
-                    plot_left,
-                    plot_right,
-                    &self.layout.x_scale,
-                    self.layout.tick_config.major_ticks_x,
+                let x_tick_layout = x_tick_layout
+                    .as_ref()
+                    .expect("non-categorical SVG render should have x tick layout");
+                let grid_x_pixels = Self::grid_tick_pixels(
+                    &x_tick_layout.pixel_positions,
+                    &x_minor_tick_pixels,
+                    &self.layout.tick_config.grid_mode,
                 );
                 svg.draw_grid(
-                    &x_tick_layout.pixel_positions,
-                    &y_tick_layout.pixel_positions,
+                    &grid_x_pixels,
+                    &grid_y_pixels,
                     plot_left,
                     plot_right,
                     plot_top,
@@ -1512,13 +1732,15 @@ impl Plot {
 
                 // Bar chart: draw axes with category labels
                 if self.layout.tick_config.enabled {
-                    svg.draw_axes(
+                    svg.draw_axes_with_minor_ticks(
                         plot_left,
                         plot_right,
                         plot_top,
                         plot_bottom,
                         &category_x_tick_positions,
                         &y_tick_layout.pixel_positions,
+                        &[],
+                        &y_minor_tick_pixels,
                         &self.layout.tick_config.direction,
                         &self.layout.tick_config.sides,
                         self.display.theme.foreground,
@@ -1553,22 +1775,19 @@ impl Plot {
                 }
             } else {
                 // Normal chart: draw axes with numeric labels
-                let x_tick_layout = TickLayout::compute(
-                    x_min,
-                    x_max,
-                    plot_left,
-                    plot_right,
-                    &self.layout.x_scale,
-                    self.layout.tick_config.major_ticks_x,
-                );
+                let x_tick_layout = x_tick_layout
+                    .as_ref()
+                    .expect("non-categorical SVG render should have x tick layout");
                 if self.layout.tick_config.enabled {
-                    svg.draw_axes(
+                    svg.draw_axes_with_minor_ticks(
                         plot_left,
                         plot_right,
                         plot_top,
                         plot_bottom,
                         &x_tick_layout.pixel_positions,
                         &y_tick_layout.pixel_positions,
+                        &x_minor_tick_pixels,
+                        &y_minor_tick_pixels,
                         &self.layout.tick_config.direction,
                         &self.layout.tick_config.sides,
                         self.display.theme.foreground,
@@ -1688,7 +1907,10 @@ impl Plot {
         // Draw legend if we have labeled series and legend is enabled
         if !legend_items.is_empty() && self.layout.legend.enabled {
             // Convert old LegendConfig to new Legend type
-            let legend = self.layout.legend.to_legend();
+            let legend = self
+                .layout
+                .legend
+                .to_legend(self.display.config.typography.legend_size());
             // Use new legend rendering with proper handles
             let plot_bounds = (plot_left, plot_top, plot_right, plot_bottom);
             svg.draw_legend_full(&legend_items, &legend, plot_bounds, None)?;

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -17,7 +17,7 @@ impl Plot {
             .map(|(image, _)| image)
     }
 
-    fn validate_axis_scale_ranges_for_render(
+    pub(crate) fn validate_axis_scale_ranges_for_render(
         &self,
         series_list: &[PlotSeries],
         x_min: f64,
@@ -44,7 +44,7 @@ impl Plot {
         Ok(())
     }
 
-    fn scaled_x_pixel(
+    pub(crate) fn scaled_x_pixel(
         value: f64,
         min: f64,
         max: f64,
@@ -59,7 +59,7 @@ impl Plot {
         }
     }
 
-    fn scaled_y_pixel(
+    pub(crate) fn scaled_y_pixel(
         value: f64,
         min: f64,
         max: f64,
@@ -128,7 +128,11 @@ impl Plot {
         (left - right).abs() <= left.abs().max(right.abs()).max(1.0) * 1e-10
     }
 
-    fn grid_tick_pixels(major_pixels: &[f32], minor_pixels: &[f32], mode: &GridMode) -> Vec<f32> {
+    pub(crate) fn grid_tick_pixels(
+        major_pixels: &[f32],
+        minor_pixels: &[f32],
+        mode: &GridMode,
+    ) -> Vec<f32> {
         match mode {
             GridMode::MajorOnly => major_pixels.to_vec(),
             GridMode::MinorOnly => minor_pixels.to_vec(),

--- a/src/core/plot/series_builders.rs
+++ b/src/core/plot/series_builders.rs
@@ -900,7 +900,9 @@ impl PlotSeriesBuilder {
         self
     }
 
-    /// Set legend font size
+    /// Set legend font size in typographic points.
+    ///
+    /// The renderers convert this value to pixels using the configured output DPI.
     pub fn legend_font_size(mut self, size: f32) -> Self {
         self.plot.layout.legend.font_size = Some(size);
         self

--- a/src/core/plot/series_internal.rs
+++ b/src/core/plot/series_internal.rs
@@ -547,8 +547,17 @@ impl Plot {
             SeriesType::Line { x_data, y_data } => {
                 let x_data = x_data.resolve(0.0);
                 let y_data = y_data.resolve(0.0);
-                let mut points =
-                    project_xy_points(&x_data, &y_data, x_min, x_max, y_min, y_max, plot_area);
+                let mut points = project_xy_points(
+                    &x_data,
+                    &y_data,
+                    x_min,
+                    x_max,
+                    y_min,
+                    y_max,
+                    plot_area,
+                    &self.layout.x_scale,
+                    &self.layout.y_scale,
+                );
                 let mut raster_plan = SeriesRasterPlan::default();
 
                 if series.marker_style.is_none()
@@ -590,8 +599,17 @@ impl Plot {
                 let y_data = y_data.resolve(0.0);
                 let marker_size = self.dpi_scaled_line_width(series.marker_size.unwrap_or(10.0));
                 let marker_style = series.marker_style.unwrap_or(MarkerStyle::Circle);
-                let points =
-                    project_xy_points(&x_data, &y_data, x_min, x_max, y_min, y_max, plot_area);
+                let points = project_xy_points(
+                    &x_data,
+                    &y_data,
+                    x_min,
+                    x_max,
+                    y_min,
+                    y_max,
+                    plot_area,
+                    &self.layout.x_scale,
+                    &self.layout.y_scale,
+                );
                 let mut raster_plan = SeriesRasterPlan::default();
                 raster_plan.push_markers(points, marker_size, marker_style, color, clip_rect);
                 Some(raster_plan)

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -45,6 +45,15 @@ fn extract_svg_text_xy(svg: &str, text: &str) -> (f32, f32) {
     (parse_svg_attr(line, "x"), parse_svg_attr(line, "y"))
 }
 
+fn extract_svg_text_font_size(svg: &str, text: &str) -> f32 {
+    let marker = format!(">{}</text>", text);
+    let line = svg
+        .lines()
+        .find(|line| line.contains(&marker))
+        .unwrap_or_else(|| panic!("missing text node for {}", text));
+    parse_svg_attr(line, "font-size")
+}
+
 fn extract_svg_group_translate_xy(svg: &str, text: &str) -> (f32, f32) {
     let marker = format!(">{}</text>", text);
     let line = svg
@@ -73,6 +82,53 @@ fn extract_svg_group_translate_xy(svg: &str, text: &str) -> (f32, f32) {
         .parse::<f32>()
         .unwrap_or_else(|_| panic!("invalid translate y for {}", text));
     (x, y)
+}
+
+fn extract_first_svg_polyline_points(svg: &str) -> Vec<(f32, f32)> {
+    let line = svg
+        .lines()
+        .find(|line| line.contains("<polyline "))
+        .expect("missing polyline");
+    let marker = r#"points=""#;
+    let start = line
+        .find(marker)
+        .expect("missing polyline points attribute")
+        + marker.len();
+    let end = line[start..]
+        .find('"')
+        .expect("unterminated polyline points attribute")
+        + start;
+
+    line[start..end]
+        .split_whitespace()
+        .map(|pair| {
+            let mut coords = pair.split(',');
+            let x = coords
+                .next()
+                .expect("missing point x")
+                .parse::<f32>()
+                .expect("invalid point x");
+            let y = coords
+                .next()
+                .expect("missing point y")
+                .parse::<f32>()
+                .expect("invalid point y");
+            (x, y)
+        })
+        .collect()
+}
+
+fn count_short_horizontal_svg_lines(svg: &str, max_length: f32) -> usize {
+    svg.lines()
+        .filter(|line| line.contains("<line "))
+        .filter(|line| {
+            let x1 = parse_svg_attr(line, "x1");
+            let x2 = parse_svg_attr(line, "x2");
+            let y1 = parse_svg_attr(line, "y1");
+            let y2 = parse_svg_attr(line, "y2");
+            (y1 - y2).abs() <= 0.1 && (x2 - x1).abs() > 0.5 && (x2 - x1).abs() <= max_length
+        })
+        .count()
 }
 
 fn mean_rgb(pixels: &[u8]) -> (f64, f64, f64) {
@@ -486,6 +542,22 @@ fn image_pixel_rgba(image: &Image, x: u32, y: u32) -> [u8; 4] {
         image.pixels[idx + 2],
         image.pixels[idx + 3],
     ]
+}
+
+fn longest_dark_pixel_run_at_y(image: &Image, y: u32) -> usize {
+    let mut longest = 0;
+    let mut current = 0;
+
+    for x in 0..image.width {
+        if image_pixel_is_dark(image, x, y) {
+            current += 1;
+            longest = longest.max(current);
+        } else {
+            current = 0;
+        }
+    }
+
+    longest
 }
 
 fn mean_normalized_channel_diff(lhs: &Image, rhs: &Image) -> f64 {
@@ -1313,6 +1385,131 @@ fn test_group_mixed_series_uses_first_member_legend_glyph() {
         legend_items[0].item_type,
         LegendItemType::Scatter { .. }
     ));
+}
+
+#[test]
+fn test_svg_legend_default_font_size_uses_typography_and_dpi() {
+    let x = vec![0.0, 1.0];
+    let y = vec![1.0, 2.0];
+    let plot: Plot = Plot::new()
+        .line(&x, &y)
+        .label("Legend Label")
+        .legend_best()
+        .dpi(144)
+        .into();
+
+    let svg = plot.render_to_svg().unwrap();
+    let font_size = extract_svg_text_font_size(&svg, "Legend Label");
+
+    assert!(
+        (font_size - 18.0).abs() <= 0.2,
+        "default legend font should be typography legend size (9pt) scaled to 144 DPI: {font_size}"
+    );
+}
+
+#[test]
+fn test_log_minor_ticks_are_generated_between_decades_by_default() {
+    let major_ticks = vec![1.0, 10.0, 100.0, 1000.0];
+    let minor_ticks = Plot::minor_tick_values_for_scale(
+        &major_ticks,
+        1.0,
+        1000.0,
+        &crate::axes::AxisScale::Log,
+        0,
+    );
+
+    assert_eq!(minor_ticks.len(), 24);
+    assert!(minor_ticks.contains(&2.0));
+    assert!(minor_ticks.contains(&9.0));
+    assert!(minor_ticks.contains(&20.0));
+    assert!(minor_ticks.contains(&900.0));
+    assert!(!minor_ticks.contains(&10.0));
+    assert!(!minor_ticks.contains(&100.0));
+}
+
+#[test]
+fn test_log_axis_raster_draws_minor_tick_marks() {
+    let plot: Plot = Plot::new()
+        .size_px(480, 360)
+        .xlim(0.0, 1.0)
+        .ylim(1.0, 1000.0)
+        .yscale(crate::axes::AxisScale::Log)
+        .major_ticks_y(4)
+        .show_bottom_ticks(false)
+        .show_top_ticks(false)
+        .show_right_ticks(false)
+        .grid(false)
+        .into();
+
+    let plot_area = compute_render_plot_area(&plot);
+    let image = plot.render().unwrap();
+    let minor_y = plot_area.bottom() - (2.0_f64.log10() / 3.0) as f32 * plot_area.height();
+    let longest_run = longest_dark_pixel_run_at_y(&image, minor_y.round() as u32);
+
+    assert!(
+        longest_run >= 4,
+        "log minor tick at y=2 should create a short horizontal dark run; got {longest_run}"
+    );
+}
+
+#[test]
+fn test_svg_log_axis_draws_minor_tick_marks() {
+    let svg = Plot::new()
+        .size_px(480, 360)
+        .xlim(0.0, 1.0)
+        .ylim(1.0, 1000.0)
+        .yscale(crate::axes::AxisScale::Log)
+        .major_ticks_y(4)
+        .show_bottom_ticks(false)
+        .show_top_ticks(false)
+        .show_right_ticks(false)
+        .grid(false)
+        .render_to_svg()
+        .unwrap();
+
+    let short_horizontal_lines = count_short_horizontal_svg_lines(&svg, 12.0);
+    assert!(
+        short_horizontal_lines >= 25,
+        "log y-axis should include major and minor left tick marks; got {short_horizontal_lines}"
+    );
+}
+
+#[test]
+fn test_svg_line_uses_log_y_scale_for_geometry() {
+    let x = vec![0.0, 1.0, 2.0, 3.0];
+    let y = vec![1.0, 10.0, 100.0, 1000.0];
+
+    let plot: Plot = Plot::new()
+        .line(&x, &y)
+        .xlim(0.0, 3.0)
+        .ylim(1.0, 1000.0)
+        .yscale(crate::axes::AxisScale::Log)
+        .into();
+
+    let svg = plot.render_to_svg().unwrap();
+    let points = extract_first_svg_polyline_points(&svg);
+    assert_eq!(points.len(), 4);
+
+    let step_1 = (points[0].1 - points[1].1).abs();
+    let step_2 = (points[1].1 - points[2].1).abs();
+    let step_3 = (points[2].1 - points[3].1).abs();
+
+    assert!(
+        (step_1 - step_2).abs() < 2.0 && (step_2 - step_3).abs() < 2.0,
+        "log-spaced y values should have nearly equal pixel spacing: {points:?}"
+    );
+}
+
+#[test]
+fn test_log_axis_rejects_non_positive_render_range() {
+    let result = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .yscale(crate::axes::AxisScale::Log)
+        .render();
+
+    let err = result.expect_err("log scale should reject zero y range bound");
+    assert!(matches!(err, PlottingError::InvalidInput(_)));
+    assert!(err.to_string().contains("Invalid y-axis range"));
 }
 
 #[test]

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -1407,6 +1407,51 @@ fn test_svg_legend_default_font_size_uses_typography_and_dpi() {
     );
 }
 
+#[cfg(feature = "parallel")]
+#[test]
+fn test_parallel_render_draws_enabled_legend() {
+    let x: Vec<f64> = (0..25_000).map(|index| index as f64 / 250.0).collect();
+    let y: Vec<f64> = x.iter().map(|value| value.sin() * 0.2 + 0.5).collect();
+
+    let make_plot = |legend: bool| -> Plot {
+        let plot = Plot::new()
+            .scatter(&x, &y)
+            .label("Samples")
+            .end_series()
+            .xlim(0.0, 100.0)
+            .ylim(0.0, 1.0)
+            .set_output_pixels(420, 320);
+
+        if legend { plot.legend_best() } else { plot }
+    };
+
+    let with_legend = make_plot(true)
+        .render_with_parallel()
+        .expect("parallel render with legend should succeed");
+    let without_legend = make_plot(false)
+        .render_with_parallel()
+        .expect("parallel render without legend should succeed");
+
+    assert_eq!(with_legend.width, without_legend.width);
+    assert_eq!(with_legend.height, without_legend.height);
+
+    let differing_pixels = with_legend
+        .pixels
+        .chunks_exact(4)
+        .zip(without_legend.pixels.chunks_exact(4))
+        .filter(|(left, right)| {
+            left.iter()
+                .zip(right.iter())
+                .any(|(lhs, rhs)| (*lhs as i16 - *rhs as i16).abs() > 8)
+        })
+        .count();
+
+    assert!(
+        differing_pixels > 250,
+        "legend should visibly change parallel render output; differing pixels={differing_pixels}"
+    );
+}
+
 #[test]
 fn test_log_minor_ticks_are_generated_between_decades_by_default() {
     let major_ticks = vec![1.0, 10.0, 100.0, 1000.0];

--- a/src/core/plot/types.rs
+++ b/src/core/plot/types.rs
@@ -1207,7 +1207,7 @@ pub(crate) struct LegendConfig {
     pub(crate) enabled: bool,
     /// Legend position
     pub(crate) position: Position,
-    /// Font size override
+    /// Font size override in typographic points.
     pub(crate) font_size: Option<f32>,
     /// Corner radius for rounded corners
     pub(crate) corner_radius: Option<f32>,

--- a/src/core/plot/types.rs
+++ b/src/core/plot/types.rs
@@ -1229,11 +1229,11 @@ impl Default for LegendConfig {
 
 impl LegendConfig {
     /// Convert to new Legend type for rendering
-    pub(super) fn to_legend(&self) -> Legend {
+    pub(super) fn to_legend(&self, default_font_size: f32) -> Legend {
         let mut legend = Legend {
             enabled: self.enabled,
             position: LegendPosition::from_position(self.position),
-            font_size: self.font_size.unwrap_or(10.0),
+            font_size: self.font_size.unwrap_or(default_font_size),
             ..Legend::default()
         };
         if let Some(radius) = self.corner_radius {

--- a/src/core/subplot.rs
+++ b/src/core/subplot.rs
@@ -583,8 +583,6 @@ mod tests {
 
     #[test]
     fn test_subplot_rendering_integration() {
-        use crate::render::Theme;
-
         let x = vec![1.0, 2.0, 3.0];
         let y = vec![2.0, 4.0, 3.0];
 
@@ -602,6 +600,66 @@ mod tests {
         assert_eq!(figure.grid_spec().total_subplots(), 1);
         assert_eq!(figure.width, 400);
         assert_eq!(figure.height, 300);
+    }
+
+    #[test]
+    fn test_subplot_renders_child_plot_legend() {
+        let dir = tempfile::tempdir().unwrap();
+        let with_legend_path = dir.path().join("with_legend.png");
+        let without_legend_path = dir.path().join("without_legend.png");
+
+        let x = vec![0.0, 1.0, 2.0, 3.0];
+        let y1 = vec![0.1, 0.2, 0.3, 0.4];
+        let y2 = vec![0.9, 0.8, 0.7, 0.6];
+
+        let make_plot = |legend: bool| -> Plot {
+            let builder = Plot::new()
+                .line(&x, &y1)
+                .label("Alpha")
+                .line(&x, &y2)
+                .label("Beta")
+                .xlim(0.0, 3.0)
+                .ylim(0.0, 1.0);
+
+            if legend {
+                builder.legend_best().into()
+            } else {
+                builder.into()
+            }
+        };
+
+        subplots(1, 1, 500, 350)
+            .unwrap()
+            .subplot(0, 0, make_plot(true))
+            .unwrap()
+            .save(&with_legend_path)
+            .unwrap();
+        subplots(1, 1, 500, 350)
+            .unwrap()
+            .subplot(0, 0, make_plot(false))
+            .unwrap()
+            .save(&without_legend_path)
+            .unwrap();
+
+        let with_legend = image::open(with_legend_path).unwrap().to_rgba8();
+        let without_legend = image::open(without_legend_path).unwrap().to_rgba8();
+        assert_eq!(with_legend.dimensions(), without_legend.dimensions());
+
+        let differing_pixels = with_legend
+            .pixels()
+            .zip(without_legend.pixels())
+            .filter(|(left, right)| {
+                left.0
+                    .iter()
+                    .zip(right.0.iter())
+                    .any(|(lhs, rhs)| (*lhs as i16 - *rhs as i16).abs() > 8)
+            })
+            .count();
+
+        assert!(
+            differing_pixels > 250,
+            "legend should visibly change subplot output; differing pixels={differing_pixels}"
+        );
     }
 
     #[test]

--- a/src/export/svg.rs
+++ b/src/export/svg.rs
@@ -75,6 +75,22 @@ impl SvgRenderer {
         self.render_scale.logical_pixels_to_pixels(logical_pixels)
     }
 
+    fn points_to_pixels(&self, points: f32) -> f32 {
+        self.render_scale.points_to_pixels(points)
+    }
+
+    fn scaled_legend_for_render(&self, legend: &Legend) -> Legend {
+        let mut scaled = legend.clone();
+        scaled.font_size = self.points_to_pixels(legend.font_size);
+        scaled.style.border_width = self.points_to_pixels(legend.style.border_width);
+        scaled.style.corner_radius = self.points_to_pixels(legend.style.corner_radius);
+        scaled.style.shadow_offset = (
+            self.points_to_pixels(legend.style.shadow_offset.0),
+            self.points_to_pixels(legend.style.shadow_offset.1),
+        );
+        scaled
+    }
+
     /// Set text rendering backend mode.
     pub fn set_text_engine_mode(&mut self, mode: TextEngineMode) {
         self.text_engine_mode = mode;
@@ -892,6 +908,140 @@ impl SvgRenderer {
         }
     }
 
+    /// Draw axis lines with major and minor tick marks.
+    pub fn draw_axes_with_minor_ticks(
+        &mut self,
+        plot_left: f32,
+        plot_right: f32,
+        plot_top: f32,
+        plot_bottom: f32,
+        x_major_ticks: &[f32],
+        y_major_ticks: &[f32],
+        x_minor_ticks: &[f32],
+        y_minor_ticks: &[f32],
+        tick_direction: &TickDirection,
+        tick_sides: &TickSides,
+        color: Color,
+    ) {
+        let axis_width = self.logical_pixels_to_pixels(1.5);
+        let major_tick_size = self.logical_pixels_to_pixels(6.0);
+        let minor_tick_size = self.logical_pixels_to_pixels(3.5);
+        let tick_width = self.logical_pixels_to_pixels(1.0);
+        let minor_tick_width = self.logical_pixels_to_pixels(0.8);
+
+        self.draw_line(
+            plot_left,
+            plot_bottom,
+            plot_right,
+            plot_bottom,
+            color,
+            axis_width,
+            LineStyle::Solid,
+        );
+
+        self.draw_line(
+            plot_left,
+            plot_top,
+            plot_left,
+            plot_bottom,
+            color,
+            axis_width,
+            LineStyle::Solid,
+        );
+
+        self.draw_line(
+            plot_left,
+            plot_top,
+            plot_right,
+            plot_top,
+            color,
+            axis_width,
+            LineStyle::Solid,
+        );
+
+        self.draw_line(
+            plot_right,
+            plot_top,
+            plot_right,
+            plot_bottom,
+            color,
+            axis_width,
+            LineStyle::Solid,
+        );
+
+        for (tick_size, tick_width, ticks) in [
+            (major_tick_size, tick_width, x_major_ticks),
+            (minor_tick_size, minor_tick_width, x_minor_ticks),
+        ] {
+            for &x in ticks {
+                if x >= plot_left && x <= plot_right {
+                    if tick_sides.bottom {
+                        let (tick_start, tick_end) =
+                            Self::vertical_tick_span(plot_bottom, tick_size, tick_direction, false);
+                        self.draw_line(
+                            x,
+                            tick_start,
+                            x,
+                            tick_end,
+                            color,
+                            tick_width,
+                            LineStyle::Solid,
+                        );
+                    }
+                    if tick_sides.top {
+                        let (tick_start, tick_end) =
+                            Self::vertical_tick_span(plot_top, tick_size, tick_direction, true);
+                        self.draw_line(
+                            x,
+                            tick_start,
+                            x,
+                            tick_end,
+                            color,
+                            tick_width,
+                            LineStyle::Solid,
+                        );
+                    }
+                }
+            }
+        }
+
+        for (tick_size, tick_width, ticks) in [
+            (major_tick_size, tick_width, y_major_ticks),
+            (minor_tick_size, minor_tick_width, y_minor_ticks),
+        ] {
+            for &y in ticks {
+                if y >= plot_top && y <= plot_bottom {
+                    if tick_sides.left {
+                        let (tick_start, tick_end) =
+                            Self::horizontal_tick_span(plot_left, tick_size, tick_direction, false);
+                        self.draw_line(
+                            tick_start,
+                            y,
+                            tick_end,
+                            y,
+                            color,
+                            tick_width,
+                            LineStyle::Solid,
+                        );
+                    }
+                    if tick_sides.right {
+                        let (tick_start, tick_end) =
+                            Self::horizontal_tick_span(plot_right, tick_size, tick_direction, true);
+                        self.draw_line(
+                            tick_start,
+                            y,
+                            tick_end,
+                            y,
+                            color,
+                            tick_width,
+                            LineStyle::Solid,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     /// Draw axis tick labels
     pub fn draw_tick_labels(
         &mut self,
@@ -1238,6 +1388,8 @@ impl SvgRenderer {
             return Ok(());
         }
 
+        let legend = self.scaled_legend_for_render(legend);
+        let legend = &legend;
         let spacing = legend.spacing.to_pixels(legend.font_size);
         let (legend_width, legend_height, label_width) = match self.text_engine_mode {
             TextEngineMode::Plain => {

--- a/src/render/parallel.rs
+++ b/src/render/parallel.rs
@@ -180,11 +180,19 @@ impl ParallelRenderer {
         output_vec.reserve(point_count);
 
         let project = |data_x: f64, data_y: f64| {
-            let normalized_x = x_scale.normalized_position(data_x, bounds.x_min, bounds.x_max);
-            let normalized_y = y_scale.normalized_position(data_y, bounds.y_min, bounds.y_max);
+            let pixel_x = if (bounds.x_max - bounds.x_min).abs() < f64::EPSILON {
+                plot_area.left + plot_area.width() * 0.5
+            } else {
+                let normalized_x = x_scale.normalized_position(data_x, bounds.x_min, bounds.x_max);
+                plot_area.left + normalized_x as f32 * plot_area.width()
+            };
 
-            let pixel_x = plot_area.left + normalized_x as f32 * plot_area.width();
-            let pixel_y = plot_area.bottom - normalized_y as f32 * plot_area.height();
+            let pixel_y = if (bounds.y_max - bounds.y_min).abs() < f64::EPSILON {
+                plot_area.top + plot_area.height() * 0.5
+            } else {
+                let normalized_y = y_scale.normalized_position(data_y, bounds.y_min, bounds.y_max);
+                plot_area.bottom - normalized_y as f32 * plot_area.height()
+            };
 
             Point2f::new(pixel_x, pixel_y)
         };
@@ -786,6 +794,44 @@ mod tests {
         assert_eq!(points.len(), 3);
         assert!((points[1].x - 50.0).abs() <= 1e-5);
         assert!((points[1].y - 50.0).abs() <= 1e-5);
+    }
+
+    #[test]
+    fn test_scaled_coordinate_transformation_handles_degenerate_log_range() {
+        let renderer = ParallelRenderer::new();
+        let x_data = vec![10.0];
+        let y_data = vec![10.0];
+
+        let bounds = DataBounds {
+            x_min: 10.0,
+            x_max: 10.0,
+            y_min: 1.0,
+            y_max: 100.0,
+        };
+
+        let plot_area = PlotArea {
+            left: 20.0,
+            right: 120.0,
+            top: 30.0,
+            bottom: 130.0,
+        };
+
+        let points = renderer
+            .transform_coordinates_parallel_scaled(
+                &x_data,
+                &y_data,
+                bounds,
+                plot_area,
+                &AxisScale::Log,
+                &AxisScale::Log,
+            )
+            .unwrap();
+
+        assert_eq!(points.len(), 1);
+        assert!((points[0].x - 70.0).abs() <= 1e-5);
+        assert!((points[0].y - 80.0).abs() <= 1e-5);
+        assert!(points[0].x.is_finite());
+        assert!(points[0].y.is_finite());
     }
 
     #[test]

--- a/src/render/parallel.rs
+++ b/src/render/parallel.rs
@@ -1,4 +1,5 @@
 use crate::{
+    axes::AxisScale,
     core::{PlottingError, Result, types::Point2f},
     data::{elements::LineSegment, get_memory_manager},
     render::{Color, LineStyle, MarkerStyle},
@@ -144,6 +145,76 @@ impl ParallelRenderer {
         plot_area: PlotArea,
     ) -> Result<Vec<Point2f>> {
         self.transform_coordinates_parallel_pooled(x_data, y_data, bounds, plot_area)
+    }
+
+    /// Transform coordinates in parallel using axis-scale aware projection.
+    ///
+    /// Linear axes keep the existing SIMD/memory-pooled fast path. Non-linear
+    /// axes use the same normalized scale mapping as the main Skia/SVG paths.
+    pub fn transform_coordinates_parallel_scaled(
+        &self,
+        x_data: &[f64],
+        y_data: &[f64],
+        bounds: DataBounds,
+        plot_area: PlotArea,
+        x_scale: &AxisScale,
+        y_scale: &AxisScale,
+    ) -> Result<Vec<Point2f>> {
+        if matches!(x_scale, AxisScale::Linear) && matches!(y_scale, AxisScale::Linear) {
+            return self.transform_coordinates_parallel_pooled(x_data, y_data, bounds, plot_area);
+        }
+
+        if x_data.len() != y_data.len() {
+            return Err(PlottingError::DataLengthMismatch {
+                x_len: x_data.len(),
+                y_len: y_data.len(),
+                series_index: None,
+            });
+        }
+
+        let point_count = x_data.len();
+        let memory_manager = get_memory_manager();
+        let mut output_buffer = memory_manager.get_point_buffer(point_count);
+        let output_vec = output_buffer.get_mut();
+        output_vec.clear();
+        output_vec.reserve(point_count);
+
+        let project = |data_x: f64, data_y: f64| {
+            let normalized_x = x_scale.normalized_position(data_x, bounds.x_min, bounds.x_max);
+            let normalized_y = y_scale.normalized_position(data_y, bounds.y_min, bounds.y_max);
+
+            let pixel_x = plot_area.left + normalized_x as f32 * plot_area.width();
+            let pixel_y = plot_area.bottom - normalized_y as f32 * plot_area.height();
+
+            Point2f::new(pixel_x, pixel_y)
+        };
+
+        if !self.chunked_processing || point_count < self.chunk_size {
+            for i in 0..point_count {
+                output_vec.push(project(x_data[i], y_data[i]));
+            }
+            return Ok(output_buffer.into_inner());
+        }
+
+        let chunks: Vec<&[f64]> = x_data.chunks(self.chunk_size).collect();
+        let y_chunks: Vec<&[f64]> = y_data.chunks(self.chunk_size).collect();
+        let chunk_results: Vec<Vec<Point2f>> = chunks
+            .par_iter()
+            .zip(y_chunks.par_iter())
+            .map(|(x_chunk, y_chunk)| {
+                x_chunk
+                    .iter()
+                    .zip(y_chunk.iter())
+                    .map(|(&x, &y)| project(x, y))
+                    .collect()
+            })
+            .collect();
+
+        for chunk_result in chunk_results {
+            output_vec.extend(chunk_result);
+        }
+
+        Ok(output_buffer.into_inner())
     }
 
     /// Memory-optimized coordinate transformation using buffer pools
@@ -679,6 +750,42 @@ mod tests {
         assert_eq!(points.len(), 3);
         assert_eq!(points[0].x, 0.0); // x=1 maps to left edge
         assert_eq!(points[2].x, 100.0); // x=3 maps to right edge
+    }
+
+    #[test]
+    fn test_scaled_coordinate_transformation_uses_log_scale() {
+        let renderer = ParallelRenderer::new();
+        let x_data = vec![1.0, 10.0, 100.0];
+        let y_data = vec![1.0, 10.0, 100.0];
+
+        let bounds = DataBounds {
+            x_min: 1.0,
+            x_max: 100.0,
+            y_min: 1.0,
+            y_max: 100.0,
+        };
+
+        let plot_area = PlotArea {
+            left: 0.0,
+            right: 100.0,
+            top: 0.0,
+            bottom: 100.0,
+        };
+
+        let points = renderer
+            .transform_coordinates_parallel_scaled(
+                &x_data,
+                &y_data,
+                bounds,
+                plot_area,
+                &AxisScale::Log,
+                &AxisScale::Log,
+            )
+            .unwrap();
+
+        assert_eq!(points.len(), 3);
+        assert!((points[1].x - 50.0).abs() <= 1e-5);
+        assert!((points[1].y - 50.0).abs() <= 1e-5);
     }
 
     #[test]

--- a/src/render/skia.rs
+++ b/src/render/skia.rs
@@ -542,12 +542,42 @@ impl SkiaRenderer {
         }
     }
 
+    fn x_label_center_scaled(
+        plot_area: &LayoutRect,
+        x_value: f64,
+        x_min: f64,
+        x_max: f64,
+        scale: &crate::axes::AxisScale,
+    ) -> f32 {
+        if (x_max - x_min).abs() < f64::EPSILON {
+            plot_area.center_x()
+        } else {
+            let normalized = scale.normalized_position(x_value, x_min, x_max);
+            plot_area.left + normalized as f32 * plot_area.width()
+        }
+    }
+
     fn y_label_center(plot_area: &LayoutRect, y_value: f64, y_min: f64, y_max: f64) -> f32 {
         let y_range = y_max - y_min;
         if y_range.abs() < f64::EPSILON {
             plot_area.center_y()
         } else {
             plot_area.bottom - ((y_value - y_min) as f32 / y_range as f32) * plot_area.height()
+        }
+    }
+
+    fn y_label_center_scaled(
+        plot_area: &LayoutRect,
+        y_value: f64,
+        y_min: f64,
+        y_max: f64,
+        scale: &crate::axes::AxisScale,
+    ) -> f32 {
+        if (y_max - y_min).abs() < f64::EPSILON {
+            plot_area.center_y()
+        } else {
+            let normalized = scale.normalized_position(y_value, y_min, y_max);
+            plot_area.bottom - normalized as f32 * plot_area.height()
         }
     }
 
@@ -678,6 +708,155 @@ impl SkiaRenderer {
                         tick_width,
                         LineStyle::Solid,
                     )?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Draw axis lines with major and minor tick marks.
+    pub fn draw_axes_with_minor_ticks(
+        &mut self,
+        plot_area: Rect,
+        x_major_ticks: &[f32],
+        y_major_ticks: &[f32],
+        x_minor_ticks: &[f32],
+        y_minor_ticks: &[f32],
+        tick_direction: &TickDirection,
+        tick_sides: &TickSides,
+        color: Color,
+    ) -> Result<()> {
+        let axis_width = self.logical_pixels_to_pixels(1.5);
+        let major_tick_size = self.logical_pixels_to_pixels(5.0);
+        let minor_tick_size = self.logical_pixels_to_pixels(3.0);
+        let major_tick_width = self.logical_pixels_to_pixels(1.0);
+        let minor_tick_width = self.logical_pixels_to_pixels(0.8);
+
+        self.draw_line(
+            plot_area.left(),
+            plot_area.bottom(),
+            plot_area.right(),
+            plot_area.bottom(),
+            color,
+            axis_width,
+            LineStyle::Solid,
+        )?;
+
+        self.draw_line(
+            plot_area.left(),
+            plot_area.top(),
+            plot_area.left(),
+            plot_area.bottom(),
+            color,
+            axis_width,
+            LineStyle::Solid,
+        )?;
+
+        self.draw_line(
+            plot_area.left(),
+            plot_area.top(),
+            plot_area.right(),
+            plot_area.top(),
+            color,
+            axis_width,
+            LineStyle::Solid,
+        )?;
+
+        self.draw_line(
+            plot_area.right(),
+            plot_area.top(),
+            plot_area.right(),
+            plot_area.bottom(),
+            color,
+            axis_width,
+            LineStyle::Solid,
+        )?;
+
+        for (tick_size, tick_width, ticks) in [
+            (major_tick_size, major_tick_width, x_major_ticks),
+            (minor_tick_size, minor_tick_width, x_minor_ticks),
+        ] {
+            for &x in ticks {
+                if x >= plot_area.left() && x <= plot_area.right() {
+                    if tick_sides.bottom {
+                        let (tick_start, tick_end) = Self::vertical_tick_span(
+                            plot_area.bottom(),
+                            tick_size,
+                            tick_direction,
+                            false,
+                        );
+                        self.draw_line(
+                            x,
+                            tick_start,
+                            x,
+                            tick_end,
+                            color,
+                            tick_width,
+                            LineStyle::Solid,
+                        )?;
+                    }
+                    if tick_sides.top {
+                        let (tick_start, tick_end) = Self::vertical_tick_span(
+                            plot_area.top(),
+                            tick_size,
+                            tick_direction,
+                            true,
+                        );
+                        self.draw_line(
+                            x,
+                            tick_start,
+                            x,
+                            tick_end,
+                            color,
+                            tick_width,
+                            LineStyle::Solid,
+                        )?;
+                    }
+                }
+            }
+        }
+
+        for (tick_size, tick_width, ticks) in [
+            (major_tick_size, major_tick_width, y_major_ticks),
+            (minor_tick_size, minor_tick_width, y_minor_ticks),
+        ] {
+            for &y in ticks {
+                if y >= plot_area.top() && y <= plot_area.bottom() {
+                    if tick_sides.left {
+                        let (tick_start, tick_end) = Self::horizontal_tick_span(
+                            plot_area.left(),
+                            tick_size,
+                            tick_direction,
+                            false,
+                        );
+                        self.draw_line(
+                            tick_start,
+                            y,
+                            tick_end,
+                            y,
+                            color,
+                            tick_width,
+                            LineStyle::Solid,
+                        )?;
+                    }
+                    if tick_sides.right {
+                        let (tick_start, tick_end) = Self::horizontal_tick_span(
+                            plot_area.right(),
+                            tick_size,
+                            tick_direction,
+                            true,
+                        );
+                        self.draw_line(
+                            tick_start,
+                            y,
+                            tick_end,
+                            y,
+                            color,
+                            tick_width,
+                            LineStyle::Solid,
+                        )?;
+                    }
                 }
             }
         }
@@ -1603,6 +1782,74 @@ impl SkiaRenderer {
         Ok(())
     }
 
+    /// Draw axis tick labels and border using scale-aware layout positions.
+    pub(crate) fn draw_axis_labels_at_scaled(
+        &mut self,
+        plot_area: &LayoutRect,
+        x_min: f64,
+        x_max: f64,
+        y_min: f64,
+        y_max: f64,
+        x_ticks: &[f64],
+        y_ticks: &[f64],
+        xtick_baseline_y: f32,
+        ytick_right_x: f32,
+        tick_size: f32,
+        color: Color,
+        dpi: f32,
+        show_tick_labels: bool,
+        draw_border: bool,
+        x_scale: &crate::axes::AxisScale,
+        y_scale: &crate::axes::AxisScale,
+    ) -> Result<()> {
+        let render_scale = RenderScale::new(dpi);
+
+        let skia_plot_area = Rect::from_ltrb(
+            plot_area.left,
+            plot_area.top,
+            plot_area.right,
+            plot_area.bottom,
+        )
+        .ok_or(PlottingError::InvalidData {
+            message: "Invalid plot area dimensions".to_string(),
+            position: None,
+        })?;
+
+        let x_labels = format_tick_labels_for_scale(x_ticks, x_scale);
+        let y_labels = format_tick_labels_for_scale(y_ticks, y_scale);
+
+        if show_tick_labels {
+            for (tick_value, label_text) in x_ticks.iter().zip(x_labels.iter()) {
+                let x_pixel =
+                    Self::x_label_center_scaled(plot_area, *tick_value, x_min, x_max, x_scale);
+
+                let label_snippet = self.generated_label(label_text);
+                let (text_width, _) = self.measure_text(&label_snippet, tick_size)?;
+                let label_x = (x_pixel - text_width / 2.0)
+                    .max(0.0)
+                    .min(self.width() as f32 - text_width);
+                self.draw_text(&label_snippet, label_x, xtick_baseline_y, tick_size, color)?;
+            }
+
+            for (tick_value, label_text) in y_ticks.iter().zip(y_labels.iter()) {
+                let y_pixel =
+                    Self::y_label_center_scaled(plot_area, *tick_value, y_min, y_max, y_scale);
+
+                let label_snippet = self.generated_label(label_text);
+                let (text_width, text_height) = self.measure_text(&label_snippet, tick_size)?;
+                let label_x = (ytick_right_x - text_width).max(0.0);
+                let centered_y = y_pixel - text_height / 2.0;
+                self.draw_text(&label_snippet, label_x, centered_y, tick_size, color)?;
+            }
+        }
+
+        if draw_border {
+            self.draw_plot_border(skia_plot_area, color, render_scale.reference_scale())?;
+        }
+
+        Ok(())
+    }
+
     /// Draw axis tick labels with categorical x-axis labels for bar charts
     ///
     /// Similar to `draw_axis_labels_at` but uses category names instead of numeric ticks
@@ -2328,6 +2575,18 @@ impl SkiaRenderer {
         legend.calculate_size(items, char_width)
     }
 
+    fn scaled_legend_for_render(&self, legend: &Legend) -> Legend {
+        let mut scaled = legend.clone();
+        scaled.font_size = self.points_to_pixels(legend.font_size);
+        scaled.style.border_width = self.points_to_pixels(legend.style.border_width);
+        scaled.style.corner_radius = self.points_to_pixels(legend.style.corner_radius);
+        scaled.style.shadow_offset = (
+            self.points_to_pixels(legend.style.shadow_offset.0),
+            self.points_to_pixels(legend.style.shadow_offset.1),
+        );
+        scaled
+    }
+
     /// Draw legend with full LegendItem support
     ///
     /// This is the new legend drawing method that properly renders different
@@ -2343,6 +2602,8 @@ impl SkiaRenderer {
             return Ok(());
         }
 
+        let legend = self.scaled_legend_for_render(legend);
+        let legend = &legend;
         let spacing = legend.spacing.to_pixels(legend.font_size);
 
         // Estimate character width for size calculation

--- a/src/render/skia/tests.rs
+++ b/src/render/skia/tests.rs
@@ -22,6 +22,29 @@ fn image_pixel_rgba(image: &Image, x: u32, y: u32) -> [u8; 4] {
     ]
 }
 
+fn dark_pixel_bounds(image: &Image) -> Option<(u32, u32, u32, u32)> {
+    let mut min_x = image.width;
+    let mut min_y = image.height;
+    let mut max_x = 0;
+    let mut max_y = 0;
+    let mut found = false;
+
+    for y in 0..image.height {
+        for x in 0..image.width {
+            let pixel = image_pixel_rgba(image, x, y);
+            if pixel[3] > 0 && pixel[0] < 230 && pixel[1] < 230 && pixel[2] < 230 {
+                min_x = min_x.min(x);
+                min_y = min_y.min(y);
+                max_x = max_x.max(x);
+                max_y = max_y.max(y);
+                found = true;
+            }
+        }
+    }
+
+    found.then_some((min_x, min_y, max_x, max_y))
+}
+
 fn assert_exact_rgba_pixels(name: &str, reference: &Image, candidate: &Image) {
     assert_eq!(reference.width, candidate.width, "{name} width changed");
     assert_eq!(reference.height, candidate.height, "{name} height changed");
@@ -786,6 +809,56 @@ fn test_typst_raster_uses_native_1x_scale() {
         "native raster height should align with logical height: pixel={} logical={}",
         rendered_native.pixmap.height(),
         rendered_native.height
+    );
+}
+
+#[test]
+fn test_draw_legend_full_scales_font_with_render_dpi() {
+    fn render_legend(dpi: f32) -> Image {
+        let mut renderer = SkiaRenderer::new(360, 240, Theme::light()).unwrap();
+        renderer.clear();
+        renderer.set_render_scale(RenderScale::new(dpi));
+
+        let items = vec![LegendItem {
+            label: "Legend Label".to_string(),
+            color: Color::BLACK,
+            item_type: LegendItemType::Line {
+                style: LineStyle::Solid,
+                width: 1.0,
+            },
+            has_error_bars: false,
+        }];
+        let legend = Legend {
+            enabled: true,
+            position: LegendPosition::UpperLeft,
+            text_color: Color::BLACK,
+            ..Legend::default()
+        };
+        let plot_area = Rect::from_xywh(40.0, 40.0, 260.0, 160.0).unwrap();
+
+        renderer
+            .draw_legend_full(&items, &legend, plot_area, None)
+            .unwrap();
+        renderer.into_image()
+    }
+
+    let low_dpi = render_legend(72.0);
+    let high_dpi = render_legend(144.0);
+    let low_bounds = dark_pixel_bounds(&low_dpi).expect("low-dpi legend should draw dark pixels");
+    let high_bounds =
+        dark_pixel_bounds(&high_dpi).expect("high-dpi legend should draw dark pixels");
+    let low_width = low_bounds.2 - low_bounds.0 + 1;
+    let low_height = low_bounds.3 - low_bounds.1 + 1;
+    let high_width = high_bounds.2 - high_bounds.0 + 1;
+    let high_height = high_bounds.3 - high_bounds.1 + 1;
+
+    assert!(
+        high_width as f32 > low_width as f32 * 1.5,
+        "legend width should scale with DPI: low={low_width}, high={high_width}"
+    );
+    assert!(
+        high_height as f32 > low_height as f32 * 1.5,
+        "legend height should scale with DPI: low={low_height}, high={high_height}"
     );
 }
 

--- a/src/render/skia/utils.rs
+++ b/src/render/skia/utils.rs
@@ -182,29 +182,13 @@ pub fn map_data_to_pixels_scaled(
     x_scale: &crate::axes::AxisScale,
     y_scale: &crate::axes::AxisScale,
 ) -> (f32, f32) {
-    use crate::axes::Scale;
+    let normalized_x = x_scale.normalized_position(data_x, data_x_min, data_x_max);
+    let normalized_y = y_scale.normalized_position(data_y, data_y_min, data_y_max);
 
-    // Create scale objects for the data ranges
-    let x_scale_obj = x_scale.create_scale(data_x_min, data_x_max);
-    let y_scale_obj = y_scale.create_scale(data_y_min, data_y_max);
+    let pixel_x = plot_area.left() + normalized_x as f32 * plot_area.width();
+    let pixel_y = plot_area.bottom() - normalized_y as f32 * plot_area.height();
 
-    // Transform data values to normalized [0, 1] space using the scales
-    let normalized_x = x_scale_obj.transform(data_x);
-    let normalized_y = y_scale_obj.transform(data_y);
-
-    // Use CoordinateTransform with normalized [0, 1] data bounds
-    // since scaling has already been applied
-    let transform = CoordinateTransform::from_plot_area(
-        plot_area.left(),
-        plot_area.top(),
-        plot_area.width(),
-        plot_area.height(),
-        0.0, // normalized min
-        1.0, // normalized max
-        0.0, // normalized min
-        1.0, // normalized max
-    );
-    transform.data_to_screen(normalized_x, normalized_y)
+    (pixel_x, pixel_y)
 }
 
 /// Generate intelligent ticks using matplotlib's MaxNLocator algorithm


### PR DESCRIPTION
Stacked on #70.

Addresses #68 and #69.

## Summary
- render subplot legends and `legend_best()` positioning correctly
- make log-scale geometry, tick labels, and default log minor ticks scale-aware for PNG and SVG
- scale legend font sizes by render DPI instead of treating point sizes as fixed pixels
- keep Typst support Typst-native only; no LaTeX alias support is added

## Tests
- cargo test --lib
- cargo test --lib minor
- cargo test --lib legend
- cargo test --lib test_log
- cargo test --features typst-math --lib core::plot::tests::typst::test_invalid_typst_snippet_returns_typst_error
- cargo run --manifest-path target/visual-check/Cargo.toml
- git diff --check
- pre-commit: rustfmt, clippy