### PR TITLE
Validate documentation examples

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,47 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-docs:
+    name: Check Documentation Examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          enable-cache: true
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-docs-examples-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-docs-examples-
+
+      - name: Install JS workspace dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Check Markdown links and examples
+        run: uv run python scripts/check_docs.py
+
   build-docs:
     name: Build Documentation
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -99,7 +99,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
-    needs: build-docs
+    needs: [check-docs, build-docs]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment:
       name: github-pages

--- a/README.md
+++ b/README.md
@@ -1,188 +1,158 @@
 # ruviz
 
-**High-performance 2D plotting library for Rust combining matplotlib's ease-of-use with Makie's performance.**
+High-performance 2D plotting library for Rust.
 
 [![Crates.io](https://img.shields.io/crates/v/ruviz)](https://crates.io/crates/ruviz)
 [![Documentation](https://docs.rs/ruviz/badge.svg)](https://docs.rs/ruviz)
 [![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue)](LICENSE)
 [![CI](https://github.com/Ameyanagi/ruviz/actions/workflows/ci.yml/badge.svg)](https://github.com/Ameyanagi/ruviz/actions/workflows/ci.yml)
 
-## Release Notes
-
-- [Changelog](CHANGELOG.md)
-- [Release Notes Index](docs/releases/README.md)
-- [Latest Release Notes (v0.4.13)](docs/releases/v0.4.13.md)
-
-## Package Surfaces
-
-- Rust crate: `ruviz`
-- GPUI adapter crate: `ruviz-gpui`
-- Raw Rust wasm bridge: `ruviz-web`
-- Python package: `ruviz` in [`python/`](python)
-- npm package: `ruviz` in [`packages/ruviz-web/`](packages/ruviz-web)
-
-Release-facing media and generated docs now use the documented layout in
-[docs/BUILD_OUTPUTS.md](docs/BUILD_OUTPUTS.md). Regenerate the full release docs
-surface with `make release-docs` on the release docs branch.
-
 ## Quick Start
 
-```rust
-use ruviz::prelude::*;
-
-fn main() -> Result<()> {
-    let x: Vec<f64> = (0..50).map(|i| i as f64 * 0.1).collect();
-    let y: Vec<f64> = x.iter().map(|&x| x * x).collect();
-
-    Plot::new()
-        .line(&x, &y)
-        .title("Quadratic Function")
-        .xlabel("x")
-        .ylabel("y = x^2")
-        .save("plot.png")?;
-
-    Ok(())
-}
-```
-
-Run it with:
-
-```bash
-cargo run --release
-```
-
-Need typeset math labels? See [Typst Text Mode](#typst-text-mode) below.
-
-![Example Plot](docs/assets/readme/readme_example.png)
-
-## Features
-
-### 🛡️ Safety & Quality
-- **Zero unsafe** in public API
-- Strong type system prevents runtime errors
-- Comprehensive error handling with `Result` types
-- Memory-safe by design
-
-### 📊 Plot Types
-**Basic**: Line, Scatter, Bar, Histogram, Box Plot, Heatmap
-**Distribution**: Violin, KDE, ECDF
-**Composition**: Pie, Donut
-**Continuous**: Contour
-**Polar**: Polar Plot, Radar Chart
-**Error**: Error Bars (symmetric/asymmetric)
-
-### 🎨 Publication Quality
-- **High-DPI export**: 72, 96, 300, 600 DPI for print
-- **Multiple formats**: PNG, SVG, and PDF (with the `pdf` feature)
-- **Professional themes**: Light, Dark, Publication, Seaborn-style
-- **Custom styling**: Colors, fonts, markers, line styles
-- **International text**: Full UTF-8 support (Japanese, Chinese, Korean, etc.) with cosmic-text
-
-### ⚡ Advanced Features
-- **Simple API**: One-liner functions for quick plotting
-- **Parallel rendering**: Multi-threaded for large datasets (rayon)
-- **GPU acceleration**: Optional wgpu backend (experimental)
-- **Interactive plots**: Optional desktop window integration on Linux, macOS, and Windows
-- **Mixed-coordinate insets**: Embed polar, pie, and radar plots inside Cartesian figures
-- **Browser runtime**: Experimental `ruviz-web` adapter and `ruviz` npm SDK for `wasm32` canvas rendering
-- **Animation**: GIF export with `record!` macro and easing functions
-- **Cross-platform**: Linux, macOS, Windows, and experimental browser/wasm targets
-
-## Installation
-
-Add to your `Cargo.toml`:
+Add the crate:
 
 ```toml
 [dependencies]
 ruviz = "0.4.13"
 ```
 
-### Feature Flags
+Create and save a PNG:
 
-Choose features based on your needs:
+```rust,check
+use ruviz::prelude::*;
 
-```toml
-[dependencies]
-ruviz = { version = "0.4.13", features = ["parallel", "simd"] }
+fn main() -> Result<()> {
+    let x: Vec<f64> = (0..100).map(|i| i as f64 * 0.1).collect();
+    let y: Vec<f64> = x.iter().map(|&v| v.sin()).collect();
+
+    Plot::new()
+        .line(&x, &y)
+        .title("Sine Wave")
+        .xlabel("x")
+        .ylabel("sin(x)")
+        .save("sine.png")?;
+
+    Ok(())
+}
 ```
 
-| Feature | Description | Use When |
-|---------|-------------|----------|
-| `default` | ndarray + parallel | General use |
-| `parallel` | Multi-threaded rendering | Large datasets |
-| `simd` | Vectorized transforms | Performance-critical |
-| `animation` | GIF animation export | Animated plots |
-| `gpu` | GPU acceleration backend (experimental) | Opt-in GPU rendering |
-| `interactive` | winit window support | Interactive plots |
-| `ndarray_support` | ndarray types | Scientific computing |
-| `nalgebra_support` | nalgebra vectors/matrices | Linear algebra workloads |
-| `polars_support` | DataFrame support | Data analysis |
-| `pdf` | PDF export | Publication output |
-| `typst-math` | Typst text engine for all plot text | Math-heavy publication plots |
-| `full` | Most bundled features (excludes HQ GIF/video extras) | Power users |
+Run with:
 
-For minimal builds: `default-features = false`
-
-Benchmark note: the current Rust feature-impact study in
-[docs/benchmarks/rust-feature-impact.md](docs/benchmarks/rust-feature-impact.md) shows
-`parallel` is the main default performance feature to care about, `simd` is situational, and
-`gpu` should remain opt-in rather than a default build choice.
-
-### Experimental WASM Support
-
-The core crate now compiles for `wasm32-unknown-unknown` with in-memory output helpers such as
-`Plot::render_png_bytes()`, `Plot::render_to_svg()`, and `Image::encode_png()`.
-
-For browser interactivity, use the companion Rust bridge crate in
-[`crates/ruviz-web`](crates/ruviz-web) and the public JS/TS SDK package
-[`ruviz`](packages/ruviz-web). The reference browser demo lives in
-[`demo/web`](demo/web). Native file-path export helpers remain desktop-only.
-
-Note:
-- `ruviz` automatically registers a bundled browser fallback font for canvas sessions.
-- Custom browser fonts can still be added explicitly via `ruviz::render::register_font_bytes(...)`.
-- The current browser adapter provides main-thread canvas and OffscreenCanvas worker sessions, plus
-  `web_runtime_capabilities()` for feature diagnostics.
-- The Vite demo includes direct wasm export, main-thread interactivity, worker interactivity, and
-  temporal signal playback plus Observable-driven updates.
-- The JS workspace is Bun-first. Use `bun install`, `bun run build:web`, and `bun run test:web`
-  from the repo root for browser package and demo work.
-
-### Python Bindings
-
-The repo now includes a mixed Python package in [`python`](python) built with `uv`, `maturin`,
-and `pyO3`.
-
-```sh
-cd python
-uv sync
-uv run maturin develop
+```bash
+cargo run --release
 ```
 
-The Python package exposes a fluent `ruviz.plot()` builder for static export and uses the browser
-runtime for notebook widgets. Outside Jupyter, `plot.show()` uses the native interactive window.
-The published Linux wheel focuses on static rendering and notebook widgets; install from source on
-Linux if you need the native desktop window there.
-Standalone MkDocs docs and runnable examples live under [`python/docs`](python/docs) and
-[`python/examples`](python/examples).
+![Example Plot](docs/assets/readme/readme_example.png)
 
-### Web SDK Docs
+## Common API
 
-The browser-first JS/TS SDK in [`packages/ruviz-web`](packages/ruviz-web) now ships with
-runtime examples under [`packages/ruviz-web/examples`](packages/ruviz-web/examples) and a
-standalone VitePress docs site under [`packages/ruviz-web/docs`](packages/ruviz-web/docs).
+The main API is the fluent `Plot` builder. Series are finalized automatically when
+you render, save, or start another series.
 
-### Typst Text Mode
+```rust,check
+use ruviz::prelude::*;
 
-Enable Typst text rendering:
+let x = vec![0.0, 1.0, 2.0, 3.0, 4.0];
+let linear = x.clone();
+let quadratic: Vec<f64> = x.iter().map(|&v| v * v).collect();
+
+Plot::new()
+    .line(&x, &linear)
+    .label("Linear")
+    .line(&x, &quadratic)
+    .label("Quadratic")
+    .legend(Position::TopLeft)
+    .theme(Theme::publication())
+    .save("series.png")?;
+```
+
+Top-level helpers are available for line, scatter, and bar plots:
+
+```rust,check
+use ruviz::prelude::*;
+
+let x = vec![0.0, 1.0, 2.0];
+let y = vec![0.0, 1.0, 4.0];
+
+line(&x, &y)
+    .title("Line")
+    .save("line.png")?;
+```
+
+The `ruviz::simple` module also provides file-oriented helper functions such as
+`line_plot`, `scatter_plot`, `bar_chart`, and `histogram`.
+
+## Plot Types
+
+The root `Plot` builder currently exposes:
+
+- Basic: line, scatter, bar, histogram, box plot, heatmap
+- Distribution: KDE, ECDF, violin
+- Composition and polar: pie, donut styling, radar, polar line
+- Continuous and error plots: contour, symmetric/asymmetric error bars
+- Layout helpers: subplots, legends, grid/tick controls, annotations, insets
+
+Some lower-level modules contain additional experimental plot implementations
+that do not yet have a high-level `Plot::new().type(...)` builder method.
+
+## Export
+
+- `save("plot.png")` writes PNG files on native targets.
+- `render()` returns an in-memory `Image`.
+- `render_png_bytes()` returns PNG bytes.
+- `export_svg("plot.svg")` writes SVG files on native targets.
+- `render_to_svg()` returns an SVG string.
+- `save_pdf("plot.pdf")` is available with the `pdf` feature.
+
+For browser/wasm targets, use in-memory helpers such as `render_png_bytes()`,
+`render_to_svg()`, and `Image::encode_png()` instead of native file-path export
+helpers.
+
+## Feature Flags
+
+Default features are `ndarray` and `parallel`.
+
+| Feature | Description |
+|---------|-------------|
+| `ndarray_support` | ndarray data support |
+| `polars_support` | polars data support |
+| `nalgebra_support` | nalgebra data support |
+| `parallel` | enables the internal parallel renderer and backend metadata |
+| `simd` | SIMD support used by performance-oriented paths |
+| `performance` | shorthand for `parallel` + `simd` |
+| `gpu` | enables GPU types and `.gpu(true)` metadata |
+| `window` | desktop window dependencies |
+| `interactive` | standalone interactive window support |
+| `interactive-gpu` | `interactive` + `gpu` |
+| `serde` | serialize themes/configuration types |
+| `pdf` | PDF export via SVG-to-PDF |
+| `typst-math` | Typst-backed text rendering |
+| `animation` | GIF recording support |
+| `full` | broad feature set for native builds |
+
+SVG export is available without enabling the legacy `svg` feature.
+
+## Backend Notes
+
+`.backend(...)`, `.auto_optimize()`, and `.get_backend_name()` store or report
+backend selection metadata. The current public `render()` and `save()` paths use
+the reference raster pipeline for output parity; treat backend metadata as a
+configuration hint, not an execution guarantee.
+
+Use release builds and benchmark your actual workload before adding optional
+performance features. See [Backend Selection](docs/guide/07_backends.md) and
+[Performance Optimization](docs/guide/08_performance.md).
+
+## Typst Text Mode
+
+Enable Typst-backed text rendering with:
 
 ```toml
 [dependencies]
 ruviz = { version = "0.4.13", features = ["typst-math"] }
 ```
 
-Use `.typst(true)` on a plot to render all static text surfaces (titles, axis labels, ticks,
-legend labels, and annotations) through Typst:
+Then call `.typst(true)`:
 
 ```rust
 use ruviz::prelude::*;
@@ -199,23 +169,8 @@ Plot::new()
     .save("typst_plot.png")?;
 ```
 
-Notes:
-- Invalid Typst snippets fail render/export with a `TypstError`.
-- `.typst(true)` is only available when `typst-math` is enabled at compile time.
-- Without `typst-math`, the compiler reports:
-
-```text
-error[E0599]: no method named `typst` found for struct `ruviz::core::Plot` in the current scope
-```
-
-- If you select the text engine directly, `TextEngineMode::Typst` is also unavailable without
-  `typst-math`, and the compiler reports:
-
-```text
-error[E0599]: no variant or associated item named `Typst` found for enum `TextEngineMode` in the current scope
-```
-
-- If Typst is optional in your own crate, define and forward a local feature first:
+Without `typst-math`, `.typst(true)` and `TextEngineMode::Typst` are not
+compiled. If Typst is optional in your crate, forward and guard your own feature:
 
 ```toml
 [dependencies]
@@ -226,16 +181,12 @@ default = []
 typst-math = ["ruviz/typst-math"]
 ```
 
-- Then guard the call with your crate feature:
-
 ```rust
 use ruviz::prelude::*;
 
 let mut plot = Plot::new()
     .line(&x, &y)
-    .title("$f(x) = e^(-x)$")
-    .xlabel("$x$")
-    .ylabel("$f(x)$");
+    .title("$f(x) = e^(-x)$");
 
 #[cfg(feature = "typst-math")]
 {
@@ -245,307 +196,48 @@ let mut plot = Plot::new()
 plot.save("typst_plot.png")?;
 ```
 
-- Migration: `.latex(true)` has been removed; use `.typst(true)` instead.
-- Typst text in PNG output is rasterized at native output scale (1x).
-- For maximum text sharpness, prefer higher DPI (for example `.dpi(300)`) or vector export (`.export_svg(...)` / `.save_pdf(...)`).
-- DPI changes output density, not the intended physical size of fonts, strokes, markers, or layout spacing.
-- Prefer `.size(width_in, height_in)` when you care about physical figure size. `.size_px(width, height)` is a convenience that maps pixels through the 100-DPI reference size before final output DPI is applied.
-- Ticks are enabled by default and render inward on all four sides. Use `.ticks(false)` to hide tick marks and tick labels while keeping the frame and axis titles.
-- Migration: if you want the older bottom/left-only tick appearance, call `.ticks_bottom_left()`.
-- Migration: if you previously relied on high-DPI exports making lines, markers, or text look larger, set those sizes explicitly instead of relying on DPI.
-
-Tick customization:
-
-```rust
-use ruviz::prelude::*;
-
-Plot::new()
-    .line(&x, &y)
-    .tick_direction_inout()
-    .ticks_bottom_left()
-    .show_top_ticks(true)
-    .show_right_ticks(true)
-    .save("custom_ticks.png")?;
-```
-
 ## Examples
 
-### Basic Line Plot
+Rust documentation examples are in `examples/doc_*.rs`.
 
-```rust
-use ruviz::prelude::*;
-
-let x = vec![0.0, 1.0, 2.0, 3.0, 4.0];
-let y = vec![0.0, 1.0, 4.0, 9.0, 16.0];
-
-Plot::new()
-    .line(&x, &y)
-    .title("My First Plot")
-    .save("output.png")?;
+```bash
+cargo run --example doc_line_plot
+cargo run --example doc_scatter_plot
+cargo run --example doc_typst_text --features typst-math
 ```
 
-### Multi-Series with Styling
-
-```rust
-use ruviz::prelude::*;
-
-let x = vec![0.0, 1.0, 2.0, 3.0, 4.0];
-
-Plot::new()
-    .line(&x, &x.iter().map(|&x| x).collect::<Vec<_>>())
-    .label("Linear")
-    .line(&x, &x.iter().map(|&x| x * x).collect::<Vec<_>>())
-    .label("Quadratic")
-    .line(&x, &x.iter().map(|&x| x.powi(3)).collect::<Vec<_>>())
-    .label("Cubic")
-    .title("Polynomial Functions")
-    .xlabel("x")
-    .ylabel("y")
-    .theme(Theme::publication())
-    .save("polynomials.png")?;
-```
-
-### Grouped Series with Shared Styling
-
-```rust
-use ruviz::prelude::*;
-
-let x = vec![0.0, 1.0, 2.0, 3.0];
-let a = vec![0.0, 1.0, 2.0, 3.0];
-let b = vec![0.0, 1.5, 3.0, 4.5];
-let baseline = vec![0.2, 1.2, 2.2, 3.2];
-
-Plot::new()
-    .group(|g| {
-        g.group_label("Sensors")
-            .line_style(LineStyle::Dashed)
-            .line_width(2.0)
-            .color(Color::from_hex("#1E88E5").unwrap())
-            .line(&x, &a)
-            .line(&x, &b)
-    })
-    .line(&x, &baseline)
-    .label("Baseline")
-    .legend(Position::TopRight)
-    .save("grouped_series.png")?;
-```
-
-### Subplots
-
-```rust
-use ruviz::prelude::*;
-
-let plot1 = Plot::new().line(&x, &y).title("Line").end_series();
-let plot2 = Plot::new().scatter(&x, &y).title("Scatter").end_series();
-let plot3 = Plot::new().bar(&["A", "B", "C"], &[1.0, 2.0, 3.0]).title("Bar").end_series();
-let data = vec![0.5, 1.0, 1.5, 2.0, 2.5];
-let plot4 = Plot::new()
-    .histogram(&data, None)
-    .title("Histogram")
-    .end_series();
-
-subplots(2, 2, 800, 600)?
-    .suptitle("Scientific Analysis")
-    .subplot(0, 0, plot1)?
-    .subplot(0, 1, plot2)?
-    .subplot(1, 0, plot3)?
-    .subplot(1, 1, plot4)?
-    .save("subplots.png")?;
-```
-
-### Large Dataset
-
-```rust
-use ruviz::prelude::*;
-
-// 100,000-point PNG export
-let x: Vec<f64> = (0..100_000).map(|i| i as f64).collect();
-let y: Vec<f64> = x.iter().map(|&x| x.sin()).collect();
-
-Plot::new()
-    .line(&x, &y)
-    .title("Large Dataset")
-    .save("large.png")?;
-```
-
-### Animation
-
-Enable the `animation` feature for this example:
-
-```toml
-[dependencies]
-ruviz = { version = "0.4.13", features = ["animation"] }
-```
-
-```rust
-use ruviz::prelude::*;
-use ruviz::animation::RecordConfig;
-use ruviz::record;
-
-let x: Vec<f64> = (0..100).map(|i| i as f64 * 0.1).collect();
-let config = RecordConfig::new().max_resolution(800, 600).framerate(30);
-
-record!(
-    "wave.gif",
-    2 secs,
-    config: config,
-    |t| {
-        let phase = t.time * 2.0 * std::f64::consts::PI;
-        let y: Vec<f64> = x.iter().map(|&xi| (xi + phase).sin()).collect();
-        Plot::new()
-            .line(&x, &y)
-            .title(format!("Wave Animation (t={:.2}s)", t.time))
-            .xlim(0.0, 10.0)
-            .ylim(-1.5, 1.5)
-    }
-)?;
-```
-
-![Animation Example](docs/assets/rustdoc/animation_sine_wave.gif)
-
-### Interactive And Animation Example Catalog
-
-Interactive window examples:
+Interactive examples require the `interactive` feature:
 
 ```bash
 cargo run --features interactive --example basic_interaction
 cargo run --features interactive --example interactive_multi_series
-cargo run --features interactive --example interactive_scatter_clusters
-cargo run --features interactive --example interactive_heatmap
-cargo run --features interactive --example data_brushing
-cargo run --features interactive --example real_time_performance
 ```
 
-Default interactive window controls:
-
-- `Mouse wheel`: zoom in/out under the cursor
-- `Left click + drag`: pan
-- `Right click`: open the context menu
-- `Right click + drag`: box zoom
-- `Escape`: close the menu or reset the view
-- `Cmd/Ctrl+S`: save the current view as PNG
-- `Cmd/Ctrl+C`: copy the current view as an image
-
-The standalone interactive window and the `ruviz-gpui` adapter are supported on
-Linux, macOS, and Windows. On Windows, the recommended CI/native target is
-`x86_64-pc-windows-msvc`.
-
-The built-in context menu includes `Reset View`, `Set Current View As Home`,
-`Go To Home View`, `Save PNG...`, `Copy Image`, `Copy Cursor Coordinates`, and
-`Copy Visible Bounds`. You can extend it with custom items through
-`InteractiveWindowBuilder::context_menu(...)` and
-`InteractiveWindowBuilder::on_context_menu_action(...)`.
-
-Animation export examples:
+Animation examples require the `animation` feature:
 
 ```bash
 cargo run --features animation --example animation_basic
-cargo run --features animation --example animation_simple
 cargo run --features animation --example animation_wave
-cargo run --features animation --example animation_easing
-cargo run --features animation --example animation_reactive
-cargo run --features animation --example generate_animation_gallery
-```
-
-Use the interactive examples when you want zoom/pan exploration in a window. Use the
-animation examples when you want rendered GIF output with the `record!` macro and easing
-helpers.
-
-### Typst Text Example
-
-Run:
-
-```bash
-cargo run --example doc_typst_text --features typst-math
 ```
 
 ## Documentation
 
-- **[User Guide](docs/guide/README.md)** - Comprehensive tutorials and examples
-- **[API Documentation](https://docs.rs/ruviz)** - Complete API reference
-- **[Gallery](docs/gallery/README.md)** - Visual examples showcase
-- **[Migration from matplotlib](docs/migration/matplotlib.md)** - For Python users
-- **[Migration from seaborn](docs/migration/seaborn.md)** - Statistical plots
-- **[Performance Guide](docs/PERFORMANCE_GUIDE.md)** - Optimization techniques
-- **[Large Dataset Benchmarks](docs/benchmarks/large-dataset-plotting.md)** - Cross-runtime PNG rendering results for Rust, Python, wasm, and matplotlib
-- **[Rust Feature Impact Benchmarks](docs/benchmarks/rust-feature-impact.md)** - Rust-only feature-flag study for render and save backend performance
+- [Quick Start](docs/QUICKSTART.md)
+- [User Guide](docs/guide/README.md)
+- [API Documentation](https://docs.rs/ruviz)
+- [Gallery](docs/gallery/README.md)
 
-## Why ruviz?
-
-Rust's plotting ecosystem has several options, but each has trade-offs:
-
-| Library | Approach | Limitation |
-|---------|----------|------------|
-| [plotters](https://github.com/plotters-rs/plotters) | Low-level drawing API | Verbose, requires boilerplate for common plots |
-| [plotly.rs](https://github.com/plotly/plotly.rs) | JavaScript bindings | Requires JS runtime, web-focused |
-| [plotpy](https://github.com/cpmech/plotpy) | Python/matplotlib wrapper | Requires Python installed |
-
-**ruviz fills the gap** with:
-- **High-level API**: matplotlib-style `Plot::new().line().title().save()` - no boilerplate
-- **Pure Rust**: No Python, JavaScript, or external runtime needed
-- **Built-in plot types**: 15+ plot types out of the box (violin, KDE, radar, etc.)
-- **Publication quality**: Professional themes and high-DPI export
-
-```rust
-// plotters: ~30 lines for a simple line plot
-// ruviz: 4 lines
-Plot::new()
-    .line(&x, &y)
-    .title("My Plot")
-    .save("plot.png")?;
-```
-
-## Contributing
-
-Contributions welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, testing, and pull request guidelines.
-
-### Development
+## Development
 
 ```bash
-# Clone repository
-git clone https://github.com/Ameyanagi/ruviz.git
-cd ruviz
-
-bun install
-
-# bun install auto-installs the repo's Lefthook hooks for local clones.
-# Re-run manually if install scripts are disabled or you need to migrate an older clone.
-make setup-hooks
-
-# Run code quality checks
-make check
-
-# Run tests
-cargo test --all-features
-
-# Run examples
+cargo test
+cargo test --doc
 cargo run --example basic_example --release
-
-# Run benchmarks
-cargo bench --all-features
 ```
 
-The repo uses Lefthook for local git hooks. `bun install` installs the hooks automatically for local clones, and `make setup-hooks` reinstalls them when install scripts are disabled or an older checkout still has the legacy `.githooks` setup. The `pre-commit` hook runs `cargo fmt --check`, `cargo clippy`, `oxfmt --check`, and `oxlint --deny-warnings`. To debug the hook manually, run `bunx lefthook run pre-commit`.
-
-## Roadmap
-
-- [x] Core plot types (line, scatter, bar, histogram, boxplot, heatmap)
-- [x] Parallel rendering
-- [x] SIMD optimization
-- [x] GPU acceleration (experimental)
-- [x] Professional themes
-- [x] Subplots and multi-panel figures
-- [x] Distribution plots: Violin, KDE, ECDF
-- [x] Composition plots: Pie, Donut
-- [x] Continuous plots: Contour
-- [x] Polar plots: Polar, Radar
-- [x] Error bars
-- [x] SVG export
-- [x] Experimental interactive window support
-- [ ] High-level APIs for area, hexbin, step, and stem plots
-- [ ] High-level APIs for regression and composite plots
-- [ ] Stabilize the interactive zoom/pan workflow
-- [ ] 3D plotting (v1.0+)
+The workspace also contains companion crates and bindings, but this README
+focuses on the root Rust crate. See the subdirectory READMEs for those package
+surfaces.
 
 ## License
 
@@ -555,16 +247,3 @@ Licensed under either of:
 - MIT license ([LICENSE](LICENSE) or http://opensource.org/licenses/MIT)
 
 at your option.
-
-## Acknowledgments
-
-- Inspired by [matplotlib](https://matplotlib.org/), [seaborn](https://seaborn.pydata.org/), and [Makie.jl](https://makie.juliaplots.org/)
-- Built with [tiny-skia](https://github.com/RazrFalcon/tiny-skia) for rendering
-- Text rendering by [cosmic-text](https://github.com/pop-os/cosmic-text)
-- Thanks to the Rust community for excellent crates and feedback
-
----
-
-**Status**: v0.4.13 - Early development, API may change. Production use at your own risk.
-
-**Support**: [Open an issue](https://github.com/Ameyanagi/ruviz/issues) or [start a discussion](https://github.com/Ameyanagi/ruviz/discussions)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -27,7 +27,7 @@ ruviz = "0.4.13"
 ```
 
 3. **Write your first plot** in `src/main.rs`:
-```rust
+```rust,check
 use ruviz::prelude::*;
 
 fn main() -> Result<()> {
@@ -263,17 +263,17 @@ Plot::new()
     // Linear
     .line(&x, &x.iter().map(|&v| v).collect::<Vec<_>>())
     .label("Linear")
-    .color(Color::from_rgb(0, 100, 200))
+    .color(Color::new(0, 100, 200))
 
     // Quadratic
     .line(&x, &x.iter().map(|&v| v * v).collect::<Vec<_>>())
     .label("Quadratic")
-    .color(Color::from_rgb(200, 0, 100))
+    .color(Color::new(200, 0, 100))
 
     // Cubic
     .line(&x, &x.iter().map(|&v| v.powi(3)).collect::<Vec<_>>())
     .label("Cubic")
-    .color(Color::from_rgb(0, 200, 100))
+    .color(Color::new(0, 200, 100))
 
     .title("Polynomial Functions")
     .xlabel("x")
@@ -327,7 +327,7 @@ use ruviz::prelude::*;
 Plot::new()
     .line(&x, &y)
     .dpi(300)
-    .dimensions(1200, 900)  // Width x Height
+    .size_px(1200, 900)  // Width x Height
     .save("high_res.png")?;
 
 // For web (96 DPI, default)
@@ -356,7 +356,7 @@ Plot::new()
 ```toml
 [dependencies]
 ruviz = { version = "0.4.13", features = ["polars_support"] }
-polars = "0.35"
+polars = "0.50"
 ```
 
 ```rust
@@ -378,18 +378,12 @@ Plot::new()
 
 ## Performance Tips
 
-### For Large Datasets (>10K points)
-Enable parallel rendering:
+### For Larger Native Builds
+The default feature set already includes `parallel`. Add `performance` only
+when you have benchmarked a path that benefits from the extra SIMD support:
 ```toml
 [dependencies]
-ruviz = { version = "0.4.13", features = ["parallel"] }
-```
-
-### For Very Large Datasets (>100K points)
-Enable SIMD optimization:
-```toml
-[dependencies]
-ruviz = { version = "0.4.13", features = ["parallel", "simd"] }
+ruviz = { version = "0.4.13", features = ["performance"] }
 ```
 
 ### Large Dataset Export
@@ -398,6 +392,9 @@ Plot::new()
     .line(&huge_x, &huge_y)
     .save("optimized.png")?;
 ```
+
+For dense plots, reducing or aggregating data before plotting is often more
+effective than relying on a backend feature flag.
 
 ## Error Handling
 
@@ -443,7 +440,7 @@ Make sure you've added ruviz to `Cargo.toml` and run `cargo build`.
 Increase DPI: `.dpi(300)` for print quality.
 
 ### "Rendering is slow"
-Enable parallel rendering: `features = ["parallel"]` in Cargo.toml.
+Use a release build first. Add `performance` only after benchmarking your plot.
 
 ### "Missing font errors"
 ruviz automatically falls back to system fonts. If issues persist, check that your system has basic fonts installed.

--- a/docs/guide/01_introduction.md
+++ b/docs/guide/01_introduction.md
@@ -1,18 +1,18 @@
 # Introduction to ruviz
 
-**ruviz** is a high-performance 2D plotting library for Rust that combines matplotlib's ease-of-use with Makie's performance.
+**ruviz** is a 2D plotting library for Rust with a fluent, matplotlib-inspired API.
 
 ## What is ruviz?
 
-ruviz provides a familiar, matplotlib-inspired API for creating publication-quality plots in Rust, with performance optimizations that can handle millions of data points efficiently.
+ruviz provides familiar builders for creating publication-quality plots in Rust,
+with PNG, SVG, and optional PDF export.
 
 ### Key Features
 
-- **🚀 High Performance**: <100ms for 100K points, <1s for 1M points
 - **🛡️ Memory Safe**: Zero unsafe code in public API
 - **📊 Rich Plot Types**: Line, scatter, bar, histogram, boxplot, and more
 - **🎨 Publication Quality**: Professional themes, high-DPI export, Unicode support
-- **⚡ Multiple Backends**: CPU (default), parallel, SIMD, GPU, DataShader
+- **⚡ Configurable Rendering**: reference raster output plus optional feature-gated renderer code
 - **🔧 Type Safe**: Strong typing prevents runtime errors
 - **📦 Easy Integration**: Works with ndarray, polars, standard Vec/slices
 
@@ -41,29 +41,18 @@ Plot::new()
     .save("plot.png")?;
 ```
 
-**Benefits of switching to ruviz**:
-- 10-100x faster rendering
+**Benefits of using ruviz**:
 - Compile-time error checking
 - No GC pauses or runtime overhead
-- Native performance for large datasets
 - Type-safe API prevents common mistakes
 
 ### Why not existing Rust libraries?
 
-| Feature | ruviz | plotters | plotly.rs |
-|---------|-------|----------|-----------|
-| Performance (100K pts) | <100ms | ~300ms | N/A (web-based) |
-| matplotlib-like API | ✅ | ❌ | ✅ |
-| Publication quality | ✅ | ⚠️ | ✅ |
-| Large data (>1M pts) | ✅ | ❌ | ❌ |
-| Compile time | <30s | <15s | ~45s |
-| Backend flexibility | ✅ (6 backends) | ⚠️ (2 backends) | ❌ (web only) |
-
 ruviz is designed specifically for:
-- **Scientific computing**: Handle large datasets efficiently
+- **Scientific computing**: Plot arrays and numeric data directly
 - **Data analysis**: Integration with ndarray, polars
 - **Publication**: IEEE/Nature-quality output
-- **Performance**: Real-time and batch processing
+- **Rust applications**: Native APIs without a Python or JavaScript runtime
 
 ## Design Philosophy
 
@@ -72,11 +61,10 @@ ruviz is designed specifically for:
 - **Builder pattern**: Fluent, chainable method calls
 - **Sensible defaults**: Get good results with minimal configuration
 
-### 2. Performance First
-- **Intelligent backend selection**: Automatically choose optimal renderer
-- **Zero-copy operations**: Minimal memory overhead
-- **Parallel processing**: Multi-core utilization for large data
-- **GPU acceleration**: Optional hardware acceleration
+### 2. Practical Output
+- **Reference raster path**: Conservative PNG/image output for visual parity
+- **Vector output**: SVG export and optional PDF export
+- **Feature flags**: Optional renderer/data integrations when your workload needs them
 
 ### 3. Safety & Quality
 - **No unsafe code**: Memory safe by design
@@ -122,16 +110,15 @@ Plot::new()
     .save("analysis.png")?;
 ```
 
-### Real-Time Visualization
+### Larger Datasets
 ```rust
 use ruviz::prelude::*;
 
-// 1M points rendered in <1s
-let x: Vec<f64> = (0..1_000_000).map(|i| i as f64).collect();
+let x: Vec<f64> = (0..250_000).map(|i| i as f64 * 0.001).collect();
 let y: Vec<f64> = x.iter().map(|&x| x.sin()).collect();
 
 Plot::new()
-    .line(&x, &y)  // Automatically uses parallel backend
+    .line(&x, &y)
     .save("large_dataset.png")?;
 ```
 
@@ -144,22 +131,22 @@ Plot::new()
 └─────────────────┬───────────────────────┘
                   │
 ┌─────────────────┴───────────────────────┐
-│        Backend Selection                │
-│  Auto-optimize, Manual override         │
+│       Plot Configuration               │
+│  Size, DPI, theme, stored backend label │
 └─────────────────┬───────────────────────┘
                   │
      ┌────────────┼────────────┬──────────┐
      │            │            │          │
 ┌────▼─────┐ ┌───▼────┐ ┌────▼─────┐ ┌──▼────┐
-│  Skia    │ │Parallel│ │   SIMD   │ │  GPU  │
-│ (default)│ │(rayon) │ │(portable)│ │(wgpu) │
+│ Raster   │ │  SVG   │ │   PDF    │ │Window │
+│  PNG     │ │Vector  │ │ feature  │ │feature│
 └──────────┘ └────────┘ └──────────┘ └───────┘
      │            │            │          │
      └────────────┴────────────┴──────────┘
                   │
          ┌────────▼────────┐
-         │   tiny-skia     │
-         │  Rasterization  │
+         │ Output helpers  │
+         │ save/render/... │
          └────────┬────────┘
                   │
             ┌─────▼──────┐
@@ -175,7 +162,7 @@ Plot::new()
 
 ## Philosophy Summary
 
-> **ruviz aims to make data visualization in Rust as easy as matplotlib, while being 10-100x faster and compile-time safe.**
+> **ruviz aims to make data visualization in Rust approachable while preserving Rust's type safety.**
 
 We believe that:
 1. Performance shouldn't require complexity

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -84,7 +84,7 @@ ruviz = "0.4.13"  # Includes: ndarray, parallel
 
 **Enabled by default**:
 - `ndarray` - ndarray support for scientific computing
-- `parallel` - Multi-core rendering with rayon
+- `parallel` - internal parallel renderer support and backend metadata
 
 ### Core Features
 
@@ -93,9 +93,9 @@ ruviz = "0.4.13"  # Includes: ndarray, parallel
 | `ndarray_support` | ndarray integration | Scientific computing, numpy-like arrays |
 | `nalgebra_support` | nalgebra integration | Dense vectors/matrices, linear algebra |
 | `polars_support` | polars integration | Data analysis, DataFrame support |
-| `parallel` | Multi-core rendering | >10K points, batch processing |
-| `simd` | SIMD optimization | >100K points, maximum speed |
-| `gpu` | GPU acceleration | >1M points, real-time visualization |
+| `parallel` | Internal parallel renderer support | Opt-in renderer experiments, metadata |
+| `simd` | SIMD support | Measured performance-sensitive paths |
+| `gpu` | GPU types and metadata | GPU-capable interactive work |
 | `interactive` | Interactive plots | Real-time exploration, data brushing |
 | `window` | Window support | Desktop applications |
 | `serde` | Serialization | Save/load plot configurations |
@@ -152,7 +152,7 @@ Create `src/main.rs`:
 ```rust
 use ruviz::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let x = vec![0.0, 1.0, 2.0, 3.0, 4.0];
     let y = vec![0.0, 1.0, 4.0, 9.0, 16.0];
 
@@ -188,7 +188,7 @@ Test specific features:
 use ruviz::prelude::*;
 use ndarray::Array1;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let x = Array1::linspace(0.0, 10.0, 100);
     let y = x.mapv(|v| v.sin());
 
@@ -201,11 +201,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-**Performance (parallel)**:
+**Performance smoke test**:
 ```rust
 use ruviz::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let x: Vec<f64> = (0..100_000).map(|i| i as f64 * 0.001).collect();
     let y: Vec<f64> = x.iter().map(|v| v.sin()).collect();
 
@@ -285,7 +285,7 @@ rustc --version  # Verify ≥ 1.92
 
 **Problem**: `error: failed to select Vulkan backend`
 
-**Solution**: GPU features require graphics drivers:
+**Solution**: GPU feature-gated code may require graphics drivers:
 ```bash
 # Linux - Install Vulkan drivers
 sudo apt-get install vulkan-tools  # Ubuntu/Debian
@@ -304,7 +304,9 @@ ruviz = { version = "0.4.13", default-features = false, features = ["parallel"] 
 
 **Problem**: Out of memory with large datasets
 
-**Solution**: Save directly; the PNG export path already switches to large-dataset rendering internally:
+**Solution**: Use release builds, keep output dimensions reasonable, and reduce
+or aggregate data before plotting when visual density is higher than display
+density:
 ```rust
 let x: Vec<f64> = (0..10_000_000).map(|i| i as f64).collect();
 let y: Vec<f64> = x.iter().map(|&v| v.sin()).collect();
@@ -335,7 +337,7 @@ codegen-units = 1    # Single codegen unit for max optimization
 
 **CPU cores** (automatic detection):
 ```rust
-// rayon uses the available cores when the parallel render path is selected
+// Benchmark the public render path for your plot.
 let x = vec![0.0, 1.0, 2.0];
 let y = vec![0.0, 1.0, 4.0];
 

--- a/docs/guide/03_first_plot.md
+++ b/docs/guide/03_first_plot.md
@@ -16,10 +16,10 @@ cargo add ruviz
 
 Edit `src/main.rs`:
 
-```rust
+```rust,check
 use ruviz::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Data
     let x = vec![0.0, 1.0, 2.0, 3.0, 4.0];
     let y = vec![0.0, 1.0, 4.0, 9.0, 16.0];
@@ -62,7 +62,7 @@ The `prelude` module includes all commonly used types and traits. This gives you
 ### Error Handling
 
 ```rust
-fn main() -> Result<(), Box<dyn std::error::Error>>
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>>
 ```
 
 ruviz operations return `Result` types. Use `?` operator for clean error propagation:
@@ -178,7 +178,7 @@ use ruviz::prelude::*;
 
 Plot::new()
     .line(&x, &y)
-    .color(Color::from_rgb(255, 0, 0))  // Red line
+    .color(Color::new(255, 0, 0))  // Red line
     .save("red_line.png")?;
 ```
 
@@ -203,7 +203,7 @@ Plot::new()
     .scatter(&x, &y)
     .marker(MarkerStyle::Circle)
     .marker_size(10.0)
-    .color(Color::from_rgb(0, 0, 255))
+    .color(Color::new(0, 0, 255))
     .save("blue_circles.png")?;
 ```
 
@@ -232,10 +232,10 @@ let y2 = vec![0.0, 2.0, 4.0, 6.0, 8.0];
 Plot::new()
     .line(&x, &y1)
         .label("Quadratic")
-        .color(Color::from_rgb(255, 0, 0))
+        .color(Color::new(255, 0, 0))
     .line(&x, &y2)
         .label("Linear")
-        .color(Color::from_rgb(0, 0, 255))
+        .color(Color::new(0, 0, 255))
     .legend(Position::TopLeft)
     .title("Multiple Series")
     .save("multi_series.png")?;
@@ -253,11 +253,11 @@ let y_scatter = vec![1.5, 2.3, 2.9, 4.2, 4.8];
 Plot::new()
     .line(&x, &y_line)
         .label("Theory")
-        .color(Color::from_rgb(0, 0, 255))
+        .color(Color::new(0, 0, 255))
     .scatter(&x, &y_scatter)
         .label("Measured")
         .marker(MarkerStyle::Circle)
-        .color(Color::from_rgb(255, 0, 0))
+        .color(Color::new(255, 0, 0))
     .legend(Position::TopLeft)
     .title("Theory vs Measurement")
     .save("mixed_plot.png")?;
@@ -305,7 +305,7 @@ Add to `Cargo.toml`:
 ```toml
 [dependencies]
 ruviz = { version = "0.4.13", features = ["ndarray_support"] }
-ndarray = "0.15"
+ndarray = "0.17"
 ```
 
 ```rust
@@ -327,7 +327,7 @@ Plot::new()
 
 ```rust
 Plot::new()
-    .dimensions(1200, 800)  // Width x Height pixels
+    .size_px(1200, 800)  // Width x Height pixels
     .line(&x, &y)
     .save("custom_size.png")?;
 ```
@@ -380,7 +380,7 @@ Plot::new()
 use ruviz::prelude::*;
 use std::f64::consts::PI;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Generate data
     let x: Vec<f64> = (0..200).map(|i| i as f64 * 0.05).collect();
     let y_sin: Vec<f64> = x.iter().map(|v| v.sin()).collect();
@@ -388,18 +388,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Create plot
     Plot::new()
-        .dimensions(1000, 600)
+        .size_px(1000, 600)
         .dpi(150)
         .theme(Theme::light())
         // Sine wave
         .line(&x, &y_sin)
             .label("sin(x)")
-            .color(Color::from_rgb(0, 0, 255))
+            .color(Color::new(0, 0, 255))
             .line_width(2.0)
         // Cosine wave
         .line(&x, &y_cos)
             .label("cos(x)")
-            .color(Color::from_rgb(255, 0, 0))
+            .color(Color::new(255, 0, 0))
             .line_style(LineStyle::Dashed)
             .line_width(2.0)
         // Configuration
@@ -491,9 +491,9 @@ Plot::new()
 
 ### Common Customizations
 ```rust
-.dimensions(width, height)     // Figure size
+.size_px(width, height)     // Figure size
 .dpi(resolution)               // Image resolution
-.color(Color::from_rgb(r,g,b)) // Series color
+.color(Color::new(r,g,b)) // Series color
 .line_width(width)             // Line thickness
 .marker(MarkerStyle::Circle)   // Marker shape
 .marker_size(size)             // Marker size

--- a/docs/guide/04_plot_types.md
+++ b/docs/guide/04_plot_types.md
@@ -615,18 +615,18 @@ let dendro = compute_dendrogram(&linkage_result, &config);
 Default rendering is optimal. No special configuration needed.
 
 ### Medium Datasets (1K - 100K points)
-The `parallel` feature can speed up the in-memory `render()` path. Reactive
-plots are resolved to a static snapshot first, so observable-backed series can
-use the same path as static data.
+Use release builds first. The default feature set already includes `parallel`,
+but the public static output path is conservative; benchmark your actual plot
+before adding more feature flags.
 
 ```toml
 [dependencies]
 ruviz = { version = "0.4.13", features = ["parallel"] }
 ```
 
-### Large Datasets (20K - 100K points)
-Use `parallel` and `simd` for heavier in-memory rendering workloads, and
-consider downsampling where visual density is already saturated.
+### Large Datasets (20K+ points)
+Consider downsampling or aggregating where visual density is already saturated.
+Use `performance` only after benchmarking a path that benefits from SIMD support.
 
 ```toml
 [dependencies]
@@ -634,9 +634,9 @@ ruviz = { version = "0.4.13", features = ["parallel", "simd"] }
 ```
 
 ### Very Large Datasets (> 100K points)
-DataShader-style aggregation can activate above `100_000` total points for
-aggregation-friendly series such as scatter and histogram. The exact
-`render()` vs `save()` behavior is documented in [Performance](08_performance.md).
+The crate contains DataShader-related code and backend metadata, but the current
+public `render()` and `save()` paths should not be documented as automatic
+DataShader output. See [Performance](08_performance.md).
 
 ---
 

--- a/docs/guide/05_styling.md
+++ b/docs/guide/05_styling.md
@@ -11,21 +11,21 @@ use ruviz::prelude::*;
 
 Plot::new()
     .line(&x, &y)
-    .color(Color::from_rgb(255, 0, 0))  // Red
+    .color(Color::new(255, 0, 0))  // Red
     .save("red_line.png")?;
 ```
 
 **Common Colors**:
 ```rust
-Color::from_rgb(255, 0, 0)      // Red
-Color::from_rgb(0, 255, 0)      // Green
-Color::from_rgb(0, 0, 255)      // Blue
-Color::from_rgb(255, 255, 0)    // Yellow
-Color::from_rgb(255, 0, 255)    // Magenta
-Color::from_rgb(0, 255, 255)    // Cyan
-Color::from_rgb(0, 0, 0)        // Black
-Color::from_rgb(255, 255, 255)  // White
-Color::from_rgb(128, 128, 128)  // Gray
+Color::new(255, 0, 0)      // Red
+Color::new(0, 255, 0)      // Green
+Color::new(0, 0, 255)      // Blue
+Color::new(255, 255, 0)    // Yellow
+Color::new(255, 0, 255)    // Magenta
+Color::new(0, 255, 255)    // Cyan
+Color::new(0, 0, 0)        // Black
+Color::new(255, 255, 255)  // White
+Color::new(128, 128, 128)  // Gray
 ```
 
 ### Hex Colors
@@ -44,19 +44,19 @@ Plot::new()
 **Muted Palette** (professional, readable):
 ```rust
 // Blue
-Color::from_rgb(76, 114, 176)   // #4C72B0
+Color::new(76, 114, 176)   // #4C72B0
 
 // Orange
-Color::from_rgb(221, 132, 82)   // #DD8452
+Color::new(221, 132, 82)   // #DD8452
 
 // Green
-Color::from_rgb(85, 168, 104)   // #55A868
+Color::new(85, 168, 104)   // #55A868
 
 // Red
-Color::from_rgb(196, 78, 82)    // #C44E52
+Color::new(196, 78, 82)    // #C44E52
 
 // Purple
-Color::from_rgb(129, 114, 179)  // #8172B3
+Color::new(129, 114, 179)  // #8172B3
 ```
 
 **Example with seaborn colors**:
@@ -66,13 +66,13 @@ use ruviz::prelude::*;
 Plot::new()
     .line(&x, &y1)
         .label("Series 1")
-        .color(Color::from_rgb(76, 114, 176))   // Muted blue
+        .color(Color::new(76, 114, 176))   // Muted blue
     .line(&x, &y2)
         .label("Series 2")
-        .color(Color::from_rgb(221, 132, 82))   // Muted orange
+        .color(Color::new(221, 132, 82))   // Muted orange
     .line(&x, &y3)
         .label("Series 3")
-        .color(Color::from_rgb(85, 168, 104))   // Muted green
+        .color(Color::new(85, 168, 104))   // Muted green
     .legend(Position::TopRight)
     .save("seaborn_colors.png")?;
 ```
@@ -83,11 +83,11 @@ Plot::new()
 use ruviz::prelude::*;
 
 // Semi-transparent colors
-Color::from_rgba(255, 0, 0, 128)  // 50% transparent red
+Color::new_rgba(255, 0, 0, 128)  // 50% transparent red
 
 Plot::new()
     .scatter(&x, &y)
-    .color(Color::from_rgba(0, 0, 255, 100))  // Transparent blue
+    .color(Color::new_rgba(0, 0, 255, 100))  // Transparent blue
     .marker_size(10.0)
     .save("transparent_scatter.png")?;
 ```
@@ -153,7 +153,7 @@ Plot::new()
     .line(&x, &y)
     .line_width(2.5)
     .line_style(LineStyle::Dashed)
-    .color(Color::from_rgb(255, 100, 0))
+    .color(Color::new(255, 100, 0))
     .label("Styled Line")
     .legend(Position::TopRight)
     .save("line_fully_styled.png")?;
@@ -230,7 +230,7 @@ Plot::new()
     .scatter(&x, &y)
     .marker(MarkerStyle::Circle)
     .marker_size(8.0)
-    .color(Color::from_rgb(255, 0, 128))  // Pink markers
+    .color(Color::new(255, 0, 128))  // Pink markers
     .save("colored_markers.png")?;
 ```
 
@@ -244,17 +244,17 @@ Plot::new()
         .label("Group A")
         .marker(MarkerStyle::Circle)
         .marker_size(8.0)
-        .color(Color::from_rgb(255, 0, 0))
+        .color(Color::new(255, 0, 0))
     .scatter(&x2, &y2)
         .label("Group B")
         .marker(MarkerStyle::Square)
         .marker_size(8.0)
-        .color(Color::from_rgb(0, 0, 255))
+        .color(Color::new(0, 0, 255))
     .scatter(&x3, &y3)
         .label("Group C")
         .marker(MarkerStyle::Triangle)
         .marker_size(10.0)
-        .color(Color::from_rgb(0, 128, 0))
+        .color(Color::new(0, 128, 0))
     .legend(Position::TopRight)
     .save("differentiated_series.png")?;
 ```
@@ -505,13 +505,13 @@ use ruviz::prelude::*;
 Plot::new()
     .line(&x, &y1)
         .label("Linear")
-        .color(Color::from_rgb(255, 0, 0))
+        .color(Color::new(255, 0, 0))
     .line(&x, &y2)
         .label("Quadratic")
-        .color(Color::from_rgb(0, 0, 255))
+        .color(Color::new(0, 0, 255))
     .line(&x, &y3)
         .label("Cubic")
-        .color(Color::from_rgb(0, 128, 0))
+        .color(Color::new(0, 128, 0))
     .legend(Position::TopLeft)
     .save("multi_series_legend.png")?;
 ```
@@ -597,7 +597,7 @@ Available tick controls:
 use ruviz::prelude::*;
 
 Plot::new()
-    .dimensions(1200, 800)  // Width x Height in pixels
+    .size_px(1200, 800)  // Width x Height in pixels
     .line(&x, &y)
     .title("Custom Dimensions")
     .save("custom_size.png")?;
@@ -617,7 +617,7 @@ use ruviz::prelude::*;
 
 // Single column (IEEE)
 Plot::new()
-    .dimensions(252, 189)  // 3.5" × 2.625" @ 72 DPI
+    .size_px(252, 189)  // 3.5" × 2.625" @ 72 DPI
     .dpi(300)              // High resolution
     .theme(Theme::publication())
     .line(&x, &y)
@@ -625,7 +625,7 @@ Plot::new()
 
 // Double column (IEEE)
 Plot::new()
-    .dimensions(523, 392)  // 7.25" × 5.44" @ 72 DPI
+    .size_px(523, 392)  // 7.25" × 5.44" @ 72 DPI
     .dpi(300)
     .theme(Theme::publication())
     .line(&x, &y)
@@ -684,7 +684,7 @@ Plot::new()
 use ruviz::prelude::*;
 use std::f64::consts::PI;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Generate data
     let x: Vec<f64> = (0..200).map(|i| i as f64 * 0.05).collect();
     let y_exp: Vec<f64> = x.iter().map(|v| (-v).exp()).collect();
@@ -698,20 +698,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create publication-quality plot
     Plot::new()
         // Figure setup
-        .dimensions(1000, 700)
+        .size_px(1000, 700)
         .dpi(300)
         .theme(publication_theme)
 
         // Data series
         .line(&x, &y_exp)
             .label("Exponential Decay")
-            .color(Color::from_rgb(76, 114, 176))   // Muted blue
+            .color(Color::new(76, 114, 176))   // Muted blue
             .line_width(2.0)
             .line_style(LineStyle::Solid)
 
         .line(&x, &y_sin)
             .label("Damped Oscillation")
-            .color(Color::from_rgb(221, 132, 82))   // Muted orange
+            .color(Color::new(221, 132, 82))   // Muted orange
             .line_width(2.0)
             .line_style(LineStyle::Dashed)
 
@@ -745,12 +745,12 @@ let presentation_theme = Theme::builder()
     .build();
 
 Plot::new()
-    .dimensions(1920, 1080)  // Full HD
+    .size_px(1920, 1080)  // Full HD
     .dpi(150)
     .theme(presentation_theme)
 
     .line(&x, &y)
-    .color(Color::from_rgb(100, 200, 255))  // Bright cyan
+    .color(Color::new(100, 200, 255))  // Bright cyan
     .line_width(4.0)  // Thick for visibility
 
     .title("Presentation Plot")

--- a/docs/guide/06_subplots.md
+++ b/docs/guide/06_subplots.md
@@ -17,7 +17,7 @@ Subplots allow you to combine multiple plots into a single figure, essential for
 ```rust
 use ruviz::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Prepare data
     let x = vec![0.0, 1.0, 2.0, 3.0, 4.0];
     let y1 = vec![0.0, 1.0, 4.0, 9.0, 16.0];
@@ -169,7 +169,7 @@ subplots(2, 2, 1000, 1000)?
 ```rust
 use ruviz::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Generate scientific datasets
     let time: Vec<f64> = (0..1000).map(|i| i as f64 * 0.01).collect();
     let signal: Vec<f64> = time.iter()
@@ -453,10 +453,10 @@ subplots(2, 2, 1000, 800)?
 use ruviz::prelude::*;
 
 let colors = [
-    Color::from_rgb(76, 114, 176),   // Muted blue
-    Color::from_rgb(221, 132, 82),   // Muted orange
-    Color::from_rgb(85, 168, 104),   // Muted green
-    Color::from_rgb(196, 78, 82),    // Muted red
+    Color::new(76, 114, 176),   // Muted blue
+    Color::new(221, 132, 82),   // Muted orange
+    Color::new(85, 168, 104),   // Muted green
+    Color::new(196, 78, 82),    // Muted red
 ];
 
 let plots: Vec<_> = (0..4).map(|i| {

--- a/docs/guide/07_backends.md
+++ b/docs/guide/07_backends.md
@@ -8,10 +8,10 @@ current codebase.
 | Goal | What to use today |
 |------|-------------------|
 | Small or medium PNG export | `Plot::save()` with default settings |
-| In-memory render with CPU parallelism | `Plot::render()` plus `features = ["parallel"]` |
-| SIMD acceleration | `features = ["parallel", "simd"]` and use `render()` |
-| Very large scatter/histogram datasets | Let DataShader activate automatically above `100_000` points |
-| GPU-accelerated PNG export | Enable `gpu` and call `.gpu(true)` |
+| In-memory render | `Plot::render()` with the public reference raster path |
+| PNG export | `Plot::save()` with the public reference raster path |
+| Backend metadata | `.backend(...)`, `.auto_optimize()`, `.get_backend_name()` |
+| Experimental optimized paths | Internal/test-only paths and lower-level renderer code |
 | Interactive window | Enable `interactive` or `interactive-gpu` and use `show_interactive()` |
 | Embedded GPUI interactive plot | Use the `ruviz-gpui` crate and `plot_builder(...).interactive()` |
 | Lower allocation pressure | `.with_memory_pooling(true)` |
@@ -30,8 +30,8 @@ There are two separate concepts in the current implementation:
    - `save()`
 
 The stored backend selection is metadata today. It is visible through
-`get_backend_name()`, but the current `render()` and `save()` implementations do
-not directly dispatch on `self.render.backend`.
+`get_backend_name()`, but the current public `render()`, `render_png_bytes()`,
+and `save()` implementations do not directly dispatch on `self.render.backend`.
 
 ## GPUI Embedded Interactive Backend
 
@@ -89,34 +89,17 @@ assert_eq!(plot.get_backend_name(), "datashader");
 
 ## What `render()` actually does
 
-`render()` returns an in-memory `Image` and currently chooses its path like this:
-
-- Above `100_000` points for aggregation-safe series such as scatter and histogram: DataShader
-- Otherwise, if the `parallel` feature is enabled:
-  - parallel rendering is used when `ParallelRenderer::should_use_parallel(...)` returns `true`
-- Otherwise: CPU/tiny-skia rendering
+`render()` returns an in-memory `Image` using the public reference raster path.
+That path is CPU/tiny-skia based and is kept conservative for output parity.
 
 Reactive plots first resolve a static snapshot, then run through the same
-backend-selection logic:
+public render path:
 
 - temporal `Signal` inputs in plain `render()` are sampled at `0.0`
 - push-based `Observable` inputs and streaming buffers read their latest values
-- `render_at(t)` uses the same backend-selection logic after sampling temporal
-  inputs at `t`
+- `render_at(t)` samples temporal inputs at `t`
 
-That means signal-backed, observable-backed, and streaming-backed plots can
-still reach the parallel path after resolution, while only aggregation-safe
-series reach the automatic DataShader path.
-
-The default parallel renderer activates when either:
-
-- the series count is at least `2`, or
-- total points exceed `20_000` (default chunk size `10_000 * 2`)
-
-`parallel_threshold(...)` only adjusts the **series-count** threshold. It does
-not change the chunk-size path.
-
-### Parallel render example
+### In-memory render example
 
 ```toml
 [dependencies]
@@ -137,10 +120,14 @@ let image = Plot::new()
 println!("Rendered {}x{}", image.width(), image.height());
 ```
 
+`parallel_threshold(...)` and the `parallel` feature configure the stored
+parallel renderer, but they do not force the public reference render path to use
+parallel execution.
+
 ### SIMD note
 
-The `simd` feature is used inside the parallel renderer. In practice that means
-it helps the `render()` path when parallel rendering is active.
+The `simd` feature is available to performance-oriented renderer code, but it is
+not a guarantee that a public `render()` call will take a SIMD path.
 
 ```toml
 [dependencies]
@@ -149,29 +136,23 @@ ruviz = { version = "0.4.13", features = ["parallel", "simd"] }
 
 ## What `save()` actually does
 
-`save()` renders and writes a PNG file. Its current path is different from
-`render()`:
+`save()` renders PNG bytes through the same public reference raster path and
+writes them to the requested file.
 
-- Above `100_000` points for aggregation-safe series such as scatter and histogram:
-  - DataShader branch
-- Otherwise, if `gpu(true)` is enabled and the plot has at least `5_000` points:
-  - GPU rendering path
-- Otherwise: CPU/tiny-skia rendering
-
-Reactive snapshotting works the same as `render()`: temporal `Signal` sources
-are sampled at `0.0`, while push-based `Observable` and streaming sources use
-their latest values before backend selection.
+Reactive snapshotting works the same as `render()`: temporal `Signal` sources are
+sampled at `0.0`, while push-based `Observable` and streaming sources use their
+latest values before output.
 
 Two important details:
 
 - `save()` does **not** currently call the dedicated `render_with_parallel()` path
-- The automatic DataShader branch in `save()` is intentionally conservative to
-  preserve plot semantics for connected line-style charts
+- `save()` does **not** currently dispatch on `.gpu(true)` or stored backend metadata
 
 ## DataShader
 
-DataShader activates automatically above `100_000` total points for
-aggregation-safe series such as scatter and histogram.
+DataShader support exists in the crate, and `.auto_optimize()` may store
+`BackendType::DataShader` metadata for large datasets. The current public
+`render()` and `save()` paths do not automatically switch to DataShader output.
 
 ```rust
 use ruviz::prelude::*;
@@ -180,7 +161,6 @@ let points = 250_000;
 let x: Vec<f64> = (0..points).map(|i| i as f64 * 0.001).collect();
 let y: Vec<f64> = x.iter().map(|v| v.sin()).collect();
 
-// Large scatter plots switch to DataShader automatically above 100_000 points.
 Plot::new()
     .scatter(&x, &y)
     .save("datashader_plot.png")?;
@@ -188,16 +168,16 @@ Plot::new()
 
 ## GPU
 
-GPU support is opt-in and requires the `gpu` feature (or `interactive-gpu`,
-which includes it).
+GPU types and metadata are opt-in and require the `gpu` feature (or
+`interactive-gpu`, which includes it).
 
 Calling `.gpu(true)` does two things:
 
 - it stores `BackendType::GPU` on the plot
-- it enables the GPU path in `save()` for plots with at least `5_000` points
+- it records the GPU preference for APIs that inspect plot configuration
 
-If GPU initialization fails during `save()`, the code logs a warning and falls
-back to CPU rendering.
+The current public `save()` and `render()` paths do not dispatch to a GPU raster
+path.
 
 ```toml
 [dependencies]
@@ -216,7 +196,8 @@ Plot::new()
     .save("gpu_plot.png")?;
 ```
 
-`render()` does not currently use this GPU path.
+Use `interactive-gpu` for GPU-capable interactive sessions. Static file export
+should be treated as CPU/reference output today.
 
 ## Interactive windows
 
@@ -244,7 +225,7 @@ tokio = { version = "1", features = ["rt", "macros"] }
 use ruviz::prelude::*;
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let x: Vec<f64> = (0..200).map(|i| i as f64 * 0.05).collect();
     let y: Vec<f64> = x.iter().map(|v| v.sin()).collect();
 
@@ -351,8 +332,8 @@ Plot::new()
 ## Recommendations
 
 - Start with plain `save()` or `render()` before setting backend metadata.
-- If you need faster in-memory rendering, add `parallel` and use `render()`.
-- Add `simd` only alongside `parallel`.
-- Use `.gpu(true)` when you want GPU-assisted PNG export or `interactive-gpu`.
+- Add `parallel`/`simd` only after benchmarking a path that uses them.
+- Use `.gpu(true)` for GPU metadata or GPU-capable interactive work, not as a
+  static PNG export guarantee.
 - Treat `.backend(...)` and `.auto_optimize()` as stored selection helpers, not
   hard execution guarantees.

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -4,8 +4,7 @@ Practical performance guidance for the current `ruviz` implementation.
 
 ## Start Here
 
-Measure before adding features. The biggest performance win is still running in
-release mode:
+Use release builds before adding feature flags:
 
 ```bash
 cargo run --release
@@ -20,14 +19,27 @@ codegen-units = 1
 opt-level = 3
 ```
 
-## Important Distinction
+Benchmark with your actual plot content. Marker-heavy scatter plots, text, high
+DPI output, and very large canvases stress different parts of the renderer.
 
-Two APIs matter for performance:
+## Public Output Paths
 
-- `render()` returns an in-memory `Image`
-- `save()` renders and writes a PNG file
+The public static-output APIs are conservative today:
 
-They do **not** currently use identical execution paths.
+- `render()` returns an in-memory `Image`.
+- `render_png_bytes()` returns PNG bytes.
+- `save()` writes PNG bytes to disk.
+- `export_svg()` and `render_to_svg()` use the SVG renderer.
+- `save_pdf()` is available with the `pdf` feature and converts SVG to PDF.
+
+For PNG/image output, the current public path uses the reference raster pipeline
+for output parity. `.backend(...)`, `.auto_optimize()`, `.parallel_threshold(...)`,
+and `.gpu(true)` store configuration or metadata; they should not be documented
+as hard execution guarantees for `render()` or `save()`.
+
+Reactive plots are resolved to a static snapshot first. Plain `render()` and
+`save()` sample temporal `Signal` sources at `0.0`; `render_at(t)` samples them
+at `t`.
 
 ## Feature Flags
 
@@ -38,95 +50,17 @@ ruviz = "0.4.13"
 
 Useful opt-in features:
 
-- `parallel`: enables the dedicated parallel `render()` path
-- `simd`: accelerates the parallel renderer
-- `gpu`: enables `.gpu(true)` and GPU-assisted PNG export
-- `performance`: shorthand for `["parallel", "simd"]`
+- `parallel`: enables the internal parallel renderer and backend metadata.
+- `simd`: enables SIMD support used by performance-oriented code paths.
+- `performance`: shorthand for `["parallel", "simd"]`.
+- `gpu`: enables GPU types and `.gpu(true)` metadata.
 
-## What `render()` does today
+These features can increase compile time and dependency surface. Add them when a
+measured code path benefits from them.
 
-`render()` chooses its execution path from actual plot content:
+## Large Datasets
 
-- Above `100_000` total points for aggregation-safe series such as scatter and histogram:
-  - DataShader
-- Otherwise, with `parallel` enabled:
-  - parallel rendering is used when the internal threshold logic says it is worthwhile
-- Otherwise: CPU/tiny-skia rendering
-
-Reactive plots now resolve to a static snapshot first, so push-based and
-streaming sources can still benefit from the same parallel/DataShader decisions.
-
-### Parallel rendering
-
-```toml
-[dependencies]
-ruviz = { version = "0.4.13", features = ["parallel"] }
-```
-
-```rust
-use ruviz::prelude::*;
-
-let x: Vec<f64> = (0..50_000).map(|i| i as f64 * 0.001).collect();
-let y: Vec<f64> = x.iter().map(|v| v.sin()).collect();
-
-let image = Plot::new()
-    .parallel_threshold(4)
-    .line(&x, &y)
-    .render()?;
-
-println!("Rendered {}x{}", image.width(), image.height());
-```
-
-`parallel_threshold(...)` only changes the series-count threshold. It does not
-override every internal condition used by the parallel renderer.
-
-### SIMD
-
-```toml
-[dependencies]
-ruviz = { version = "0.4.13", features = ["parallel", "simd"] }
-```
-
-The `simd` feature is used inside the parallel renderer, so it helps when the
-parallel `render()` path is active.
-
-## What `save()` does today
-
-`save()` writes PNG output and uses a different path:
-
-- Above `100_000` total points: DataShader branch
-- Otherwise, if `.gpu(true)` is enabled and the plot has at least `5_000` points:
-  - GPU path
-- Otherwise: CPU/tiny-skia rendering
-
-The current `save()` implementation does **not** call the dedicated
-`render_with_parallel()` path.
-
-### GPU-assisted PNG export
-
-```toml
-[dependencies]
-ruviz = { version = "0.4.13", features = ["gpu"] }
-```
-
-```rust
-use ruviz::prelude::*;
-
-let x: Vec<f64> = (0..20_000).map(|i| i as f64 * 0.001).collect();
-let y: Vec<f64> = x.iter().map(|v| v.cos()).collect();
-
-Plot::new()
-    .gpu(true)
-    .line(&x, &y)
-    .save("gpu_plot.png")?;
-```
-
-If GPU initialization fails, `save()` falls back to CPU rendering.
-
-## DataShader
-
-DataShader-style aggregation activates automatically above `100_000` total
-points for aggregation-safe series such as scatter and histogram.
+Large plots are still valid through the normal API:
 
 ```rust
 use ruviz::prelude::*;
@@ -137,8 +71,11 @@ let y: Vec<f64> = x.iter().map(|v| v.sin()).collect();
 
 Plot::new()
     .scatter(&x, &y)
-    .save("datashader_plot.png")?;
+    .save("large_scatter.png")?;
 ```
+
+For dense plots where many data points map to the same pixels, downsampling or
+aggregating before plotting is often more useful than enabling a backend flag.
 
 ## Memory Pooling
 
@@ -155,15 +92,6 @@ Plot::new()
 
 Use it when repeated large renders are spending noticeable time in allocation.
 
-## Practical Recommendations
-
-- Start with `save()` or `render()` before setting backend metadata.
-- Use `render()` when you want the in-memory image path and parallel CPU speedups.
-- Use `save()` when you want PNG output and optional `.gpu(true)` acceleration.
-- Add `simd` only alongside `parallel`.
-- Downsample scatter-style plots when visual density is higher than display density.
-- Benchmark your real workload instead of relying on generic backend labels.
-
 ## Benchmark Template
 
 ```rust
@@ -174,6 +102,7 @@ let start = Instant::now();
 let image = Plot::new()
     .line(&x, &y)
     .render()?;
+
 println!(
     "Rendered {}x{} in {:?}",
     image.width(),
@@ -181,6 +110,14 @@ println!(
     start.elapsed()
 );
 ```
+
+## Recommendations
+
+- Start with plain `save()` or `render()`.
+- Use release builds for any timing comparison.
+- Prefer smaller canvases and explicit data reduction when visual density is too high.
+- Use `.size(width_in, height_in)` plus `.dpi(...)` for print output.
+- Treat backend names as metadata unless a specific API documents otherwise.
 
 ## Related Guides
 

--- a/docs/guide/09_data_integration.md
+++ b/docs/guide/09_data_integration.md
@@ -65,7 +65,7 @@ Plot::new()
 ```toml
 [dependencies]
 ruviz = { version = "0.4.13", features = ["ndarray_support"] }
-ndarray = "0.15"
+ndarray = "0.17"
 ```
 
 ### Basic Usage
@@ -92,7 +92,7 @@ use ruviz::prelude::*;
 use ndarray::{Array1, Array2};
 use std::f64::consts::PI;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Generate mesh grid
     let n = 100;
     let x = Array1::linspace(0.0, 2.0 * PI, n);
@@ -105,14 +105,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Plot::new()
         .line(&x, &y_sin)
             .label("sin(x)")
-            .color(Color::from_rgb(255, 0, 0))
+            .color(Color::new(255, 0, 0))
         .line(&x, &y_cos)
             .label("cos(x)")
-            .color(Color::from_rgb(0, 0, 255))
+            .color(Color::new(0, 0, 255))
             .line_style(LineStyle::Dashed)
         .line(&x, &y_tan)
             .label("tan(x/2)")
-            .color(Color::from_rgb(0, 128, 0))
+            .color(Color::new(0, 128, 0))
             .line_style(LineStyle::Dotted)
         .title("Trigonometric Functions")
         .xlabel("x (radians)")
@@ -230,7 +230,7 @@ synthetic absorbed-energy style example.
 ```toml
 [dependencies]
 ruviz = { version = "0.4.13", features = ["polars_support"] }
-polars = "0.35"
+polars = "0.50"
 ```
 
 ### Basic DataFrame Plotting
@@ -239,7 +239,7 @@ polars = "0.35"
 use ruviz::prelude::*;
 use polars::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Create DataFrame
     let df = df! {
         "x" => &[1.0, 2.0, 3.0, 4.0, 5.0],
@@ -293,7 +293,7 @@ Plot::new()
 use ruviz::prelude::*;
 use polars::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Load data
     let df = df! {
         "category" => &["A", "B", "C", "A", "B", "C", "A", "B", "C"],
@@ -339,7 +339,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 use ruviz::prelude::*;
 use polars::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Create time series data
     let dates: Vec<i64> = (0..100).collect();
     let values: Vec<f64> = (0..100).map(|i| {
@@ -372,10 +372,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Plot::new()
         .line(&x_values, &original)
             .label("Original")
-            .color(Color::from_rgba(0, 0, 255, 100))
+            .color(Color::new_rgba(0, 0, 255, 100))
         .line(&x_values, &smoothed)
             .label("Rolling Average")
-            .color(Color::from_rgb(255, 0, 0))
+            .color(Color::new(255, 0, 0))
             .line_width(2.0)
         .title("Time Series with Rolling Average")
         .xlabel("Time")
@@ -396,7 +396,7 @@ use ruviz::prelude::*;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Read CSV file
     let file = File::open("data.csv")?;
     let reader = BufReader::new(file);
@@ -431,7 +431,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 use ruviz::prelude::*;
 use polars::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Read CSV with polars
     let df = CsvReader::from_path("data.csv")?
         .finish()?;
@@ -457,7 +457,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 use ruviz::prelude::*;
 use polars::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Read and filter CSV
     let df = CsvReader::from_path("measurements.csv")?
         .finish()?;
@@ -504,7 +504,7 @@ struct DataPoint {
     y: f64,
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Read JSON file
     let json_data = std::fs::read_to_string("data.json")?;
     let data: Vec<DataPoint> = serde_json::from_str(&json_data)?;
@@ -531,7 +531,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 use ruviz::prelude::*;
 use polars::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // 1. Load data
     println!("Loading data from CSV...");
     let df = CsvReader::from_path("experiment_results.csv")?
@@ -574,7 +574,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Creating plot...");
     Plot::new()
         .bar(&conditions, &means)
-        .color(Color::from_rgb(70, 130, 180))
+        .color(Color::new(70, 130, 180))
         .title("Experimental Results by Condition")
         .xlabel("Condition")
         .ylabel("Mean Measurement")
@@ -593,7 +593,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 use ruviz::prelude::*;
 use polars::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Load experiment data
     let df = CsvReader::from_path("experiment.csv")?.finish()?;
 

--- a/docs/guide/10_export.md
+++ b/docs/guide/10_export.md
@@ -141,25 +141,25 @@ use ruviz::prelude::*;
 
 // Widescreen (16:9)
 Plot::new()
-    .dimensions(1920, 1080)
+    .size_px(1920, 1080)
     .line(&x, &y)
     .save("widescreen.png")?;
 
 // Square
 Plot::new()
-    .dimensions(1000, 1000)
+    .size_px(1000, 1000)
     .line(&x, &y)
     .save("square.png")?;
 
 // Portrait
 Plot::new()
-    .dimensions(600, 800)
+    .size_px(600, 800)
     .line(&x, &y)
     .save("portrait.png")?;
 
 // Ultra-wide
 Plot::new()
-    .dimensions(2560, 1080)
+    .size_px(2560, 1080)
     .line(&x, &y)
     .save("ultrawide.png")?;
 ```
@@ -171,25 +171,25 @@ use ruviz::prelude::*;
 
 // Presentation (4:3)
 Plot::new()
-    .dimensions(1024, 768)
+    .size_px(1024, 768)
     .line(&x, &y)
     .save("presentation_43.png")?;
 
 // Presentation (16:9)
 Plot::new()
-    .dimensions(1920, 1080)
+    .size_px(1920, 1080)
     .line(&x, &y)
     .save("presentation_169.png")?;
 
 // Social media (Instagram post)
 Plot::new()
-    .dimensions(1080, 1080)
+    .size_px(1080, 1080)
     .line(&x, &y)
     .save("instagram.png")?;
 
 // Social media (Twitter card)
 Plot::new()
-    .dimensions(1200, 675)
+    .size_px(1200, 675)
     .line(&x, &y)
     .save("twitter.png")?;
 ```
@@ -208,7 +208,7 @@ use ruviz::prelude::*;
 // IEEE single-column: 3.5 inches wide
 // At 300 DPI: 3.5" × 300 = 1050 pixels
 Plot::new()
-    .dimensions(1050, 787)  // 3.5" × 2.625" @ 300 DPI
+    .size_px(1050, 787)  // 3.5" × 2.625" @ 300 DPI
     .dpi(300)
     .theme(Theme::publication())
     .line(&x, &y)
@@ -226,7 +226,7 @@ use ruviz::prelude::*;
 // IEEE double-column: 7.25 inches wide
 // At 300 DPI: 7.25" × 300 = 2175 pixels
 Plot::new()
-    .dimensions(2175, 1631)  // 7.25" × 5.44" @ 300 DPI
+    .size_px(2175, 1631)  // 7.25" × 5.44" @ 300 DPI
     .dpi(300)
     .theme(Theme::publication())
     .line(&x, &y)
@@ -244,7 +244,7 @@ use ruviz::prelude::*;
 // Nature single-column: 89mm = 3.5 inches
 // At 300 DPI: 1050 pixels
 Plot::new()
-    .dimensions(1050, 1050)  // Square or custom height
+    .size_px(1050, 1050)  // Square or custom height
     .dpi(300)
     .theme(Theme::publication())
     .line(&x, &y)
@@ -253,7 +253,7 @@ Plot::new()
 
 // Nature two-column: 183mm = 7.2 inches
 Plot::new()
-    .dimensions(2160, 1440)
+    .size_px(2160, 1440)
     .dpi(300)
     .theme(Theme::publication())
     .line(&x, &y)
@@ -267,7 +267,7 @@ use ruviz::prelude::*;
 
 // Science single-column: 2.37 inches @ 300 DPI = 711 pixels
 Plot::new()
-    .dimensions(711, 533)
+    .size_px(711, 533)
     .dpi(300)
     .theme(Theme::publication())
     .line(&x, &y)
@@ -275,7 +275,7 @@ Plot::new()
 
 // Science double-column: 4.92 inches @ 300 DPI = 1476 pixels
 Plot::new()
-    .dimensions(1476, 1107)
+    .size_px(1476, 1107)
     .dpi(300)
     .theme(Theme::publication())
     .line(&x, &y)
@@ -306,7 +306,7 @@ fn main() {
 use ruviz::prelude::*;
 use std::f64::consts::PI;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Generate publication-quality data
     let x: Vec<f64> = (0..200).map(|i| i as f64 * 0.05).collect();
     let y_exp: Vec<f64> = x.iter().map(|v| (-v).exp()).collect();
@@ -321,18 +321,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // IEEE double-column figure @ 300 DPI
     Plot::new()
-        .dimensions(2175, 1500)
+        .size_px(2175, 1500)
         .dpi(300)
         .theme(publication_theme)
 
         .line(&x, &y_exp)
             .label("Exponential Decay")
-            .color(Color::from_rgb(76, 114, 176))
+            .color(Color::new(76, 114, 176))
             .line_width(2.0)
 
         .line(&x, &y_decay)
             .label("Damped Oscillation")
-            .color(Color::from_rgb(221, 132, 82))
+            .color(Color::new(221, 132, 82))
             .line_width(2.0)
             .line_style(LineStyle::Dashed)
 
@@ -365,21 +365,21 @@ use ruviz::prelude::*;
 // 1. Quick draft (low DPI, fast iteration)
 Plot::new()
     .line(&x, &y)
-    .dimensions(800, 600)
+    .size_px(800, 600)
     .dpi(72)  // Fast rendering
     .save("draft.png")?;
 
 // 2. Review version (screen quality)
 Plot::new()
     .line(&x, &y)
-    .dimensions(1200, 800)
+    .size_px(1200, 800)
     .dpi(96)
     .save("review.png")?;
 
 // 3. Final version (publication quality)
 Plot::new()
     .line(&x, &y)
-    .dimensions(2175, 1500)
+    .size_px(2175, 1500)
     .dpi(300)
     .theme(Theme::publication())
     .save("final.png")?;
@@ -402,14 +402,14 @@ fn export_plot(data: &[f64], filename: &str, quality: &str) -> Result<(), Box<dy
 
     Plot::new()
         .line(&x, data)
-        .dimensions(dimensions.0, dimensions.1)
+        .size_px(dimensions.0, dimensions.1)
         .dpi(dpi)
         .save(filename)?;
 
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let data = vec![/* ... */];
 
     // Export at multiple quality levels
@@ -430,21 +430,21 @@ use ruviz::prelude::*;
 
 // Large file (high DPI + large dimensions)
 Plot::new()
-    .dimensions(3000, 2000)
+    .size_px(3000, 2000)
     .dpi(600)
     .line(&x, &y)
     .save("large.png")?;  // ~2-5 MB
 
 // Optimized (balanced quality/size)
 Plot::new()
-    .dimensions(1600, 1200)
+    .size_px(1600, 1200)
     .dpi(300)
     .line(&x, &y)
     .save("optimized.png")?;  // ~500 KB
 
 // Minimal (web-ready)
 Plot::new()
-    .dimensions(800, 600)
+    .size_px(800, 600)
     .dpi(96)
     .line(&x, &y)
     .save("web.png")?;  // ~100 KB
@@ -487,7 +487,7 @@ fn safe_export(plot: Plot, path: &str) -> Result<(), Box<dyn std::error::Error>>
     }
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let plot = Plot::new()
         .line(&x, &y)
         .title("Safe Export");

--- a/docs/guide/11_advanced.md
+++ b/docs/guide/11_advanced.md
@@ -22,14 +22,14 @@ use ruviz::prelude::*;
 struct CustomPalette;
 
 impl CustomPalette {
-    fn oceanblue() -> Color { Color::from_rgb(0, 119, 182) }
-    fn deepcyan() -> Color { Color::from_rgb(0, 180, 216) }
-    fn skyblue() -> Color { Color::from_rgb(144, 224, 239) }
-    fn coral() -> Color { Color::from_rgb(240, 128, 128) }
-    fn sunset() -> Color { Color::from_rgb(255, 99, 71) }
+    fn oceanblue() -> Color { Color::new(0, 119, 182) }
+    fn deepcyan() -> Color { Color::new(0, 180, 216) }
+    fn skyblue() -> Color { Color::new(144, 224, 239) }
+    fn coral() -> Color { Color::new(240, 128, 128) }
+    fn sunset() -> Color { Color::new(255, 99, 71) }
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let x = vec![0.0, 1.0, 2.0, 3.0, 4.0];
     let datasets = vec![
         vec![1.0, 2.0, 3.0, 4.0, 5.0],
@@ -71,12 +71,12 @@ fn interpolate_color(color1: Color, color2: Color, t: f64) -> Color {
     let g = (g1 as f64 * (1.0 - t) + g2 as f64 * t) as u8;
     let b = (b1 as f64 * (1.0 - t) + b2 as f64 * t) as u8;
 
-    Color::from_rgb(r, g, b)
+    Color::new(r, g, b)
 }
 
 fn create_gradient_palette(n: usize) -> Vec<Color> {
-    let start = Color::from_rgb(0, 0, 255);    // Blue
-    let end = Color::from_rgb(255, 0, 0);      // Red
+    let start = Color::new(0, 0, 255);    // Blue
+    let end = Color::new(255, 0, 0);      // Red
 
     (0..n).map(|i| {
         let t = i as f64 / (n - 1) as f64;
@@ -84,7 +84,7 @@ fn create_gradient_palette(n: usize) -> Vec<Color> {
     }).collect()
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let colors = create_gradient_palette(5);
     // Use colors for multi-series plot
     Ok(())
@@ -98,7 +98,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```rust
 use ruviz::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Create overview panel and detail panels
     let overview = Plot::new()
         .line(&time, &overall_signal)
@@ -169,7 +169,7 @@ subplots(1, 2, 2400, 1000)?  // Extra wide for different panel shapes
 use ruviz::prelude::*;
 use std::f64::consts::PI;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Parametric spiral
     let t: Vec<f64> = (0..1000).map(|i| i as f64 * 0.01).collect();
     let x: Vec<f64> = t.iter().map(|&t| t * (t * 2.0).cos()).collect();
@@ -192,7 +192,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```rust
 use ruviz::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Simple harmonic oscillator phase portrait
     let n = 1000;
     let dt = 0.01;
@@ -224,7 +224,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```rust
 use ruviz::prelude::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Approximate vector field with small line segments
     let grid_size = 20;
     let step = 0.5;
@@ -282,7 +282,7 @@ fn create_plot_from_config(
     };
 
     Plot::new()
-        .dimensions(config.width, config.height)
+        .size_px(config.width, config.height)
         .dpi(config.dpi)
         .theme(theme)
         .line(x, y)
@@ -294,7 +294,7 @@ fn create_plot_from_config(
     Ok(())
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     // Load configuration from JSON
     let config_json = std::fs::read_to_string("plot_config.json")?;
     let config: PlotConfig = serde_json::from_str(&config_json)?;
@@ -322,11 +322,11 @@ impl PlotTemplate {
         title: &str
     ) -> Result<(), Box<dyn std::error::Error>> {
         Plot::new()
-            .dimensions(2175, 1500)
+            .size_px(2175, 1500)
             .dpi(300)
             .theme(Theme::publication())
             .line(time, signal)
-            .color(Color::from_rgb(76, 114, 176))
+            .color(Color::new(76, 114, 176))
             .line_width(2.0)
             .title(title)
             .xlabel("Time (s)")
@@ -341,11 +341,11 @@ impl PlotTemplate {
         label: &str
     ) -> Result<(), Box<dyn std::error::Error>> {
         Plot::new()
-            .dimensions(600, 400)
+            .size_px(600, 400)
             .dpi(96)
             .theme(Theme::light())
             .histogram(data, None)
-            .color(Color::from_rgb(70, 130, 180))
+            .color(Color::new(70, 130, 180))
             .title(label)
             .xlabel("Value")
             .ylabel("Count")
@@ -448,7 +448,7 @@ fn plot_with_fallback(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Try high-quality first
     match Plot::new()
-        .dimensions(2175, 1500)
+        .size_px(2175, 1500)
         .dpi(300)
         .line(x, y)
         .save(output)
@@ -462,7 +462,7 @@ fn plot_with_fallback(
 
     // Fallback to standard quality
     Plot::new()
-        .dimensions(800, 600)
+        .size_px(800, 600)
         .dpi(96)
         .line(x, y)
         .save(output)?;

--- a/docs/migration/matplotlib.md
+++ b/docs/migration/matplotlib.md
@@ -91,7 +91,7 @@ plt.plot(x, y, color='red', linewidth=2, linestyle='--', marker='o')
 ```rust
 Plot::new()
     .line(&x, &y)
-    .color(Color::from_rgb(255, 0, 0))
+    .color(Color::new(255, 0, 0))
     .line_width(2.0)
     .line_style(LineStyle::Dashed)
     .marker(MarkerStyle::Circle)
@@ -174,7 +174,7 @@ Plot::new()
 | Subplots | `subplots()` | `subplots()` |
 | Themes | `style.use()` | `.theme()` |
 | DPI control | `dpi=` | `.dpi()` |
-| Figure size | `figsize=` | `.dimensions()` |
+| Figure size | `figsize=` | `.size_px()` |
 | PNG export | `savefig()` | `.save()` |
 
 ### Support Snapshot ⚠️
@@ -300,14 +300,14 @@ let y_sin: Vec<f64> = x.iter().map(|v| v.sin()).collect();
 let y_cos: Vec<f64> = x.iter().map(|v| v.cos()).collect();
 
 Plot::new()
-    .dimensions(1000, 600)
+    .size_px(1000, 600)
     .dpi(300)
     .line(&x, &y_sin)
-        .color(Color::from_rgb(0, 0, 255))
+        .color(Color::new(0, 0, 255))
         .line_width(2.0)
         .label("sin(x)")
     .line(&x, &y_cos)
-        .color(Color::from_rgb(255, 0, 0))
+        .color(Color::new(255, 0, 0))
         .line_style(LineStyle::Dashed)
         .line_width(2.0)
         .label("cos(x)")
@@ -394,7 +394,7 @@ Plot::new()
 **A**: Yes, but differently:
 ```rust
 // Custom colors
-.color(Color::from_rgb(255, 128, 0))
+.color(Color::new(255, 128, 0))
 .color(Color::from_hex("#FF8000")?)
 
 let viridis_like = Theme::builder()

--- a/docs/migration/seaborn.md
+++ b/docs/migration/seaborn.md
@@ -199,9 +199,9 @@ sns.color_palette("pastel")
 **ruviz**:
 ```rust
 // Seaborn "muted" palette (approximate)
-let muted_blue = Color::from_rgb(76, 114, 176);
-let muted_orange = Color::from_rgb(221, 132, 82);
-let muted_green = Color::from_rgb(85, 168, 104);
+let muted_blue = Color::new(76, 114, 176);
+let muted_orange = Color::new(221, 132, 82);
+let muted_green = Color::new(85, 168, 104);
 let muted_theme = Theme::builder()
     .palette([muted_blue, muted_orange, muted_green])
     .build();
@@ -219,11 +219,11 @@ Plot::new()
 Common seaborn palettes translated to RGB:
 
 **muted**:
-- Blue: `#4C72B0` → `Color::from_rgb(76, 114, 176)`
-- Orange: `#DD8452` → `Color::from_rgb(221, 132, 82)`
-- Green: `#55A868` → `Color::from_rgb(85, 168, 104)`
-- Red: `#C44E52` → `Color::from_rgb(196, 78, 82)`
-- Purple: `#8172B3` → `Color::from_rgb(129, 114, 179)`
+- Blue: `#4C72B0` → `Color::new(76, 114, 176)`
+- Orange: `#DD8452` → `Color::new(221, 132, 82)`
+- Green: `#55A868` → `Color::new(85, 168, 104)`
+- Red: `#C44E52` → `Color::new(196, 78, 82)`
+- Purple: `#8172B3` → `Color::new(129, 114, 179)`
 
 **deep** (default):
 - Blue: `#4C72B0`

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,9 @@ pre-commit:
     - name: clippy
       files: echo Cargo.toml
       run: cargo clippy --all-features -- -D warnings
+    - name: docs-examples
+      files: git diff --cached --name-only --diff-filter=ACMR | grep -E '^(README\.md|docs/.*\.md|python/(README\.md|docs/.*\.md|examples/README\.md)|packages/ruviz-web/(README\.md|docs/.*\.md|examples/README\.md)|scripts/check_docs\.py)$' || true
+      run: uv run python scripts/check_docs.py
     - name: oxfmt
       files: git diff --cached --name-only --diff-filter=ACMR | grep -E '^(packages/ruviz-web/src/.*\.(js|ts)|demo/web/src/.*\.(js|ts)|demo/web/tests/.*\.(js|ts)|demo/web/playwright\.config\.js)$' || true
       run: bunx oxfmt --check {files}

--- a/packages/ruviz-web/README.md
+++ b/packages/ruviz-web/README.md
@@ -13,12 +13,23 @@ rendering, and reactive demos.
 npm install ruviz
 ```
 
-The package ships as ESM and expects a bundler or runtime that can load Web
-Workers and WebAssembly from standard module URLs.
+The package ships as ESM. Browser apps should use a bundler or runtime that can
+load WebAssembly and module workers from package-relative `import.meta.url`
+references.
+
+The public package entrypoints are:
+
+```ts,check
+import { createPlot, createWorkerSession } from "ruviz";
+import initRaw, { JsPlot } from "ruviz/raw";
+
+await initRaw();
+const rawPlot = new JsPlot();
+```
 
 ## Quick Start
 
-```ts
+```ts,check
 import { createPlot } from "ruviz";
 
 const plot = createPlot()
@@ -34,7 +45,7 @@ await plot.save({ format: "png", fileName: "quadratic.png" });
 
 Mount a plot into a normal HTML canvas:
 
-```ts
+```ts,check
 import { createCanvasSession, createPlot } from "ruviz";
 
 const canvas = document.querySelector("canvas")!;
@@ -45,8 +56,49 @@ await session.setPlot(
 session.render();
 ```
 
-Use `createWorkerSession(...)` when you want OffscreenCanvas worker rendering
-with main-thread fallback support.
+Use `createWorkerSession(...)` when you want OffscreenCanvas worker rendering:
+
+```ts,check
+import { createPlot, createWorkerSession } from "ruviz";
+
+const canvas = document.querySelector("canvas")!;
+const session = await createWorkerSession(canvas, {
+  backendPreference: "auto",
+  fallbackToMainThread: true,
+});
+await session.setPlot(createPlot().scatter({ x: [0, 1, 2], y: [2, 1, 3] }));
+session.render();
+```
+
+When `Worker`, `OffscreenCanvas`, or `transferControlToOffscreen()` is missing,
+`createWorkerSession()` returns a `WorkerSession` in `mode === "main-thread"` by
+default. Pass `{ fallbackToMainThread: false }` to throw instead.
+
+Both `createCanvasSession()` and `createWorkerSession()` default to
+`autoResize: true` and `bindInput: true`, so pointer, wheel, and resize events
+are wired automatically unless you disable them.
+
+## Plot Types
+
+The fluent builder currently supports:
+
+- `line({ x, y })` and `scatter({ x, y })`
+- `bar({ categories, values })`
+- `histogram(values)` and `boxplot(values)`
+- `heatmap(rows)` where `rows` is a rectangular `number[][]`
+- `errorBars({ x, y, yErrors })`
+- `errorBarsXY({ x, y, xErrors, yErrors })`
+- `kde(values)` and `ecdf(values)`
+- `contour({ x, y, z })` where `z.length === x.length * y.length`
+- `pie(values, labels?)`
+- `radar({ labels, series })`
+- `violin(values)`
+- `polarLine({ r, theta })`
+
+`number[]`, `Float64Array`, and other `ArrayLike<number>` values are accepted
+for numeric inputs. `createObservable(...)` can drive line, scatter, bar,
+histogram, boxplot, and error-bar inputs. `createSineSignal(...)` can be used as
+the `y` input for line and scatter plots.
 
 ## Reactive Helpers
 
@@ -54,6 +106,7 @@ The package also exports:
 
 - `createObservable(...)` for mutable numeric series
 - `createSineSignal(...)` for time-varying demo inputs
+- `createPlotFromSnapshot(...)` for rehydrating `plot.toSnapshot()` output
 - `getRuntimeCapabilities()` for browser capability checks
 - `registerFont(...)` for custom browser text faces
 
@@ -72,8 +125,14 @@ The package also exports:
 
 ## Local Development
 
+From the repository root:
+
 ```sh
 bun install
+bun run --cwd packages/ruviz-web build:js
 bun run --cwd packages/ruviz-web build
 bun run --cwd packages/ruviz-web docs:dev
 ```
+
+`build:js` runs the TypeScript build against existing generated wasm bindings.
+`build` also rebuilds the wasm package before compiling TypeScript.

--- a/packages/ruviz-web/docs/api/index.md
+++ b/packages/ruviz-web/docs/api/index.md
@@ -4,9 +4,9 @@ The API reference pages are generated from the exported TypeScript surface with 
 
 - Package root API: `src/index.ts`
 - Snapshot and option types: `src/shared.ts`
-- Low-level raw bindings: `ruviz/raw`
+- Low-level raw bindings: `ruviz/raw`, exported from `generated/raw/ruviz_web_raw.js`
 
-Run `bun run --cwd packages/ruviz-web docs:api` to regenerate the markdown reference files before
-building the VitePress site.
+Run `bun run --cwd packages/ruviz-web docs:api` to regenerate the markdown
+reference files before building the VitePress site.
 
 - [Generated module reference](./reference/README.md)

--- a/packages/ruviz-web/docs/guide/gallery.md
+++ b/packages/ruviz-web/docs/guide/gallery.md
@@ -6,7 +6,11 @@ Each example doubles as:
 
 - a runnable development example
 - a gallery source for the VitePress docs
-- a regression surface for the published npm package flows
+- a regression surface for the high-level Web SDK flows
+
+The files import from `../src/index.js` so the local docs always exercise the
+workspace source. Published package snippets should import the same symbols from
+`ruviz`.
 
 Use the local docs build to preview the same gallery content that ships with the
 package docs:

--- a/packages/ruviz-web/docs/guide/getting-started.md
+++ b/packages/ruviz-web/docs/guide/getting-started.md
@@ -19,8 +19,11 @@ await plot.save({ format: "png", fileName: "quadratic.png" });
 
 You can also call:
 
-- `await plot.renderPng()` to get PNG bytes
+- `await plot.renderPng()` to get PNG bytes as a `Uint8Array`
 - `await plot.renderSvg()` to get SVG markup
+
+`save()` triggers a browser download. Use `renderPng()` or `renderSvg()` when
+you want bytes or markup for your own storage flow.
 
 ## First Interactive Session
 
@@ -49,8 +52,16 @@ await session.setPlot(createPlot().line({ x: [0, 1], y: [0, 1] }));
 session.render();
 ```
 
+The constructor options are:
+
+- `backendPreference: "auto" | "cpu" | "svg" | "gpu"`
+- `autoResize`, default `true`
+- `bindInput`, default `true`
+- `initialTime`, for signal-backed plots
+
 ## Runtime Notes
 
 - The package is ESM-first.
-- WebAssembly and worker assets are resolved through module URLs.
+- WebAssembly and worker assets are resolved through package-relative module URLs.
 - Use `createWorkerSession(...)` when you want OffscreenCanvas worker rendering.
+- Use `import ... from "ruviz/raw"` only when you need the low-level wasm-bindgen API.

--- a/packages/ruviz-web/docs/guide/interactivity.md
+++ b/packages/ruviz-web/docs/guide/interactivity.md
@@ -16,7 +16,13 @@ Use `createWorkerSession(...)` or `plot.mountWorker(canvas)` when you want the
 interactive rendering lifecycle in a worker-backed session.
 
 When `OffscreenCanvas` is unavailable, the SDK can fall back to a main-thread
-session instead of failing immediately.
+session instead of failing immediately. The returned object is still a
+`WorkerSession`, but `session.mode` is `"main-thread"`. Pass
+`{ fallbackToMainThread: false }` to make unsupported worker rendering throw.
+
+Worker sessions serialize plots with `plot.toSnapshot()` and rebuild them inside
+`session-worker.js`. Observable sources are transferred as their current values,
+and sine signals are transferred as normalized signal options.
 
 ## Input and Resize Wiring
 
@@ -29,10 +35,19 @@ By default session constructors:
 You can disable that wiring through `CanvasSessionOptions` or
 `WorkerSessionOptions` if you want to drive it yourself.
 
+When input wiring is disabled, call `resize()`, `pointerDown()`,
+`pointerMove()`, `pointerUp()`, `pointerLeave()`, and `wheel()` directly with
+canvas pixel coordinates.
+
 ## Reactive Data
 
 Use `createObservable(...)` for mutable numeric series and
 `createSineSignal(...)` for time-varying demo inputs. Those values can be
 serialized into snapshots and rehydrated later.
+
+Observable sources work with line, scatter, bar, histogram, boxplot, and
+error-bar inputs. Sine signals can be used as the `y` source for line and
+scatter plots. After mutating an observable or advancing session time, call
+`session.render()` to draw the next frame.
 
 <PlotGallery :categories="['interactive']" />

--- a/packages/ruviz-web/docs/guide/plot-types.md
+++ b/packages/ruviz-web/docs/guide/plot-types.md
@@ -1,6 +1,56 @@
 # Plot Types
 
-The fluent builder covers the standard plot families exposed by the Rust core and the Python
-binding. The live gallery below uses the canonical files from `packages/ruviz-web/examples/`.
+The fluent builder covers the plot families exposed by the current Web package
+API. The live gallery below uses the canonical files from
+`packages/ruviz-web/examples/`.
+
+## Builder Methods
+
+| Plot | Method |
+| --- | --- |
+| Line | `line({ x, y })` |
+| Scatter | `scatter({ x, y })` |
+| Bar | `bar({ categories, values })` |
+| Histogram | `histogram(values)` |
+| Boxplot | `boxplot(values)` |
+| Heatmap | `heatmap(rows)` |
+| Vertical error bars | `errorBars({ x, y, yErrors })` |
+| Horizontal and vertical error bars | `errorBarsXY({ x, y, xErrors, yErrors })` |
+| Kernel density estimate | `kde(values)` |
+| ECDF | `ecdf(values)` |
+| Contour | `contour({ x, y, z })` |
+| Pie | `pie(values, labels?)` |
+| Radar | `radar({ labels, series })` |
+| Violin | `violin(values)` |
+| Polar line | `polarLine({ r, theta })` |
+
+Numeric inputs accept `number[]`, `Float64Array`, or `ArrayLike<number>`.
+Length checks are enforced for paired series. Heatmap rows must be rectangular,
+and contour data must provide exactly `x.length * y.length` `z` values.
+
+## Snapshots
+
+`plot.toSnapshot()` returns a `PlotSnapshot`:
+
+```ts
+type PlotSnapshot = {
+  sizePx?: [number, number];
+  theme?: "light" | "dark";
+  ticks?: boolean;
+  title?: string;
+  xLabel?: string;
+  yLabel?: string;
+  series: PlotSeriesSnapshot[];
+};
+```
+
+Snapshot series use `kind` values matching the builder families, including
+`"line"`, `"scatter"`, `"bar"`, `"histogram"`, `"boxplot"`, `"heatmap"`,
+`"error-bars"`, `"error-bars-xy"`, `"kde"`, `"ecdf"`, `"contour"`, `"pie"`,
+`"radar"`, `"violin"`, and `"polar-line"`.
+
+Static and observable numeric sources snapshot as `{ kind, values }`. Sine
+signals snapshot as `{ kind: "sine-signal", options }`. Rehydrate snapshots
+with `createPlotFromSnapshot(snapshot)` or `PlotBuilder.fromSnapshot(snapshot)`.
 
 <PlotGallery :categories="['basic', 'statistical', 'matrix', 'categorical', 'specialized']" />

--- a/packages/ruviz-web/docs/index.md
+++ b/packages/ruviz-web/docs/index.md
@@ -9,12 +9,16 @@ It combines:
 - interactive main-thread canvas sessions
 - worker-backed canvas sessions with fallback
 - reactive helpers for observable and time-based demo data
+- serializable plot snapshots for worker transfer and rehydration
 
 ## Install
 
 ```sh
 npm install ruviz
 ```
+
+The package exports the high-level SDK from `ruviz` and the raw wasm-bindgen
+bridge from `ruviz/raw`.
 
 ## Start Here
 

--- a/packages/ruviz-web/examples/README.md
+++ b/packages/ruviz-web/examples/README.md
@@ -7,17 +7,19 @@ Each example should be suitable for:
 
 - local SDK debugging
 - gallery/documentation embedding
-- published npm package onboarding
+- source-aligned npm package onboarding snippets
 
 ## Local Preview
 
 ```sh
 bun install
+bun run --cwd packages/ruviz-web build:js
 bun run --cwd packages/ruviz-web docs:dev
 ```
 
 ## Authoring Expectations
 
 - keep examples self-contained
-- prefer published package entrypoints over internal imports
+- import from `../src/index.js` in gallery source files so local docs exercise the workspace SDK
+- translate those imports to `ruviz` in published package snippets
 - update the docs pages when you add a new example category or workflow

--- a/python/README.md
+++ b/python/README.md
@@ -2,6 +2,8 @@
 
 `ruviz` for Python wraps the Rust plotting runtime with a fluent Python API,
 static export helpers, native desktop `show()`, and notebook widget support.
+It requires Python 3.10 or newer and installs the runtime dependencies needed
+for NumPy inputs, static rendering, and AnyWidget notebooks.
 
 ## Install
 
@@ -9,16 +11,19 @@ static export helpers, native desktop `show()`, and notebook widget support.
 pip install ruviz
 ```
 
-If you want pandas or Polars dataframe inputs, install the optional dataframe
-extras:
+If you want pandas or Polars dataframe inputs, install the matching optional
+extra:
 
 ```sh
 pip install "ruviz[dataframes]"
+# or only one dataframe backend:
+pip install "ruviz[pandas]"
+pip install "ruviz[polars]"
 ```
 
 ## Quick Start
 
-```python
+```python,check
 import numpy as np
 import ruviz
 
@@ -46,33 +51,36 @@ y = x**2
 - In the widget, right click opens the export menu and right drag performs box zoom.
 - Outside notebooks, `plot.show()` opens the native interactive window.
 - The published Linux wheel focuses on static rendering and notebook widgets. Install from source on Linux if you need the native desktop `plot.show()` window.
-- `plot.render_png()` and `plot.render_svg()` return in-memory export data.
+- `plot.render_png()` returns PNG bytes and `plot.render_svg()` returns an SVG string.
+- `plot.save(path)` writes PNG, SVG, or PDF according to the file extension and returns the output `Path`.
 
 ## Reactive Notebook Data
 
-Use `ruviz.observable(...)` for notebook-driven updates that keep widget state
-in sync:
+Use `ruviz.observable(...)` for notebook-driven updates that keep explicit
+widgets in sync:
 
-```python
+```python,check
 import numpy as np
 import ruviz
 
 x = np.linspace(0.0, 6.0, 200)
 y = ruviz.observable(np.sin(x))
 
-plot = ruviz.plot().line(x, y).title("Live Sine Wave")
+plot = ruviz.plot().size_px(640, 360).line(x, y).title("Live Sine Wave")
 widget = plot.widget()
 ```
 
 `ObservableSeries` supports elementwise arithmetic and NumPy ufuncs. Derived
-observables stay live until you write to them directly:
+observables stay live until you write to them directly. Live observable series
+are supported by `line`, `scatter`, `bar`, `histogram`, `boxplot`,
+`error_bars`, and `error_bars_xy`; other plot types snapshot their inputs.
 
-```python
-from copy import deepcopy
+```python,check
 import numpy as np
 
 scaled = np.sin(y * 2.0 + 0.25)
-template = deepcopy(plot)
+plot.line(x, scaled)
+y.replace(np.cos(x))
 ```
 
 `deepcopy(plot)` creates an independent live copy with fresh observables, while

--- a/python/docs/api.md
+++ b/python/docs/api.md
@@ -8,4 +8,10 @@ to PyPI:
 - `observable()` and `ObservableSeries` for synced notebook data, elementwise arithmetic, and NumPy ufuncs
 - `RuvizWidget` for explicit notebook widget embedding
 
+The public import surface is:
+
+```python
+from ruviz import ObservableSeries, Plot, RuvizWidget, observable, plot
+```
+
 ::: ruviz

--- a/python/docs/getting-started.md
+++ b/python/docs/getting-started.md
@@ -8,11 +8,16 @@ For normal use:
 pip install ruviz
 ```
 
-Install the dataframe extras if you want pandas or Polars inputs:
+Install dataframe extras if you want pandas or Polars inputs:
 
 ```sh
 pip install "ruviz[dataframes]"
+pip install "ruviz[pandas]"
+pip install "ruviz[polars]"
 ```
+
+`ruviz` requires Python 3.10 or newer. The base install includes `anywidget`,
+`numpy`, and `traitlets`; pandas and Polars are optional.
 
 For local contributor builds:
 
@@ -41,6 +46,9 @@ svg = plot.render_svg()
 png_bytes = plot.render_png()
 ```
 
+`save(path)` writes PNG, SVG, or PDF according to the file extension and returns
+the output `Path`. `render_png()` returns `bytes`; `render_svg()` returns `str`.
+
 ## DataFrame Inputs
 
 The high-level API accepts named columns through `data=...`:
@@ -60,12 +68,40 @@ This works with:
 - `dict`-backed column data
 - plain NumPy arrays, lists, and other array-like inputs
 
+The `data=` column lookup is available on `line`, `scatter`, `bar`,
+`histogram`, `boxplot`, `error_bars`, `error_bars_xy`, `kde`, `ecdf`,
+`contour`, `pie`, `violin`, and `polar_line`.
+
+## Plot Types
+
+The fluent builder appends each series in call order:
+
+```python
+import ruviz
+
+ruviz.plot().line([0, 1, 2], [0.0, 0.8, 0.3])
+ruviz.plot().scatter([0, 1, 2], [0.0, 0.8, 0.3])
+ruviz.plot().bar(["CPU", "WASM", "Jupyter"], [3.8, 4.9, 4.1])
+ruviz.plot().histogram([0.2, 0.4, 0.4, 0.9])
+ruviz.plot().boxplot([0.2, 0.4, 0.4, 0.9])
+ruviz.plot().heatmap([[0.1, 0.4], [0.8, 0.2]])
+ruviz.plot().error_bars([0, 1, 2], [1.0, 1.2, 0.9], [0.1, 0.2, 0.1])
+ruviz.plot().error_bars_xy([0, 1], [1.0, 1.2], [0.1, 0.1], [0.2, 0.2])
+ruviz.plot().kde([0.2, 0.4, 0.4, 0.9])
+ruviz.plot().ecdf([0.2, 0.4, 0.4, 0.9])
+ruviz.plot().contour([0, 1], [0, 1], [0.1, 0.2, 0.3, 0.4])
+ruviz.plot().pie([30, 70], ["static", "widget"])
+ruviz.plot().radar(["API", "Docs"], [{"name": "Python", "values": [4.5, 4.7]}])
+ruviz.plot().violin([0.2, 0.4, 0.4, 0.9])
+ruviz.plot().polar_line([1.0, 1.2, 1.1], [0.0, 1.57, 3.14])
+```
+
 ## Plot Lifecycle
 
 - `plot()` creates a fluent builder
 - plot methods append series and update presentation state
-- `save()` writes a file
-- `render_png()` and `render_svg()` return in-memory export data
+- `save()` writes a PNG, SVG, or PDF file and returns the output `Path`
+- `render_png()` returns PNG bytes and `render_svg()` returns an SVG string
 - `to_snapshot()` serializes the current state for widget sync and inspection
 - `copy.deepcopy(plot)` creates an independent live copy, while `plot.clone()` stays snapshot-only
 
@@ -86,6 +122,11 @@ template = deepcopy(plot)
 
 `scaled` updates when `source` changes. If you write to `scaled` directly, it
 detaches from `source` and becomes its own mutable observable.
+
+Live observables are passed through to the native renderer for `line`,
+`scatter`, `bar`, `histogram`, `boxplot`, `error_bars`, and `error_bars_xy`.
+Other plot types accept observable values as array-like input but snapshot them
+when the series is added.
 
 ## Examples
 

--- a/python/docs/index.md
+++ b/python/docs/index.md
@@ -12,13 +12,16 @@ API with three main workflows:
 - the same plot builder works across scripts, notebooks, and desktop sessions
 - pandas, Polars, dict, and array-like inputs work through the same API
 - notebook widgets reuse the browser runtime instead of a separate Python-only frontend
-- native static export stays in Rust for PNG, SVG, and PDF generation
+- native static export stays in Rust; `save()` writes PNG, SVG, or PDF files
 
 ## Install
 
 ```sh
 pip install ruviz
 ```
+
+Install `ruviz[dataframes]`, `ruviz[pandas]`, or `ruviz[polars]` when you want
+named dataframe column inputs. The package requires Python 3.10 or newer.
 
 ## First Plot
 

--- a/python/docs/interactive.md
+++ b/python/docs/interactive.md
@@ -30,6 +30,10 @@ plot = ruviz.plot().size_px(640, 360).line(x, y).title("Live Sine Wave")
 widget = plot.widget()
 ```
 
+`plot.widget()` returns a `RuvizWidget` AnyWidget instance bound to the plot.
+When observable data changes, the widget receives a refreshed JSON-friendly
+snapshot from `plot.to_snapshot()`.
+
 When a plot has `size_px(width, height)` configured, the widget uses that as
 its display size inside the notebook. If the notebook column is narrower than
 the configured width, the widget shrinks proportionally while preserving the
@@ -61,6 +65,10 @@ signal = np.sin((phase * 2.0) + 0.5)
 
 Derived observables detach on the first direct write, so `signal.set_at(...)`
 turns `signal` into an independent mutable series without mutating `phase`.
+Live observable updates are supported by `line`, `scatter`, `bar`, `histogram`,
+`boxplot`, `error_bars`, and `error_bars_xy`. Plot types such as `heatmap`,
+`kde`, `ecdf`, `contour`, `pie`, `radar`, `violin`, and `polar_line` snapshot
+their data when added.
 
 ## Desktop Windows
 

--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -2,11 +2,22 @@
 
 The examples in this directory are the source of truth for the Python docs and gallery.
 
+Examples import the installed `ruviz` package and local helpers from
+`examples/_shared.py`. Install optional dataframe dependencies before running
+`dataframe_line.py`; `uv sync` includes them for contributors.
+
 Run a single example:
 
 ```sh
 cd python
 uv run python examples/line.py
+```
+
+Run the example-backed docs smoke tests:
+
+```sh
+cd python
+uv run pytest tests/test_examples.py
 ```
 
 Regenerate the gallery previews and the generated gallery page:

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -25,6 +26,8 @@ from urllib.parse import unquote
 
 
 ROOT = Path(__file__).resolve().parents[1]
+WEB_PACKAGE = ROOT / "packages" / "ruviz-web"
+WEB_SRC = WEB_PACKAGE / "src"
 MARKDOWN_ROOTS = [ROOT / "README.md", ROOT / "docs"]
 SNIPPET_MARKDOWN_ROOTS = [
     ROOT / "README.md",
@@ -42,6 +45,45 @@ FENCE_BLOCK_RE = re.compile(
     r"^```(?P<info>[^\n`]*)\n(?P<code>.*?)^```\s*$",
     re.DOTALL | re.MULTILINE,
 )
+RAW_MODULE_STUB = """\
+export default function init(input?: unknown): Promise<void>;
+
+export enum WebBackendPreference {
+  Auto = 0,
+  Cpu = 1,
+  Svg = 2,
+  Gpu = 3,
+}
+
+export class JsPlot {
+  [key: string]: any;
+  constructor();
+}
+
+export class ObservableVecF64 {
+  [key: string]: any;
+  constructor(values: Float64Array);
+}
+
+export class SignalVecF64 {
+  [key: string]: any;
+  static sineWave(...args: number[]): SignalVecF64;
+}
+
+export class WebCanvasSession {
+  [key: string]: any;
+  constructor(canvas: HTMLCanvasElement);
+}
+
+export class OffscreenCanvasSession {
+  [key: string]: any;
+  constructor(canvas: OffscreenCanvas);
+}
+
+export function register_default_browser_fonts_js(): void;
+export function register_font_bytes_js(bytes: Uint8Array): void;
+export function web_runtime_capabilities(): Record<string, boolean>;
+"""
 
 
 @dataclass(frozen=True)
@@ -316,6 +358,16 @@ def check_typescript_snippets(fences: list[CodeFence]) -> list[str]:
 
     with tempfile.TemporaryDirectory(prefix="ruviz-ts-doc-snippets-") as temp:
         temp_path = Path(temp)
+        web_package = temp_path / "ruviz-web"
+        raw_dir = web_package / "generated" / "raw"
+        raw_dir.mkdir(parents=True)
+        shutil.copytree(WEB_SRC, web_package / "src")
+        (raw_dir / "ruviz_web_raw.d.ts").write_text(
+            RAW_MODULE_STUB,
+            encoding="utf-8",
+        )
+        (raw_dir / "ruviz_web_raw.js").write_text("", encoding="utf-8")
+
         files = []
         for index, fence in enumerate(fences):
             snippet_path = temp_path / f"snippet_{index}.ts"
@@ -336,17 +388,8 @@ def check_typescript_snippets(fences: list[CodeFence]) -> list[str]:
                         "skipLibCheck": True,
                         "baseUrl": str(temp_path),
                         "paths": {
-                            "ruviz": [str(ROOT / "packages" / "ruviz-web" / "src" / "index.ts")],
-                            "ruviz/raw": [
-                                str(
-                                    ROOT
-                                    / "packages"
-                                    / "ruviz-web"
-                                    / "generated"
-                                    / "raw"
-                                    / "ruviz_web_raw.d.ts"
-                                )
-                            ],
+                            "ruviz": [str(web_package / "src" / "index.ts")],
+                            "ruviz/raw": [str(raw_dir / "ruviz_web_raw.d.ts")],
                         },
                     },
                     "files": files,
@@ -358,7 +401,15 @@ def check_typescript_snippets(fences: list[CodeFence]) -> list[str]:
 
         try:
             result = subprocess.run(
-                ["bun", "run", "--cwd", str(ROOT / "packages" / "ruviz-web"), "tsc", "-p", str(tsconfig_path)],
+                [
+                    "bun",
+                    "run",
+                    "--cwd",
+                    str(WEB_PACKAGE),
+                    "tsc",
+                    "-p",
+                    str(tsconfig_path),
+                ],
                 cwd=ROOT,
                 text=True,
                 stdout=subprocess.PIPE,

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -226,14 +226,18 @@ def cargo_project_manifest(crate_name: str) -> str:
     )
 
 
-def check_readme_quickstart() -> list[str]:
+def check_readme_quickstart(snippet_fences: list[CodeFence]) -> list[str]:
     try:
         fence = readme_quickstart_fence()
     except RuntimeError as error:
         return [str(error)]
 
     if "check" in fence.flags or "compile" in fence.flags:
-        # readme_quickstart_fence has already enforced the reader-facing fn main.
+        if fence not in snippet_fences:
+            return [
+                "README.md first Rust block is marked for checking but was not "
+                "included in checked Markdown snippets"
+            ]
         return []
 
     with tempfile.TemporaryDirectory(prefix="ruviz-readme-check-") as temp:
@@ -393,10 +397,10 @@ def check_typescript_snippets(fences: list[CodeFence]) -> list[str]:
                         "strict": True,
                         "noEmit": True,
                         "skipLibCheck": True,
-                        "baseUrl": str(temp_path),
+                        "baseUrl": ".",
                         "paths": {
-                            "ruviz": [str(web_package / "src" / "index.ts")],
-                            "ruviz/raw": [str(raw_dir / "ruviz_web_raw.d.ts")],
+                            "ruviz": ["ruviz-web/src/index.ts"],
+                            "ruviz/raw": ["ruviz-web/generated/raw/ruviz_web_raw.d.ts"],
                         },
                     },
                     "files": files,
@@ -437,8 +441,7 @@ def check_typescript_snippets(fences: list[CodeFence]) -> list[str]:
     return []
 
 
-def check_markdown_snippets() -> tuple[list[str], int]:
-    fences = checked_fences()
+def check_markdown_snippets(fences: list[CodeFence]) -> tuple[list[str], int]:
     unsupported = sorted({fence.lang for fence in fences if fence.lang not in {"rust", "python", "ts"}})
     errors = [
         f"unsupported checked Markdown code fence language: {lang!r}"
@@ -452,10 +455,11 @@ def check_markdown_snippets() -> tuple[list[str], int]:
 
 def main() -> int:
     files = markdown_files()
+    snippet_fences = checked_fences()
     errors = check_fences(files)
     errors.extend(check_local_links(files))
-    errors.extend(check_readme_quickstart())
-    snippet_errors, checked_snippet_count = check_markdown_snippets()
+    errors.extend(check_readme_quickstart(snippet_fences))
+    snippet_errors, checked_snippet_count = check_markdown_snippets(snippet_fences)
     errors.extend(snippet_errors)
 
     if errors:

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -6,32 +6,71 @@ The checks are intentionally narrow and deterministic:
 - Local Markdown links/images in README.md and docs/ must resolve.
 - The README's first Rust quick-start block must be a complete binary that
   type-checks against the local crate.
+- Markdown code fences marked with `check` are validated:
+  - `rust,check` fences are compiled against the local crate.
+  - `ts,check` / `typescript,check` fences are type-checked against the local Web SDK.
+  - `python,check` fences are syntax-checked.
 """
 
 from __future__ import annotations
 
+import json
 import re
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import unquote
 
 
 ROOT = Path(__file__).resolve().parents[1]
 MARKDOWN_ROOTS = [ROOT / "README.md", ROOT / "docs"]
+SNIPPET_MARKDOWN_ROOTS = [
+    ROOT / "README.md",
+    ROOT / "docs",
+    ROOT / "python" / "README.md",
+    ROOT / "python" / "docs",
+    ROOT / "python" / "examples" / "README.md",
+    ROOT / "packages" / "ruviz-web" / "README.md",
+    ROOT / "packages" / "ruviz-web" / "docs",
+    ROOT / "packages" / "ruviz-web" / "examples" / "README.md",
+]
 LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 FENCE_RE = re.compile(r"^```", re.MULTILINE)
-RUST_BLOCK_RE = re.compile(r"```rust\n(.*?)\n```", re.DOTALL)
+FENCE_BLOCK_RE = re.compile(
+    r"^```(?P<info>[^\n`]*)\n(?P<code>.*?)^```\s*$",
+    re.DOTALL | re.MULTILINE,
+)
 
 
-def markdown_files() -> list[Path]:
+@dataclass(frozen=True)
+class CodeFence:
+    path: Path
+    line: int
+    info: str
+    lang: str
+    flags: frozenset[str]
+    code: str
+
+    def label(self) -> str:
+        return f"{self.path.relative_to(ROOT)}:{self.line}"
+
+
+def markdown_files(roots: list[Path] | None = None) -> list[Path]:
+    roots = roots or MARKDOWN_ROOTS
     files: list[Path] = []
-    for root in MARKDOWN_ROOTS:
+    seen: set[Path] = set()
+    for root in roots:
         if root.is_file():
-            files.append(root)
+            candidates = [root]
         else:
-            files.extend(sorted(root.rglob("*.md")))
+            candidates = sorted(root.rglob("*.md"))
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                files.append(candidate)
     return sorted(files)
 
 
@@ -75,44 +114,101 @@ def check_local_links(files: list[Path]) -> list[str]:
     return errors
 
 
-def readme_quickstart_block() -> str:
-    readme = (ROOT / "README.md").read_text(encoding="utf-8")
-    match = RUST_BLOCK_RE.search(readme)
-    if match is None:
+def parse_fence_info(info: str) -> tuple[str, frozenset[str]]:
+    tokens = [token for token in re.split(r"[\s,]+", info.strip()) if token]
+    if not tokens:
+        return "", frozenset()
+
+    lang = tokens[0].lower()
+    if lang in {"typescript", "tsx"}:
+        lang = "ts"
+    elif lang in {"py", "python3"}:
+        lang = "python"
+    return lang, frozenset(token.lower() for token in tokens[1:])
+
+
+def extract_code_fences(files: list[Path]) -> list[CodeFence]:
+    fences: list[CodeFence] = []
+    for path in files:
+        text = path.read_text(encoding="utf-8")
+        for match in FENCE_BLOCK_RE.finditer(text):
+            info = match.group("info").strip()
+            lang, flags = parse_fence_info(info)
+            fences.append(
+                CodeFence(
+                    path=path,
+                    line=text.count("\n", 0, match.start()) + 1,
+                    info=info,
+                    lang=lang,
+                    flags=flags,
+                    code=match.group("code"),
+                )
+            )
+    return fences
+
+
+def checked_fences() -> list[CodeFence]:
+    return [
+        fence
+        for fence in extract_code_fences(markdown_files(SNIPPET_MARKDOWN_ROOTS))
+        if "check" in fence.flags or "compile" in fence.flags
+    ]
+
+
+def readme_quickstart_fence() -> CodeFence:
+    rust_fences = [
+        fence
+        for fence in extract_code_fences([ROOT / "README.md"])
+        if fence.lang == "rust"
+    ]
+    if not rust_fences:
         raise RuntimeError("README.md does not contain a Rust quick-start block")
-    code = match.group(1)
-    if "fn main" not in code:
+    fence = rust_fences[0]
+    if "fn main" not in fence.code:
         raise RuntimeError("README.md first Rust block must include fn main")
-    return code
+    return fence
+
+
+def cargo_project_manifest(crate_name: str) -> str:
+    return "\n".join(
+        [
+            "[package]",
+            f'name = "{crate_name}"',
+            'version = "0.0.0"',
+            'edition = "2024"',
+            "",
+            "[dependencies]",
+            f'ruviz = {{ path = "{ROOT}" }}',
+            "",
+        ]
+    )
 
 
 def check_readme_quickstart() -> list[str]:
     try:
-        code = readme_quickstart_block()
+        fence = readme_quickstart_fence()
     except RuntimeError as error:
         return [str(error)]
+
+    if "check" in fence.flags or "compile" in fence.flags:
+        return []
 
     with tempfile.TemporaryDirectory(prefix="ruviz-readme-check-") as temp:
         temp_path = Path(temp)
         (temp_path / "src").mkdir()
-        (temp_path / "src" / "main.rs").write_text(code, encoding="utf-8")
+        (temp_path / "src" / "main.rs").write_text(fence.code, encoding="utf-8")
         (temp_path / "Cargo.toml").write_text(
-            "\n".join(
-                [
-                    "[package]",
-                    'name = "ruviz-readme-check"',
-                    'version = "0.0.0"',
-                    'edition = "2024"',
-                    "",
-                    "[dependencies]",
-                    f'ruviz = {{ path = "{ROOT}" }}',
-                    "",
-                ]
-            ),
+            cargo_project_manifest("ruviz-readme-check"),
             encoding="utf-8",
         )
         result = subprocess.run(
-            ["cargo", "check", "--quiet", "--manifest-path", str(temp_path / "Cargo.toml")],
+            [
+                "cargo",
+                "check",
+                "--quiet",
+                "--manifest-path",
+                str(temp_path / "Cargo.toml"),
+            ],
             cwd=ROOT,
             text=True,
             stdout=subprocess.PIPE,
@@ -127,18 +223,192 @@ def check_readme_quickstart() -> list[str]:
     return []
 
 
+def rust_snippet_source(code: str) -> str:
+    if re.search(r"\bfn\s+main\s*\(", code):
+        return code
+
+    return "\n".join(
+        [
+            "fn main() -> ruviz::prelude::Result<()> {",
+            code,
+            "Ok(())",
+            "}",
+            "",
+        ]
+    )
+
+
+def numbered_source(source: str) -> str:
+    return "\n".join(
+        f"{line_number:>4} | {line}"
+        for line_number, line in enumerate(source.splitlines(), start=1)
+    )
+
+
+def check_rust_snippets(fences: list[CodeFence]) -> list[str]:
+    if not fences:
+        return []
+
+    with tempfile.TemporaryDirectory(prefix="ruviz-rust-doc-snippets-") as temp:
+        temp_path = Path(temp)
+        src_bin = temp_path / "src" / "bin"
+        src_bin.mkdir(parents=True)
+        generated_snippets: list[tuple[int, CodeFence, str]] = []
+        for index, fence in enumerate(fences):
+            source = rust_snippet_source(fence.code)
+            (src_bin / f"snippet_{index}.rs").write_text(
+                source,
+                encoding="utf-8",
+            )
+            generated_snippets.append((index, fence, source))
+        (temp_path / "Cargo.toml").write_text(
+            cargo_project_manifest("ruviz-rust-doc-snippets"),
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                "cargo",
+                "check",
+                "--quiet",
+                "--bins",
+                "--manifest-path",
+                str(temp_path / "Cargo.toml"),
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode != 0:
+            snippets = "\n\n".join(
+                "\n".join(
+                    [
+                        f"--- snippet_{index}: {fence.label()}",
+                        f"    generated as src/bin/snippet_{index}.rs ---",
+                        numbered_source(source),
+                    ]
+                )
+                for index, fence, source in generated_snippets
+            )
+            return [
+                "checked Rust Markdown snippets failed cargo check:\n"
+                + snippets
+                + "\n\ncargo output:\n"
+                + result.stdout
+                + result.stderr
+            ]
+    return []
+
+
+def check_python_snippets(fences: list[CodeFence]) -> list[str]:
+    errors: list[str] = []
+    for fence in fences:
+        try:
+            compile(fence.code, fence.label(), "exec")
+        except SyntaxError as error:
+            errors.append(f"{fence.label()} Python snippet has invalid syntax: {error}")
+    return errors
+
+
+def check_typescript_snippets(fences: list[CodeFence]) -> list[str]:
+    if not fences:
+        return []
+
+    with tempfile.TemporaryDirectory(prefix="ruviz-ts-doc-snippets-") as temp:
+        temp_path = Path(temp)
+        files = []
+        for index, fence in enumerate(fences):
+            snippet_path = temp_path / f"snippet_{index}.ts"
+            snippet_path.write_text(fence.code, encoding="utf-8")
+            files.append(str(snippet_path))
+
+        tsconfig_path = temp_path / "tsconfig.json"
+        tsconfig_path.write_text(
+            json.dumps(
+                {
+                    "compilerOptions": {
+                        "target": "ES2022",
+                        "lib": ["DOM", "DOM.Iterable", "ES2022"],
+                        "module": "ES2022",
+                        "moduleResolution": "Bundler",
+                        "strict": True,
+                        "noEmit": True,
+                        "skipLibCheck": True,
+                        "baseUrl": str(temp_path),
+                        "paths": {
+                            "ruviz": [str(ROOT / "packages" / "ruviz-web" / "src" / "index.ts")],
+                            "ruviz/raw": [
+                                str(
+                                    ROOT
+                                    / "packages"
+                                    / "ruviz-web"
+                                    / "generated"
+                                    / "raw"
+                                    / "ruviz_web_raw.d.ts"
+                                )
+                            ],
+                        },
+                    },
+                    "files": files,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+        try:
+            result = subprocess.run(
+                ["bun", "run", "--cwd", str(ROOT / "packages" / "ruviz-web"), "tsc", "-p", str(tsconfig_path)],
+                cwd=ROOT,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            return ["bun is required to type-check TypeScript Markdown snippets"]
+
+        if result.returncode != 0:
+            labels = "\n".join(f"  snippet_{index}: {fence.label()}" for index, fence in enumerate(fences))
+            return [
+                "checked TypeScript Markdown snippets failed tsc:\n"
+                + labels
+                + "\n"
+                + result.stdout
+                + result.stderr
+            ]
+    return []
+
+
+def check_markdown_snippets() -> tuple[list[str], int]:
+    fences = checked_fences()
+    unsupported = sorted({fence.lang for fence in fences if fence.lang not in {"rust", "python", "ts"}})
+    errors = [
+        f"unsupported checked Markdown code fence language: {lang!r}"
+        for lang in unsupported
+    ]
+    errors.extend(check_rust_snippets([fence for fence in fences if fence.lang == "rust"]))
+    errors.extend(check_python_snippets([fence for fence in fences if fence.lang == "python"]))
+    errors.extend(check_typescript_snippets([fence for fence in fences if fence.lang == "ts"]))
+    return errors, len(fences)
+
+
 def main() -> int:
     files = markdown_files()
     errors = check_fences(files)
     errors.extend(check_local_links(files))
     errors.extend(check_readme_quickstart())
+    snippet_errors, checked_snippet_count = check_markdown_snippets()
+    errors.extend(snippet_errors)
 
     if errors:
         for error in errors:
             print(error, file=sys.stderr)
         return 1
 
-    print(f"Validated {len(files)} Markdown files and README quick-start syntax.")
+    print(
+        f"Validated {len(files)} Markdown files, README quick-start syntax, "
+        f"and {checked_snippet_count} checked Markdown code fences."
+    )
     return 0
 
 

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -3,7 +3,7 @@
 
 The checks are intentionally narrow and deterministic:
 - Markdown fences must be balanced.
-- Local Markdown links/images in README.md and docs/ must resolve.
+- Local Markdown links/images in repository-facing docs must resolve.
 - The README's first Rust quick-start block must be a complete binary that
   type-checks against the local crate.
 - Markdown code fences marked with `check` are validated:
@@ -28,8 +28,7 @@ from urllib.parse import unquote
 ROOT = Path(__file__).resolve().parents[1]
 WEB_PACKAGE = ROOT / "packages" / "ruviz-web"
 WEB_SRC = WEB_PACKAGE / "src"
-MARKDOWN_ROOTS = [ROOT / "README.md", ROOT / "docs"]
-SNIPPET_MARKDOWN_ROOTS = [
+MARKDOWN_ROOTS = [
     ROOT / "README.md",
     ROOT / "docs",
     ROOT / "python" / "README.md",
@@ -39,6 +38,7 @@ SNIPPET_MARKDOWN_ROOTS = [
     ROOT / "packages" / "ruviz-web" / "docs",
     ROOT / "packages" / "ruviz-web" / "examples" / "README.md",
 ]
+SNIPPET_MARKDOWN_ROOTS = MARKDOWN_ROOTS
 LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
 FENCE_RE = re.compile(r"^```", re.MULTILINE)
 FENCE_BLOCK_RE = re.compile(

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -233,6 +233,7 @@ def check_readme_quickstart() -> list[str]:
         return [str(error)]
 
     if "check" in fence.flags or "compile" in fence.flags:
+        # readme_quickstart_fence has already enforced the reader-facing fn main.
         return []
 
     with tempfile.TemporaryDirectory(prefix="ruviz-readme-check-") as temp:
@@ -355,6 +356,12 @@ def check_python_snippets(fences: list[CodeFence]) -> list[str]:
 def check_typescript_snippets(fences: list[CodeFence]) -> list[str]:
     if not fences:
         return []
+
+    if not WEB_SRC.is_dir():
+        return [
+            "packages/ruviz-web/src is required to type-check TypeScript "
+            "Markdown snippets"
+        ]
 
     with tempfile.TemporaryDirectory(prefix="ruviz-ts-doc-snippets-") as temp:
         temp_path = Path(temp)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,11 +20,13 @@
 //!
 //! ## Features
 //!
-//! - **High Performance**: <100ms for 100K points, <1s for 1M points
+//! - **Performance-Oriented**: Built for release-mode plotting workloads
+//!   with benchmarkable output paths
 //! - **Zero Unsafe Public API**: Memory safety without compromising performance
 //! - **30+ Plotting Primitives and Layouts**: Distribution, categorical, polar, regression, and layout helpers
 //! - **Publication Quality**: PNG/SVG export with custom themes
-//! - **Large Dataset Support**: DataShader-style aggregation for 100M+ points
+//! - **Large Dataset Support**: Streaming-friendly data structures and
+//!   practical downsampling workflows
 //! - **Cross Platform**: Linux, macOS, Windows
 //! - **Animation Tooling**: Frame-based recording plus signal-aware plot data APIs
 //!
@@ -56,7 +58,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ruviz = { version = "0.4.0", features = ["typst-math"] }
+//! ruviz = { version = "0.4.13", features = ["typst-math"] }
 //! ```
 //!
 //! Then opt into Typst text rendering per plot with `.typst(true)`:
@@ -93,7 +95,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ruviz = { version = "0.4.0", default-features = false }
+//! ruviz = { version = "0.4.13", default-features = false }
 //!
 //! [features]
 //! default = []


### PR DESCRIPTION
## Summary
- correct README and docs examples for the current Rust, Python, and Web APIs
- add opt-in checked Markdown code fences for Rust, TypeScript, and Python snippets
- run the docs example checker from the Lefthook pre-commit hook when docs are staged
- add a GitHub Actions Documentation workflow job for checked Markdown examples

## Validation
- uv run python scripts/check_docs.py
- cargo test --doc
- bun run --cwd packages/ruviz-web build:js
- cd python && uv run pytest
- git diff --check
- pre-commit: rustfmt, clippy, docs-examples
- workflow YAML parsed locally