### PR TITLE
Scale heatmap colorbar rendering with DPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-- _None yet._
+### Fixed
+
+- Fixed heatmap and contour colorbar DPI scaling so tick labels, rotated labels, width, margin, and border stroke use the documented point/logical-pixel units consistently. Existing colorbar font sizes that were tuned as raw pixels may render larger because they are now honored as typographic points.
 
 ## [0.4.17] - 2026-05-24
 

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -979,6 +979,11 @@ impl Plot {
         renderer: &SkiaRenderer,
         spec: &ColorbarMeasurementSpec,
     ) -> Result<f32> {
+        let render_scale = renderer.render_scale();
+        let colorbar_width = render_scale.logical_pixels_to_pixels(COLORBAR_WIDTH_PX);
+        let colorbar_margin = render_scale.logical_pixels_to_pixels(COLORBAR_MARGIN_PX);
+        let tick_font_size = render_scale.points_to_pixels(spec.tick_font_size);
+        let label_font_size = render_scale.points_to_pixels(spec.label_font_size);
         let ticks = crate::render::skia::compute_colorbar_ticks(
             spec.vmin,
             spec.vmax,
@@ -986,23 +991,23 @@ impl Plot {
             spec.show_log_subticks,
         );
         let max_label_width =
-            Self::measure_tick_label_extent(renderer, &ticks.major_labels, spec.tick_font_size)?
+            Self::measure_tick_label_extent(renderer, &ticks.major_labels, tick_font_size)?
                 .map(|(width, _)| width)
                 .unwrap_or(0.0);
         let rotated_label_width = if let Some(label) = spec.label.as_deref() {
-            renderer.measure_text(label, spec.label_font_size)?.1
+            renderer.measure_text(label, label_font_size)?.1
         } else {
             0.0
         };
         let layout = crate::render::skia::compute_colorbar_layout_metrics(
-            COLORBAR_WIDTH_PX,
-            spec.tick_font_size,
+            colorbar_width,
+            tick_font_size,
             max_label_width,
             spec.label.as_ref().map(|_| rotated_label_width),
         );
-        let outer_padding = spec.tick_font_size.max(4.0) * 0.5;
+        let outer_padding = tick_font_size.max(4.0) * 0.5;
 
-        Ok(COLORBAR_MARGIN_PX + layout.total_extent + outer_padding)
+        Ok(colorbar_margin + layout.total_extent + outer_padding)
     }
 
     /// Pre-measure title/xlabel/ylabel for Typst layout parity.

--- a/src/core/plot/series_internal.rs
+++ b/src/core/plot/series_internal.rs
@@ -787,7 +787,10 @@ impl Plot {
                 }
 
                 if data.config.colorbar {
-                    let colorbar_x = plot_area.right() + COLORBAR_MARGIN_PX;
+                    let render_scale = self.render_scale();
+                    let colorbar_margin = render_scale.logical_pixels_to_pixels(COLORBAR_MARGIN_PX);
+                    let colorbar_width = render_scale.logical_pixels_to_pixels(COLORBAR_WIDTH_PX);
+                    let colorbar_x = plot_area.right() + colorbar_margin;
                     let colorbar_y = plot_area.y();
                     let colorbar_height = plot_area.height();
 
@@ -797,7 +800,7 @@ impl Plot {
                         data.vmax,
                         colorbar_x,
                         colorbar_y,
-                        COLORBAR_WIDTH_PX,
+                        colorbar_width,
                         colorbar_height,
                         &data.config.value_scale,
                         data.config.colorbar_label.as_deref(),
@@ -1368,7 +1371,10 @@ impl Plot {
 
                 // Draw colorbar if enabled
                 if data.config.colorbar {
-                    let colorbar_x = plot_area.right() + COLORBAR_MARGIN_PX;
+                    let render_scale = self.render_scale();
+                    let colorbar_margin = render_scale.logical_pixels_to_pixels(COLORBAR_MARGIN_PX);
+                    let colorbar_width = render_scale.logical_pixels_to_pixels(COLORBAR_WIDTH_PX);
+                    let colorbar_x = plot_area.right() + colorbar_margin;
                     let colorbar_y = plot_area.y();
                     let colorbar_height = plot_area.height();
 
@@ -1392,7 +1398,7 @@ impl Plot {
                         vmax,
                         colorbar_x,
                         colorbar_y,
-                        COLORBAR_WIDTH_PX,
+                        colorbar_width,
                         colorbar_height,
                         &crate::axes::AxisScale::Linear,
                         data.config.colorbar_label.as_deref(),

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -1160,6 +1160,35 @@ fn test_heatmap_log_colorbar_layout_reserves_right_margin() {
 }
 
 #[test]
+fn test_heatmap_colorbar_layout_scales_with_dpi() {
+    let values = vec![vec![0.0, 0.5], vec![1.0, 1.5]];
+    let config = || {
+        crate::plots::heatmap::HeatmapConfig::new()
+            .colorbar(true)
+            .colorbar_label("corrected")
+    };
+
+    let low_dpi = Plot::new()
+        .dpi(100)
+        .heatmap(&values, Some(config()))
+        .end_series();
+    let high_dpi = Plot::new()
+        .dpi(200)
+        .heatmap(&values, Some(config()))
+        .end_series();
+
+    let low_layout = compute_render_layout(&low_dpi);
+    let high_layout = compute_render_layout(&high_dpi);
+
+    assert!(
+        high_layout.margins.right > low_layout.margins.right * 1.8,
+        "colorbar right margin should scale with DPI: low={} high={}",
+        low_layout.margins.right,
+        high_layout.margins.right
+    );
+}
+
+#[test]
 fn test_plot_preserves_reversed_manual_limits() {
     let plot: Plot = Plot::new()
         .line(&[0.0, 4.0], &[0.0, 4.0])

--- a/src/render/skia.rs
+++ b/src/render/skia.rs
@@ -2755,8 +2755,10 @@ impl SkiaRenderer {
         label_font_size: Option<f32>,
         show_log_subticks: bool,
     ) -> Result<()> {
-        // Use tick font size for label if not specified separately
-        let label_font_size = label_font_size.unwrap_or(tick_font_size * 1.1);
+        let tick_font_size_px = self.points_to_pixels(tick_font_size);
+        let label_font_size_px = label_font_size
+            .map(|size| self.points_to_pixels(size))
+            .unwrap_or(tick_font_size_px * 1.1);
 
         // Draw the colorbar gradient (vertical, from vmax at top to vmin at bottom)
         // Use one segment per pixel row to eliminate anti-aliasing artifacts
@@ -2775,32 +2777,32 @@ impl SkiaRenderer {
         }
 
         // Draw border around colorbar
-        let stroke_width = 1.0;
-        self.draw_rectangle(x, y, width, height, foreground_color, false)?;
+        let stroke_width = self.logical_pixels_to_pixels(1.0);
+        self.draw_rectangle_outline(x, y, width, height, foreground_color, stroke_width)?;
 
         let ticks = compute_colorbar_ticks(vmin, vmax, value_scale, show_log_subticks);
         let mut measured_major_labels = Vec::with_capacity(ticks.major_labels.len());
         let mut max_label_width: f32 = 0.0;
         for label_text in &ticks.major_labels {
             let label_snippet = self.generated_label(label_text);
-            let (text_width, _) = self.measure_text(&label_snippet, tick_font_size)?;
+            let (text_width, _) = self.measure_text(&label_snippet, tick_font_size_px)?;
             let ink_center_from_top =
-                self.measure_text_ink_center_from_top(&label_snippet, tick_font_size)?;
+                self.measure_text_ink_center_from_top(&label_snippet, tick_font_size_px)?;
             max_label_width = max_label_width.max(text_width);
             measured_major_labels.push((label_snippet, ink_center_from_top));
         }
 
         let rotated_label_width = if let Some(label_text) = label {
-            Some(self.measure_text(label_text, label_font_size)?.1)
+            Some(self.measure_text(label_text, label_font_size_px)?.1)
         } else {
             None
         };
         let log_decade_base_center = matches!(value_scale, crate::axes::AxisScale::Log)
-            .then(|| self.measure_text_ink_center_from_top("10", tick_font_size))
+            .then(|| self.measure_text_ink_center_from_top("10", tick_font_size_px))
             .transpose()?;
         let layout = compute_colorbar_layout_metrics(
             width,
-            tick_font_size,
+            tick_font_size_px,
             max_label_width,
             rotated_label_width,
         );
@@ -2856,7 +2858,7 @@ impl SkiaRenderer {
                 label_text,
                 x + layout.tick_label_x_offset,
                 label_y,
-                tick_font_size,
+                tick_font_size_px,
                 foreground_color,
             )?;
         }
@@ -2867,7 +2869,13 @@ impl SkiaRenderer {
         {
             let label_x = x + label_center_x_offset;
             let label_y = y + height / 2.0;
-            self.draw_text_rotated(label, label_x, label_y, label_font_size, foreground_color)?;
+            self.draw_text_rotated(
+                label,
+                label_x,
+                label_y,
+                label_font_size_px,
+                foreground_color,
+            )?;
         }
 
         Ok(())

--- a/src/render/skia/tests.rs
+++ b/src/render/skia/tests.rs
@@ -923,6 +923,98 @@ fn test_draw_legend_full_scales_font_with_render_dpi() {
     );
 }
 
+const TEST_COLORBAR_X: f32 = 20.0;
+const TEST_COLORBAR_Y: f32 = 20.0;
+const TEST_COLORBAR_WIDTH: f32 = 20.0;
+const TEST_COLORBAR_HEIGHT: f32 = 200.0;
+
+fn test_colorbar_width(dpi: f32) -> f32 {
+    RenderScale::new(dpi).logical_pixels_to_pixels(TEST_COLORBAR_WIDTH)
+}
+
+fn render_test_colorbar(dpi: f32, colormap: crate::render::ColorMap) -> Image {
+    let mut renderer = SkiaRenderer::new(360, 260, Theme::light()).unwrap();
+    renderer.clear();
+    renderer.set_render_scale(RenderScale::new(dpi));
+    renderer
+        .draw_colorbar(
+            &colormap,
+            0.0,
+            1.0,
+            TEST_COLORBAR_X,
+            TEST_COLORBAR_Y,
+            test_colorbar_width(dpi),
+            TEST_COLORBAR_HEIGHT,
+            &crate::axes::AxisScale::Linear,
+            Some("corrected"),
+            Color::BLACK,
+            12.0,
+            Some(14.0),
+            false,
+        )
+        .unwrap();
+    renderer.into_image()
+}
+
+fn darkness_score_in_band(
+    image: &Image,
+    x_start: u32,
+    x_end: u32,
+    y_start: u32,
+    y_end: u32,
+) -> f32 {
+    (y_start..=y_end)
+        .flat_map(|y| (x_start..=x_end).map(move |x| (x, y)))
+        .filter(|&(x, y)| x < image.width && y < image.height)
+        .map(|y| {
+            let (x, y) = y;
+            let pixel = image_pixel_rgba(image, x, y);
+            let max_channel = pixel[0].max(pixel[1]).max(pixel[2]) as f32;
+            (255.0 - max_channel).max(0.0)
+        })
+        .sum()
+}
+
+fn top_colorbar_border_darkness(image: &Image, dpi: f32) -> f32 {
+    let center_x = TEST_COLORBAR_X + test_colorbar_width(dpi) / 2.0;
+    let x_start = (center_x - 5.0).round().max(0.0) as u32;
+    let x_end = (center_x + 5.0).round().max(0.0) as u32;
+    darkness_score_in_band(image, x_start, x_end, 17, 25)
+}
+
+#[test]
+fn test_draw_colorbar_scales_text_with_render_dpi() {
+    let low_dpi = render_test_colorbar(100.0, crate::render::ColorMap::viridis());
+    let high_dpi = render_test_colorbar(200.0, crate::render::ColorMap::viridis());
+    let low_bounds = dark_pixel_bounds(&low_dpi).expect("low-dpi colorbar should draw");
+    let high_bounds = dark_pixel_bounds(&high_dpi).expect("high-dpi colorbar should draw");
+    let low_width = low_bounds.2 - low_bounds.0 + 1;
+    let high_width = high_bounds.2 - high_bounds.0 + 1;
+
+    assert!(
+        high_width as f32 > low_width as f32 * 1.5,
+        "colorbar text extent should scale with DPI: low={low_width}, high={high_width}"
+    );
+}
+
+#[test]
+fn test_draw_colorbar_scales_border_width_with_render_dpi() {
+    let white_map = || crate::render::ColorMap::from_colors(&[Color::WHITE, Color::WHITE]);
+    let low_dpi = render_test_colorbar(100.0, white_map());
+    let high_dpi = render_test_colorbar(200.0, white_map());
+    let low_darkness = top_colorbar_border_darkness(&low_dpi, 100.0);
+    let high_darkness = top_colorbar_border_darkness(&high_dpi, 200.0);
+
+    assert!(
+        low_darkness > 0.0,
+        "low-DPI colorbar border should draw dark pixels"
+    );
+    assert!(
+        high_darkness > low_darkness * 1.2,
+        "colorbar border width should scale with DPI: low_darkness={low_darkness}, high_darkness={high_darkness}"
+    );
+}
+
 #[test]
 fn test_renderer_dimensions() {
     let theme = Theme::default();


### PR DESCRIPTION
## Summary
- scale heatmap/contour colorbar tick and label fonts through the active render DPI
- scale colorbar width, margin, border stroke, and layout measurement with RenderScale
- add regression coverage for colorbar layout, text extent, and border width scaling
- document that colorbar font-size settings are now honored as typographic points

## Bug
High-resolution heatmaps using `.max_resolution()` scaled title/axis typography, but colorbar labels and tick labels stayed at raw pixel sizes. The colorbar border also computed a scaled stroke width but used a fixed-width rectangle outline path.

## Review follow-up
- tightened the border-width regression test to use a white colorbar, a DPI-scaled test colorbar width, and a top-border-only probe band
- added a `CHANGELOG.md` note for callers who previously tuned colorbar font sizes as raw pixels

## Tests
- `cargo fmt --all --check`
- `cargo test -p ruviz colorbar -- --test-threads=1`
- `cargo check --all-targets`
- `git diff --check`

Note: pre-commit also ran `rustfmt`, `clippy`, and docs examples; clippy only emitted the existing MSRV mismatch warning between `clippy.toml` and `Cargo.toml`.