### PR TITLE
Fix font family consistency across renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,12 @@ Enable Typst-backed text rendering with:
 ruviz = { version = "0.4.19", features = ["typst-math"] }
 ```
 
-Then call `.typst(true)`:
+Then call `.typst(true)`. The configured family is passed to plain raster,
+plain SVG, and Typst text. Named-font consistency depends on that font being
+available to each renderer or SVG viewer; otherwise backend-specific fallback
+or substitution may occur. Typst resolves `serif`, `sans-serif`, and `monospace`
+to available concrete families. Because Typst has no generic cursive or fantasy
+selector, those two values use its selected sans-serif fallback:
 
 ```rust
 use ruviz::prelude::*;
@@ -178,6 +183,7 @@ fn main() -> Result<()> {
         .title("$f(x) = e^(-x)$")
         .xlabel("$x$")
         .ylabel("$f(x)$")
+        .font_family("New Computer Modern Sans")
         .typst(true)
         .save("typst_plot.png")?;
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -94,7 +94,13 @@ If you want publication-style math in labels and titles, enable Typst text rende
 ruviz = { version = "0.4.19", features = ["typst-math"] }
 ```
 
-`.typst(true)` is only available when `typst-math` is enabled. Without it, the compile error is:
+`.typst(true)` is only available when `typst-math` is enabled. The configured
+family is passed to plain raster, plain SVG, and Typst text. Named-font
+consistency depends on that font being available to each renderer or SVG
+viewer; otherwise backend-specific fallback or substitution may occur. Typst
+resolves `serif`, `sans-serif`, and `monospace` to available concrete families.
+Because Typst has no generic cursive or fantasy selector, those two values use
+its selected sans-serif fallback. Without the feature, the compile error is:
 
 ```text
 error[E0599]: no method named `typst` found for struct `ruviz::core::Plot` in the current scope
@@ -148,6 +154,7 @@ fn main() -> Result<()> {
         .title("Quadratic: $y = x^2$")
         .xlabel("$x$")
         .ylabel("$y$")
+        .font_family("New Computer Modern Sans")
         .typst(true)
         .save("plot_typst.png")?;
 

--- a/gallery/advanced/test_font_families.rs
+++ b/gallery/advanced/test_font_families.rs
@@ -2,14 +2,14 @@ use ruviz::prelude::*;
 
 fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     println!("Testing different font families...");
-    
+
     // Create test output directory if it doesn't exist
     std::fs::create_dir_all("generated/bench")?;
-    
+
     // Generate simple test data
     let x_data: Vec<f64> = (0..20).map(|i| i as f64).collect();
     let y_data: Vec<f64> = x_data.iter().map(|&x| x * 0.5).collect();
-    
+
     // Test different font families
     let font_tests = vec![
         ("sans_serif", FontFamily::SansSerif),
@@ -17,7 +17,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         ("monospace", FontFamily::Monospace),
         ("arial", FontFamily::Name("Arial".to_string())),
     ];
-    
+
     for (name, font_family) in font_tests {
         println!("Testing {} font...", name);
 
@@ -26,12 +26,13 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             .xlabel("X Values")
             .ylabel("Y Values")
             .theme(Theme::publication())
+            .font_family(font_family)
             .line(&x_data, &y_data)
             .label(&format!("{} line", name))
             .save_with_size(&format!("generated/bench/font_test_{}.png", name), 800, 600)?;
 
-        println!("✅ Generated generated/bench/font_test_{}.png", name);
+        println!("Generated generated/bench/font_test_{}.png", name);
     }
-    
+
     Ok(())
 }

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -929,6 +929,15 @@ impl PlotConfigBuilder {
         self
     }
 
+    /// Set the font family used for text.
+    pub fn font_family<F>(mut self, family: F) -> Self
+    where
+        F: Into<FontFamily>,
+    {
+        self.config.typography.family = family.into();
+        self
+    }
+
     /// Configure line widths with a closure
     pub fn lines<F>(mut self, f: F) -> Self
     where
@@ -1054,6 +1063,7 @@ mod tests {
         let config = PlotConfig::builder()
             .figure(8.0, 6.0)
             .dpi(150.0)
+            .font_family("New Computer Modern Sans")
             .font_size(12.0)
             .line_width(2.0)
             .build();
@@ -1061,6 +1071,10 @@ mod tests {
         assert!((config.figure.width - 8.0).abs() < 0.001);
         assert!((config.figure.height - 6.0).abs() < 0.001);
         assert!((config.figure.dpi - 150.0).abs() < 0.001);
+        assert_eq!(
+            config.typography.family,
+            FontFamily::Name("New Computer Modern Sans".to_string())
+        );
         assert!((config.typography.base_size - 12.0).abs() < 0.001);
         assert!((config.lines.data_width - 2.0).abs() < 0.001);
     }

--- a/src/core/plot/builder.rs
+++ b/src/core/plot/builder.rs
@@ -834,6 +834,17 @@ where
         self
     }
 
+    /// Set the font family used for plot text.
+    ///
+    /// This method forwards to the inner Plot.
+    pub fn font_family<F>(mut self, family: F) -> Self
+    where
+        F: Into<crate::render::FontFamily>,
+    {
+        self.plot = self.plot.font_family(family);
+        self
+    }
+
     /// Set maximum output resolution while preserving figure aspect ratio
     ///
     /// This method forwards to the inner Plot. See [`super::Plot::max_resolution`] for details.

--- a/src/core/plot/construction.rs
+++ b/src/core/plot/construction.rs
@@ -110,6 +110,8 @@ impl Plot {
     /// ```
     pub fn with_theme(theme: Theme) -> Self {
         let mut plot = Self::new();
+        plot.display.config.typography.family =
+            crate::render::FontFamily::from(theme.font_family.as_str());
         plot.display.theme = theme;
         plot
     }
@@ -231,6 +233,8 @@ impl Plot {
     /// |---------|------|---------|-------------|
     /// | ![Default](https://raw.githubusercontent.com/Ameyanagi/ruviz/main/docs/assets/rustdoc/theme_default.png) | ![Dark](https://raw.githubusercontent.com/Ameyanagi/ruviz/main/docs/assets/rustdoc/theme_dark.png) | ![Seaborn](https://raw.githubusercontent.com/Ameyanagi/ruviz/main/docs/assets/rustdoc/theme_seaborn.png) | ![Publication](https://raw.githubusercontent.com/Ameyanagi/ruviz/main/docs/assets/rustdoc/theme_publication.png) |
     pub fn theme(mut self, theme: Theme) -> Self {
+        self.display.config.typography.family =
+            crate::render::FontFamily::from(theme.font_family.as_str());
         self.display.theme = theme;
         self
     }
@@ -772,6 +776,18 @@ impl Plot {
         // Convert to scale factor
         self.display.config.typography.title_scale =
             size / self.display.config.typography.base_size;
+        self
+    }
+
+    /// Set the font family used for plot text.
+    ///
+    /// This applies to titles, axis labels, tick labels, legends, and text
+    /// rendered through Typst when the `typst-math` feature is enabled.
+    pub fn font_family<F>(mut self, family: F) -> Self
+    where
+        F: Into<crate::render::FontFamily>,
+    {
+        self.display.config.typography.family = family.into();
         self
     }
 

--- a/src/core/plot/construction.rs
+++ b/src/core/plot/construction.rs
@@ -232,6 +232,10 @@ impl Plot {
     /// | Default | Dark | Seaborn | Publication |
     /// |---------|------|---------|-------------|
     /// | ![Default](https://raw.githubusercontent.com/Ameyanagi/ruviz/main/docs/assets/rustdoc/theme_default.png) | ![Dark](https://raw.githubusercontent.com/Ameyanagi/ruviz/main/docs/assets/rustdoc/theme_dark.png) | ![Seaborn](https://raw.githubusercontent.com/Ameyanagi/ruviz/main/docs/assets/rustdoc/theme_seaborn.png) | ![Publication](https://raw.githubusercontent.com/Ameyanagi/ruviz/main/docs/assets/rustdoc/theme_publication.png) |
+    ///
+    /// Builder calls use last-call-wins precedence. Applying a theme replaces
+    /// the current typography settings, including the font family. Call
+    /// [`Plot::font_family`] after `theme` to override the theme's family.
     pub fn theme(mut self, theme: Theme) -> Self {
         self.display.config.typography.family =
             crate::render::FontFamily::from(theme.font_family.as_str());

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -2136,7 +2136,12 @@ fn compute_plot_layout(
     let layout_plot = plot.prepared_frame_plot(size_px, scale_factor, time_seconds);
     let dpi = layout_plot.display.config.figure.dpi;
 
-    let mut renderer = SkiaRenderer::new(size_px.0, size_px.1, layout_plot.display.theme.clone())?;
+    let mut renderer = SkiaRenderer::with_font_family(
+        size_px.0,
+        size_px.1,
+        layout_plot.display.theme.clone(),
+        layout_plot.display.config.typography.family.clone(),
+    )?;
     renderer.set_text_engine_mode(layout_plot.display.text_engine);
     renderer.set_render_scale(layout_plot.render_scale());
 

--- a/src/core/plot/parallel_render.rs
+++ b/src/core/plot/parallel_render.rs
@@ -157,8 +157,12 @@ impl Plot {
 
         // Create renderer with DPI scaling
         let (scaled_width, scaled_height) = self.dpi_scaled_dimensions();
-        let mut renderer =
-            SkiaRenderer::new(scaled_width, scaled_height, self.display.theme.clone())?;
+        let mut renderer = SkiaRenderer::with_font_family(
+            scaled_width,
+            scaled_height,
+            self.display.theme.clone(),
+            self.display.config.typography.family.clone(),
+        )?;
         renderer.set_text_engine_mode(self.display.text_engine);
         renderer.note_parallel_render();
         let render_scale = self.render_scale();

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -226,8 +226,12 @@ impl Plot {
         }
 
         let (scaled_width, scaled_height) = self.config_canvas_size();
-        let mut renderer =
-            SkiaRenderer::new(scaled_width, scaled_height, self.display.theme.clone())?;
+        let mut renderer = SkiaRenderer::with_font_family(
+            scaled_width,
+            scaled_height,
+            self.display.theme.clone(),
+            self.display.config.typography.family.clone(),
+        )?;
         renderer.set_text_engine_mode(self.display.text_engine);
         renderer.set_render_mode_diagnostics(match mode {
             RenderExecutionMode::Reference => "reference",
@@ -2157,7 +2161,11 @@ impl Plot {
         let width = width_px as f32;
         let height = height_px as f32;
 
-        let mut svg = SvgRenderer::new(width, height);
+        let mut svg = SvgRenderer::with_font_family(
+            width,
+            height,
+            self.display.config.typography.family.clone(),
+        );
         let render_scale = self.render_scale();
         svg.set_render_scale(render_scale);
         svg.set_text_engine_mode(self.display.text_engine);
@@ -2168,8 +2176,12 @@ impl Plot {
 
         // Use the same content-driven layout path as PNG rendering.
         let content = self.create_plot_content(y_min, y_max);
-        let mut measurement_renderer =
-            SkiaRenderer::new(width_px, height_px, self.display.theme.clone())?;
+        let mut measurement_renderer = SkiaRenderer::with_font_family(
+            width_px,
+            height_px,
+            self.display.theme.clone(),
+            self.display.config.typography.family.clone(),
+        )?;
         measurement_renderer.set_text_engine_mode(self.display.text_engine);
         measurement_renderer.set_render_scale(render_scale);
         let x_major_measurement_layout = TickLayout::compute(

--- a/src/core/plot/series_builders.rs
+++ b/src/core/plot/series_builders.rs
@@ -948,6 +948,15 @@ impl PlotSeriesBuilder {
         self
     }
 
+    /// Set the font family used for plot text.
+    pub fn font_family<F>(mut self, family: F) -> Self
+    where
+        F: Into<crate::render::FontFamily>,
+    {
+        self.plot = self.plot.font_family(family);
+        self
+    }
+
     /// Set maximum output resolution while preserving figure aspect ratio
     ///
     /// See [`Plot::max_resolution`] for details.

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -4757,5 +4757,58 @@ fn test_quiver_rejects_non_finite_input_values() {
     assert!(matches!(err, PlottingError::InvalidData { .. }));
 }
 
+#[test]
+fn test_plot_font_family_api_updates_typography_config() {
+    let plot = Plot::new().font_family("New Computer Modern Sans");
+    assert_eq!(
+        plot.get_config().typography.family,
+        crate::render::FontFamily::Name("New Computer Modern Sans".to_string())
+    );
+}
+
+#[test]
+fn test_render_to_svg_propagates_named_font_family() {
+    let x = vec![0.0, 1.0];
+    let y = vec![0.0, 1.0];
+    let svg = Plot::new()
+        .line(&x, &y)
+        .title("Label")
+        .font_family(crate::render::FontFamily::Name("serif".to_string()))
+        .render_to_svg()
+        .expect("SVG render should succeed");
+
+    assert!(svg.contains(r#"font-family="&quot;serif&quot;""#));
+}
+
+#[test]
+fn test_theme_sets_plot_typography_font_family() {
+    let themed = Plot::new().theme(crate::render::Theme::publication());
+    assert_eq!(
+        themed.get_config().typography.family,
+        crate::render::FontFamily::Name("Times New Roman".to_string())
+    );
+
+    let constructed = Plot::with_theme(crate::render::Theme::minimal());
+    assert_eq!(
+        constructed.get_config().typography.family,
+        crate::render::FontFamily::Name("Helvetica".to_string())
+    );
+}
+
+#[test]
+fn test_plot_builder_font_family_forwards_to_plot() {
+    let x = vec![0.0, 1.0, 2.0];
+    let y = vec![0.0, 1.0, 4.0];
+    let plot: Plot = Plot::new()
+        .line(&x, &y)
+        .font_family("New Computer Modern Sans")
+        .into();
+
+    assert_eq!(
+        plot.get_config().typography.family,
+        crate::render::FontFamily::Name("New Computer Modern Sans".to_string())
+    );
+}
+
 #[cfg(feature = "typst-math")]
 mod typst;

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -4796,6 +4796,23 @@ fn test_theme_sets_plot_typography_font_family() {
 }
 
 #[test]
+fn test_theme_and_font_family_follow_last_call_precedence() {
+    let theme = crate::render::Theme::publication();
+    let theme_family = crate::render::FontFamily::from(theme.font_family.as_str());
+
+    let theme_last = Plot::new()
+        .font_family("Explicit Font")
+        .theme(theme.clone());
+    assert_eq!(theme_last.get_config().typography.family, theme_family);
+
+    let font_last = Plot::new().theme(theme).font_family("Explicit Font");
+    assert_eq!(
+        font_last.get_config().typography.family,
+        crate::render::FontFamily::Name("Explicit Font".to_string())
+    );
+}
+
+#[test]
 fn test_plot_builder_font_family_forwards_to_plot() {
     let x = vec![0.0, 1.0, 2.0];
     let y = vec![0.0, 1.0, 4.0];

--- a/src/core/plot/tests/typst.rs
+++ b/src/core/plot/tests/typst.rs
@@ -48,3 +48,30 @@ fn test_invalid_typst_snippet_returns_typst_error() {
 
     assert!(matches!(result, Err(PlottingError::TypstError(_))));
 }
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn test_plot_to_typst_svg_applies_font_family() {
+    let x = vec![0.0, 1.0];
+    let y = vec![0.0, 1.0];
+    let render = |font_family| {
+        Plot::new()
+            .line(&x, &y)
+            .title("iiiiiiiiWWWW")
+            .font_family(font_family)
+            .typst(true)
+            .render_to_svg()
+            .expect("Typst SVG plot render should succeed")
+    };
+
+    let serif = render(crate::render::FontFamily::Name(
+        "Libertinus Serif".to_string(),
+    ));
+    let mono = render(crate::render::FontFamily::Name(
+        "DejaVu Sans Mono".to_string(),
+    ));
+
+    assert!(serif.contains(r#"data-ruviz-text-engine="typst""#));
+    assert!(mono.contains(r#"data-ruviz-text-engine="typst""#));
+    assert_ne!(serif, mono);
+}

--- a/src/export/svg.rs
+++ b/src/export/svg.rs
@@ -30,11 +30,18 @@ pub struct SvgRenderer {
     text_engine_mode: TextEngineMode,
     /// Plain text metrics for anchor conversion.
     text_renderer: TextRenderer,
+    /// Font family for plain SVG text and Typst-rendered SVG text.
+    font_family: FontFamily,
 }
 
 impl SvgRenderer {
     /// Create a new SVG renderer with specified dimensions
     pub fn new(width: f32, height: f32) -> Self {
+        Self::with_font_family(width, height, FontFamily::SansSerif)
+    }
+
+    /// Create a new SVG renderer with a specified text font family.
+    pub fn with_font_family(width: f32, height: f32, font_family: FontFamily) -> Self {
         Self {
             width,
             height,
@@ -48,6 +55,7 @@ impl SvgRenderer {
             ),
             text_engine_mode: TextEngineMode::Plain,
             text_renderer: TextRenderer::new(),
+            font_family,
         }
     }
 
@@ -87,6 +95,19 @@ impl SvgRenderer {
     /// Get text rendering backend mode.
     pub fn text_engine_mode(&self) -> TextEngineMode {
         self.text_engine_mode
+    }
+
+    /// Set the font family used by plain and Typst text rendering.
+    pub fn set_font_family<F>(&mut self, family: F)
+    where
+        F: Into<FontFamily>,
+    {
+        self.font_family = family.into();
+    }
+
+    /// Get the configured font family.
+    pub fn font_family(&self) -> &FontFamily {
+        &self.font_family
     }
 
     /// Map renderer font size to Typst size units.
@@ -191,8 +212,39 @@ impl SvgRenderer {
     }
 
     fn plain_text_metrics(&self, text: &str, font_size: f32) -> Result<TextPlacementMetrics> {
-        let config = FontConfig::new(FontFamily::SansSerif, font_size);
+        let config = FontConfig::new(self.font_family.clone(), font_size);
         self.text_renderer.measure_text_placement(text, &config)
+    }
+
+    fn escape_css_string(value: &str) -> String {
+        let mut escaped = String::with_capacity(value.len());
+        for character in value.chars() {
+            match character {
+                '\0' => escaped.push('\u{FFFD}'),
+                '"' | '\\' => {
+                    escaped.push('\\');
+                    escaped.push(character);
+                }
+                '\u{0001}'..='\u{001F}' | '\u{007F}' | '\u{FFFE}' | '\u{FFFF}' => {
+                    write!(escaped, "\\{:06X}", character as u32)
+                        .expect("writing CSS escape to String cannot fail");
+                }
+                _ => escaped.push(character),
+            }
+        }
+        escaped
+    }
+
+    fn escaped_font_family(&self) -> String {
+        let css_value = match &self.font_family {
+            FontFamily::Serif
+            | FontFamily::SansSerif
+            | FontFamily::Monospace
+            | FontFamily::Cursive
+            | FontFamily::Fantasy => self.font_family.as_str().to_string(),
+            FontFamily::Name(name) => format!("\"{}\"", Self::escape_css_string(name)),
+        };
+        self.escape_xml(&css_value)
     }
 
     fn measure_text_for_layout(&self, text: &str, font_size: f32) -> Result<(f32, f32)> {
@@ -204,12 +256,13 @@ impl SvgRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(font_size);
-                typst_text::measure_text(
+                typst_text::measure_text_with_font_family(
                     text,
                     size_pt,
                     Color::BLACK,
                     0.0,
                     TypstBackendKind::Svg,
+                    &self.font_family,
                     "SVG text measurement",
                 )
             }
@@ -530,10 +583,11 @@ impl SvgRenderer {
                 let escaped_text = self.escape_xml(text);
                 let metrics = self.plain_text_metrics(text, size)?;
                 let baseline_y = top_anchor_to_baseline(y, metrics);
+                let font_family = self.escaped_font_family();
                 writeln!(
                     self.content,
-                    r#"  <text x="{:.2}" y="{:.2}" font-family="sans-serif" font-size="{:.1}" fill="{}">{}</text>"#,
-                    x, baseline_y, size, color_str, escaped_text
+                    r#"  <text x="{:.2}" y="{:.2}" font-family="{}" font-size="{:.1}" fill="{}">{}</text>"#,
+                    x, baseline_y, font_family, size, color_str, escaped_text
                 )
                 .unwrap();
                 Ok(())
@@ -541,8 +595,14 @@ impl SvgRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
-                let rendered =
-                    typst_text::render_svg(text, size_pt, color, 0.0, "SVG text rendering")?;
+                let rendered = typst_text::render_svg_with_font_family(
+                    text,
+                    size_pt,
+                    color,
+                    0.0,
+                    &self.font_family,
+                    "SVG text rendering",
+                )?;
                 let (draw_x, draw_y) = typst_text::anchored_top_left(
                     x,
                     y,
@@ -578,10 +638,11 @@ impl SvgRenderer {
                 let escaped_text = self.escape_xml(text);
                 let metrics = self.plain_text_metrics(text, size)?;
                 let baseline_y = top_anchor_to_baseline(y, metrics);
+                let font_family = self.escaped_font_family();
                 writeln!(
                     self.content,
-                    r#"  <text x="{:.2}" y="{:.2}" font-family="sans-serif" font-size="{:.1}" fill="{}" text-anchor="middle">{}</text>"#,
-                    x, baseline_y, size, color_str, escaped_text
+                    r#"  <text x="{:.2}" y="{:.2}" font-family="{}" font-size="{:.1}" fill="{}" text-anchor="middle">{}</text>"#,
+                    x, baseline_y, font_family, size, color_str, escaped_text
                 )
                 .unwrap();
                 Ok(())
@@ -589,11 +650,12 @@ impl SvgRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
-                let rendered = typst_text::render_svg(
+                let rendered = typst_text::render_svg_with_font_family(
                     text,
                     size_pt,
                     color,
                     0.0,
+                    &self.font_family,
                     "SVG centered text rendering",
                 )?;
                 let (draw_x, draw_y) = typst_text::anchored_top_left(
@@ -631,10 +693,11 @@ impl SvgRenderer {
                 let escaped_text = self.escape_xml(text);
                 let metrics = self.plain_text_metrics(text, size)?;
                 let center_baseline_y = center_anchor_to_baseline(0.0, metrics);
+                let font_family = self.escaped_font_family();
                 writeln!(
                     self.content,
-                    r#"  <g transform="translate({:.2},{:.2}) rotate({:.1})"><text x="0" y="{:.2}" font-family="sans-serif" font-size="{:.1}" fill="{}" text-anchor="middle">{}</text></g>"#,
-                    x, y, angle, center_baseline_y, size, color_str, escaped_text
+                    r#"  <g transform="translate({:.2},{:.2}) rotate({:.1})"><text x="0" y="{:.2}" font-family="{}" font-size="{:.1}" fill="{}" text-anchor="middle">{}</text></g>"#,
+                    x, y, angle, center_baseline_y, font_family, size, color_str, escaped_text
                 )
                 .unwrap();
                 Ok(())
@@ -642,11 +705,12 @@ impl SvgRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
-                let rendered = typst_text::render_svg(
+                let rendered = typst_text::render_svg_with_font_family(
                     text,
                     size_pt,
                     color,
                     angle,
+                    &self.font_family,
                     "SVG rotated text rendering",
                 )?;
                 let (draw_x, draw_y) = typst_text::anchored_top_left(

--- a/src/export/svg/tests.rs
+++ b/src/export/svg/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-fn parse_svg_attr(line: &str, attr: &str) -> f32 {
+fn svg_attr_value<'a>(line: &'a str, attr: &str) -> &'a str {
     let marker = format!(r#"{}=""#, attr);
     let start = line
         .find(&marker)
@@ -10,7 +10,11 @@ fn parse_svg_attr(line: &str, attr: &str) -> f32 {
         .find('"')
         .unwrap_or_else(|| panic!("unterminated {} in line: {}", attr, line))
         + start;
-    line[start..end]
+    &line[start..end]
+}
+
+fn parse_svg_attr(line: &str, attr: &str) -> f32 {
+    svg_attr_value(line, attr)
         .parse::<f32>()
         .unwrap_or_else(|_| panic!("invalid {} in line: {}", attr, line))
 }
@@ -70,6 +74,104 @@ fn test_svg_renderer_creation() {
     let renderer = SvgRenderer::new(800.0, 600.0);
     assert_eq!(renderer.width(), 800.0);
     assert_eq!(renderer.height(), 600.0);
+}
+
+#[test]
+fn test_plain_svg_generic_font_families_are_unquoted() {
+    let cases = [
+        (FontFamily::Serif, "serif"),
+        (FontFamily::SansSerif, "sans-serif"),
+        (FontFamily::Monospace, "monospace"),
+        (FontFamily::Cursive, "cursive"),
+        (FontFamily::Fantasy, "fantasy"),
+    ];
+
+    for (family, expected) in cases {
+        let mut renderer = SvgRenderer::with_font_family(100.0, 100.0, family);
+        renderer
+            .draw_text("Label", 10.0, 20.0, 12.0, Color::BLACK)
+            .unwrap();
+
+        let svg = renderer.to_svg_string();
+        assert!(
+            svg.contains(&format!(r#"font-family="{expected}""#)),
+            "unexpected SVG font family: {svg}"
+        );
+    }
+}
+
+#[test]
+fn test_plain_svg_named_font_family_is_css_quoted() {
+    let mut renderer = SvgRenderer::with_font_family(
+        100.0,
+        100.0,
+        FontFamily::Name("New Computer Modern Sans".to_string()),
+    );
+    renderer
+        .draw_text("Label", 10.0, 20.0, 12.0, Color::BLACK)
+        .unwrap();
+
+    let svg = renderer.to_svg_string();
+    assert!(svg.contains(r#"font-family="&quot;New Computer Modern Sans&quot;""#));
+}
+
+#[test]
+fn test_plain_svg_named_generic_keyword_remains_quoted() {
+    let mut renderer =
+        SvgRenderer::with_font_family(100.0, 100.0, FontFamily::Name("serif".to_string()));
+    renderer
+        .draw_text("Label", 10.0, 20.0, 12.0, Color::BLACK)
+        .unwrap();
+
+    let svg = renderer.to_svg_string();
+    assert!(svg.contains(r#"font-family="&quot;serif&quot;""#));
+}
+
+#[test]
+fn test_plain_svg_named_font_family_css_and_xml_escaping() {
+    let mut renderer = SvgRenderer::with_font_family(
+        100.0,
+        100.0,
+        FontFamily::Name(r#"Font, "A"\B & <C>"#.to_string()),
+    );
+    renderer
+        .draw_text("Label", 10.0, 20.0, 12.0, Color::BLACK)
+        .unwrap();
+
+    let svg = renderer.to_svg_string();
+    assert!(svg.contains(r#"font-family="&quot;Font, \&quot;A\&quot;\\B &amp; &lt;C&gt;&quot;""#));
+}
+
+#[test]
+fn test_plain_svg_named_font_family_escapes_control_characters() {
+    let mut renderer = SvgRenderer::with_font_family(
+        100.0,
+        100.0,
+        FontFamily::Name(
+            "Line\nBreak\rReturn\tTab\u{000C}Form\0Null\u{0001}Unit\u{007F}Delete\u{FFFE}End"
+                .to_string(),
+        ),
+    );
+    renderer
+        .draw_text("Label", 10.0, 20.0, 12.0, Color::BLACK)
+        .unwrap();
+
+    let svg = renderer.to_svg_string();
+    let text_line = svg
+        .lines()
+        .find(|line| line.contains(">Label</text>"))
+        .expect("missing SVG text element");
+    let family = svg_attr_value(text_line, "font-family");
+
+    assert_eq!(
+        family,
+        r#"&quot;Line\00000ABreak\00000DReturn\000009Tab\00000CForm�Null\000001Unit\00007FDelete\00FFFEEnd&quot;"#
+    );
+    assert!(
+        family
+            .chars()
+            .all(|character| character >= ' ' && character != '\u{007F}')
+    );
 }
 
 #[test]

--- a/src/render/skia.rs
+++ b/src/render/skia.rs
@@ -153,7 +153,8 @@ pub struct SkiaRenderer {
 impl SkiaRenderer {
     /// Create a new renderer with the given dimensions
     pub fn new(width: u32, height: u32, theme: Theme) -> Result<Self> {
-        Self::with_font_family(width, height, theme, FontFamily::SansSerif)
+        let font_family = FontFamily::from(theme.font_family.as_str());
+        Self::with_font_family(width, height, theme, font_family)
     }
 
     /// Create a new renderer with specified font family
@@ -242,6 +243,19 @@ impl SkiaRenderer {
     /// Get text rendering backend mode.
     pub fn text_engine_mode(&self) -> TextEngineMode {
         self.text_engine_mode
+    }
+
+    /// Set the font family used by plain and Typst text rendering.
+    pub fn set_font_family<F>(&mut self, family: F)
+    where
+        F: Into<FontFamily>,
+    {
+        self.font_config.family = family.into();
+    }
+
+    /// Get the configured font family.
+    pub fn font_family(&self) -> &FontFamily {
+        &self.font_config.family
     }
 
     pub(crate) fn set_render_mode_diagnostics(&mut self, mode: &'static str) {
@@ -1240,8 +1254,14 @@ impl SkiaRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
-                let rendered =
-                    typst_text::render_raster(text, size_pt, color, 0.0, "Skia text rendering")?;
+                let rendered = typst_text::render_raster_with_font_family(
+                    text,
+                    size_pt,
+                    color,
+                    0.0,
+                    &self.font_config.family,
+                    "Skia text rendering",
+                )?;
                 let (draw_x, draw_y) = typst_text::anchored_top_left(
                     x,
                     y,
@@ -1273,11 +1293,12 @@ impl SkiaRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
-                let rendered = typst_text::render_raster(
+                let rendered = typst_text::render_raster_with_font_family(
                     text,
                     size_pt,
                     color,
                     -90.0,
+                    &self.font_config.family,
                     "Skia rotated text rendering",
                 )?;
                 let (draw_x, draw_y) = typst_text::anchored_top_left(
@@ -1318,11 +1339,12 @@ impl SkiaRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
-                let rendered = typst_text::render_raster(
+                let rendered = typst_text::render_raster_with_font_family(
                     text,
                     size_pt,
                     color,
                     0.0,
+                    &self.font_config.family,
                     "Skia centered text rendering",
                 )?;
                 let (draw_x, draw_y) = typst_text::anchored_top_left(
@@ -1348,12 +1370,13 @@ impl SkiaRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
-                typst_text::measure_text(
+                typst_text::measure_text_with_font_family(
                     text,
                     size_pt,
                     self.theme.foreground,
                     0.0,
                     TypstBackendKind::Raster,
+                    &self.font_config.family,
                     "Skia text measurement",
                 )
             }

--- a/src/render/skia/tests.rs
+++ b/src/render/skia/tests.rs
@@ -309,6 +309,15 @@ fn test_renderer_creation() {
 }
 
 #[test]
+fn test_renderer_uses_theme_font_family() {
+    let renderer = SkiaRenderer::new(800, 600, Theme::publication()).unwrap();
+    assert_eq!(
+        renderer.font_family(),
+        &FontFamily::Name("Times New Roman".to_string())
+    );
+}
+
+#[test]
 fn test_set_dpi_scale_sanitizes_invalid_values() {
     let theme = Theme::default();
     let mut renderer = SkiaRenderer::new(100, 100, theme).unwrap();

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -1005,6 +1005,8 @@ mod tests {
         assert_eq!(FontFamily::from("sans"), FontFamily::SansSerif);
         assert_eq!(FontFamily::from("monospace"), FontFamily::Monospace);
         assert_eq!(FontFamily::from("mono"), FontFamily::Monospace);
+        assert_eq!(FontFamily::from("cursive"), FontFamily::Cursive);
+        assert_eq!(FontFamily::from("fantasy"), FontFamily::Fantasy);
         assert_eq!(
             FontFamily::from("Arial"),
             FontFamily::Name("Arial".to_string())
@@ -1016,7 +1018,21 @@ mod tests {
         assert_eq!(FontFamily::Serif.as_str(), "serif");
         assert_eq!(FontFamily::SansSerif.as_str(), "sans-serif");
         assert_eq!(FontFamily::Monospace.as_str(), "monospace");
+        assert_eq!(FontFamily::Cursive.as_str(), "cursive");
+        assert_eq!(FontFamily::Fantasy.as_str(), "fantasy");
         assert_eq!(FontFamily::Name("Roboto".to_string()).as_str(), "Roboto");
+    }
+
+    #[test]
+    fn test_font_family_to_cosmic_generic_mapping() {
+        assert!(matches!(
+            FontFamily::Cursive.to_cosmic_family(),
+            Family::Cursive
+        ));
+        assert!(matches!(
+            FontFamily::Fantasy.to_cosmic_family(),
+            Family::Fantasy
+        ));
     }
 
     #[test]

--- a/src/render/theme.rs
+++ b/src/render/theme.rs
@@ -502,14 +502,9 @@ impl Theme {
         use super::FontFamily;
         use crate::core::config::TypographyConfig;
 
-        // Determine FontFamily from font_family string
-        let family = match self.font_family.to_lowercase().as_str() {
-            s if s.contains("serif") && !s.contains("sans") => FontFamily::Serif,
-            s if s.contains("mono") || s.contains("courier") || s.contains("consolas") => {
-                FontFamily::Monospace
-            }
-            _ => FontFamily::SansSerif,
-        };
+        // Preserve exact font family names while keeping generic CSS family
+        // names mapped to their corresponding portable family.
+        let family = FontFamily::from(self.font_family.as_str());
 
         TypographyConfig {
             base_size: self.font_size,
@@ -711,6 +706,23 @@ mod tests {
         assert_eq!(publication.font_family, "Times New Roman");
         assert_eq!(minimal.font_family, "Helvetica");
         assert!(colorblind.colorblind_friendly);
+    }
+
+    #[test]
+    fn test_theme_typography_preserves_named_font_families() {
+        let publication = Theme::publication().to_typography_config();
+        let minimal = Theme::minimal().to_typography_config();
+        let ieee = Theme::ieee().to_typography_config();
+
+        assert_eq!(
+            publication.family,
+            crate::render::FontFamily::Name("Times New Roman".to_string())
+        );
+        assert_eq!(
+            minimal.family,
+            crate::render::FontFamily::Name("Helvetica".to_string())
+        );
+        assert_eq!(ieee.family, crate::render::FontFamily::Serif);
     }
 
     #[test]

--- a/src/render/typst_text.rs
+++ b/src/render/typst_text.rs
@@ -1,7 +1,7 @@
 use crate::{
     core::{PlottingError, Result},
     render::{
-        Color,
+        Color, FontFamily,
         text_anchor::{TextAnchorKind, anchor_to_top_left},
     },
 };
@@ -85,11 +85,41 @@ pub fn render_raster(
 }
 
 #[cfg(not(feature = "typst-math"))]
+pub fn render_raster_with_font_family(
+    _snippet: &str,
+    _size_pt: f32,
+    _color: Color,
+    _rotation_deg: f32,
+    _font_family: &FontFamily,
+    operation: &str,
+) -> Result<TypstRasterOutput> {
+    Err(PlottingError::FeatureNotEnabled {
+        feature: "typst-math".to_string(),
+        operation: operation.to_string(),
+    })
+}
+
+#[cfg(not(feature = "typst-math"))]
 pub fn render_svg(
     _snippet: &str,
     _size_pt: f32,
     _color: Color,
     _rotation_deg: f32,
+    operation: &str,
+) -> Result<TypstSvgOutput> {
+    Err(PlottingError::FeatureNotEnabled {
+        feature: "typst-math".to_string(),
+        operation: operation.to_string(),
+    })
+}
+
+#[cfg(not(feature = "typst-math"))]
+pub fn render_svg_with_font_family(
+    _snippet: &str,
+    _size_pt: f32,
+    _color: Color,
+    _rotation_deg: f32,
+    _font_family: &FontFamily,
     operation: &str,
 ) -> Result<TypstSvgOutput> {
     Err(PlottingError::FeatureNotEnabled {
@@ -113,12 +143,28 @@ pub fn measure_text(
     })
 }
 
+#[cfg(not(feature = "typst-math"))]
+pub fn measure_text_with_font_family(
+    _snippet: &str,
+    _size_pt: f32,
+    _color: Color,
+    _rotation_deg: f32,
+    _backend: TypstBackendKind,
+    _font_family: &FontFamily,
+    operation: &str,
+) -> Result<(f32, f32)> {
+    Err(PlottingError::FeatureNotEnabled {
+        feature: "typst-math".to_string(),
+        operation: operation.to_string(),
+    })
+}
+
 #[cfg(feature = "typst-math")]
 mod imp {
     use super::{TypstBackendKind, TypstRasterOutput, TypstSvgOutput};
     use crate::{
         core::{PlottingError, Result},
-        render::Color,
+        render::{Color, FontFamily},
     };
     use std::{
         collections::HashMap,
@@ -149,6 +195,7 @@ mod imp {
         color: (u8, u8, u8, u8),
         rotation_bits: u32,
         backend: TypstBackendKind,
+        font_family: String,
     }
 
     #[derive(Debug, Clone)]
@@ -178,6 +225,8 @@ mod imp {
         book: LazyHash<FontBook>,
         fonts: Vec<FontSlot>,
         sans_family: String,
+        serif_family: String,
+        mono_family: String,
     }
 
     #[derive(Debug)]
@@ -233,29 +282,76 @@ mod imp {
         FONTS.get_or_init(|| {
             let mut searcher = FontSearcher::new();
             let found = searcher.search();
-            let sans_family = select_sans_family(&found.book);
+            let sans_family = select_family(
+                &found.book,
+                &[
+                    "noto sans",
+                    "dejavu sans",
+                    "liberation sans",
+                    "arial",
+                    "helvetica",
+                    "new computer modern sans",
+                    "latin modern sans",
+                ],
+                "sans",
+                "New Computer Modern Sans",
+            );
+            let serif_family = select_family(
+                &found.book,
+                &[
+                    "new computer modern",
+                    "latin modern roman",
+                    "times new roman",
+                    "noto serif",
+                    "dejavu serif",
+                    "liberation serif",
+                    "georgia",
+                ],
+                "serif",
+                "New Computer Modern",
+            );
+            let mono_family = select_family(
+                &found.book,
+                &[
+                    "new computer modern mono",
+                    "latin modern mono",
+                    "noto sans mono",
+                    "dejavu sans mono",
+                    "liberation mono",
+                    "courier new",
+                    "monaco",
+                ],
+                "mono",
+                "New Computer Modern Mono",
+            );
             FontContext {
                 book: LazyHash::new(found.book),
                 fonts: found.fonts,
                 sans_family,
+                serif_family,
+                mono_family,
             }
         })
     }
 
-    fn select_sans_family(book: &FontBook) -> String {
-        const PREFERRED: &[&str] = &[
-            "noto sans",
-            "dejavu sans",
-            "liberation sans",
-            "arial",
-            "helvetica",
-            "new computer modern sans",
-            "latin modern sans",
-        ];
+    fn canonical_family_name<'a>(book: &'a FontBook, requested: &str) -> Option<&'a str> {
+        let requested = requested.to_lowercase();
+        book.select_family(&requested)
+            .next()
+            .and_then(|index| book.info(index))
+            .map(|info| info.family.as_str())
+    }
 
-        for candidate in PREFERRED {
-            if book.contains_family(candidate) {
-                return (*candidate).to_string();
+    fn select_family(
+        book: &FontBook,
+        preferred: &[&str],
+        fallback_fragment: &str,
+        final_fallback: &str,
+    ) -> String {
+        let fallback_fragment = fallback_fragment.to_ascii_lowercase();
+        for candidate in preferred {
+            if let Some(family) = canonical_family_name(book, candidate) {
+                return family.to_string();
             }
         }
 
@@ -264,12 +360,64 @@ mod imp {
             if first_family.is_none() {
                 first_family = Some(family.to_string());
             }
-            if family.to_ascii_lowercase().contains("sans") {
+            if family.to_ascii_lowercase().contains(&fallback_fragment) {
                 return family.to_string();
             }
         }
 
-        first_family.unwrap_or_else(|| "New Computer Modern Sans".to_string())
+        first_family.unwrap_or_else(|| final_fallback.to_string())
+    }
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum GenericFontFamily {
+        SansSerif,
+        Serif,
+        Monospace,
+    }
+
+    fn inferred_generic_family_for_name(name: &str) -> GenericFontFamily {
+        let lowered = name.to_ascii_lowercase();
+        if lowered.contains("mono")
+            || lowered.contains("courier")
+            || lowered.contains("consolas")
+            || lowered.contains("menlo")
+        {
+            GenericFontFamily::Monospace
+        } else if lowered.contains("sans") {
+            GenericFontFamily::SansSerif
+        } else if lowered.contains("serif")
+            || lowered.contains("times")
+            || lowered.contains("georgia")
+            || lowered.contains("cambria")
+            || lowered.contains("garamond")
+        {
+            GenericFontFamily::Serif
+        } else {
+            GenericFontFamily::SansSerif
+        }
+    }
+
+    fn fallback_family(font_ctx: &FontContext, generic: GenericFontFamily) -> &str {
+        match generic {
+            GenericFontFamily::SansSerif => &font_ctx.sans_family,
+            GenericFontFamily::Serif => &font_ctx.serif_family,
+            GenericFontFamily::Monospace => &font_ctx.mono_family,
+        }
+    }
+
+    fn resolve_typst_font_family(font_ctx: &FontContext, family: &FontFamily) -> String {
+        match family {
+            FontFamily::Serif => font_ctx.serif_family.clone(),
+            FontFamily::Monospace => font_ctx.mono_family.clone(),
+            FontFamily::SansSerif | FontFamily::Cursive | FontFamily::Fantasy => {
+                font_ctx.sans_family.clone()
+            }
+            FontFamily::Name(name) => canonical_family_name(&font_ctx.book, name)
+                .map(str::to_string)
+                .unwrap_or_else(|| {
+                    fallback_family(font_ctx, inferred_generic_family_for_name(name)).to_string()
+                }),
+        }
     }
 
     fn escape_typst_string(value: &str) -> String {
@@ -303,12 +451,24 @@ mod imp {
         rotation_deg: f32,
         backend: TypstBackendKind,
     ) -> CacheKey {
+        make_key_with_font_family(snippet, size_pt, color, rotation_deg, backend, "")
+    }
+
+    fn make_key_with_font_family(
+        snippet: &str,
+        size_pt: f32,
+        color: Color,
+        rotation_deg: f32,
+        backend: TypstBackendKind,
+        font_family: &str,
+    ) -> CacheKey {
         CacheKey {
             snippet: snippet.to_string(),
             size_bits: size_pt.to_bits(),
             color: (color.r, color.g, color.b, color.a),
             rotation_bits: rotation_deg.to_bits(),
             backend,
+            font_family: font_family.to_string(),
         }
     }
 
@@ -434,11 +594,11 @@ mod imp {
         size_pt: f32,
         color: Color,
         rotation_deg: f32,
+        font_family: &str,
         operation: &str,
     ) -> Result<Page> {
         let font_ctx = fonts();
-        let source_text =
-            build_document_source(snippet, size_pt, color, rotation_deg, &font_ctx.sans_family);
+        let source_text = build_document_source(snippet, size_pt, color, rotation_deg, font_family);
         let main = FileId::new_fake(VirtualPath::new("/main.typ"));
         let source = Source::new(main, source_text);
         let world = TypstWorld {
@@ -480,6 +640,24 @@ mod imp {
         rotation_deg: f32,
         operation: &str,
     ) -> Result<TypstRasterOutput> {
+        render_raster_with_font_family(
+            snippet,
+            size_pt,
+            color,
+            rotation_deg,
+            &FontFamily::SansSerif,
+            operation,
+        )
+    }
+
+    pub fn render_raster_with_font_family(
+        snippet: &str,
+        size_pt: f32,
+        color: Color,
+        rotation_deg: f32,
+        font_family: &FontFamily,
+        operation: &str,
+    ) -> Result<TypstRasterOutput> {
         if snippet.trim().is_empty() {
             let pixmap = Pixmap::new(1, 1).ok_or_else(|| {
                 PlottingError::RenderError("Failed to allocate pixmap".to_string())
@@ -491,12 +669,15 @@ mod imp {
             });
         }
 
-        let key = make_key(
+        let font_ctx = fonts();
+        let resolved_font_family = resolve_typst_font_family(font_ctx, font_family);
+        let key = make_key_with_font_family(
             snippet,
             size_pt,
             color,
             rotation_deg,
             TypstBackendKind::Raster,
+            &resolved_font_family,
         );
 
         {
@@ -525,7 +706,14 @@ mod imp {
             }
         }
 
-        let page = compile_single_page(snippet, size_pt, color, rotation_deg, operation)?;
+        let page = compile_single_page(
+            snippet,
+            size_pt,
+            color,
+            rotation_deg,
+            &resolved_font_family,
+            operation,
+        )?;
         let size = page.frame.size();
         let logical_width = size.x.to_pt() as f32;
         let logical_height = size.y.to_pt() as f32;
@@ -576,6 +764,24 @@ mod imp {
         rotation_deg: f32,
         operation: &str,
     ) -> Result<TypstSvgOutput> {
+        render_svg_with_font_family(
+            snippet,
+            size_pt,
+            color,
+            rotation_deg,
+            &FontFamily::SansSerif,
+            operation,
+        )
+    }
+
+    pub fn render_svg_with_font_family(
+        snippet: &str,
+        size_pt: f32,
+        color: Color,
+        rotation_deg: f32,
+        font_family: &FontFamily,
+        operation: &str,
+    ) -> Result<TypstSvgOutput> {
         if snippet.trim().is_empty() {
             return Ok(TypstSvgOutput {
                 svg: String::new(),
@@ -584,7 +790,16 @@ mod imp {
             });
         }
 
-        let key = make_key(snippet, size_pt, color, rotation_deg, TypstBackendKind::Svg);
+        let font_ctx = fonts();
+        let resolved_font_family = resolve_typst_font_family(font_ctx, font_family);
+        let key = make_key_with_font_family(
+            snippet,
+            size_pt,
+            color,
+            rotation_deg,
+            TypstBackendKind::Svg,
+            &resolved_font_family,
+        );
         {
             let cache = lock_cache()?;
             if let Some(CachedValue::Svg { svg, width, height }) = cache.entries.get(&key) {
@@ -596,7 +811,14 @@ mod imp {
             }
         }
 
-        let page = compile_single_page(snippet, size_pt, color, rotation_deg, operation)?;
+        let page = compile_single_page(
+            snippet,
+            size_pt,
+            color,
+            rotation_deg,
+            &resolved_font_family,
+            operation,
+        )?;
         let raw_svg = typst_svg::svg(&page);
         let size = page.frame.size();
         let width = size.x.to_pt() as f32;
@@ -632,13 +854,47 @@ mod imp {
         backend: TypstBackendKind,
         operation: &str,
     ) -> Result<(f32, f32)> {
+        measure_text_with_font_family(
+            snippet,
+            size_pt,
+            color,
+            rotation_deg,
+            backend,
+            &FontFamily::SansSerif,
+            operation,
+        )
+    }
+
+    pub fn measure_text_with_font_family(
+        snippet: &str,
+        size_pt: f32,
+        color: Color,
+        rotation_deg: f32,
+        backend: TypstBackendKind,
+        font_family: &FontFamily,
+        operation: &str,
+    ) -> Result<(f32, f32)> {
         match backend {
             TypstBackendKind::Raster => {
-                let rendered = render_raster(snippet, size_pt, color, rotation_deg, operation)?;
+                let rendered = render_raster_with_font_family(
+                    snippet,
+                    size_pt,
+                    color,
+                    rotation_deg,
+                    font_family,
+                    operation,
+                )?;
                 Ok((rendered.width, rendered.height))
             }
             TypstBackendKind::Svg => {
-                let rendered = render_svg(snippet, size_pt, color, rotation_deg, operation)?;
+                let rendered = render_svg_with_font_family(
+                    snippet,
+                    size_pt,
+                    color,
+                    rotation_deg,
+                    font_family,
+                    operation,
+                )?;
                 Ok((rendered.width, rendered.height))
             }
         }
@@ -659,6 +915,174 @@ mod imp {
             let err = lock_cache_resource(&mutex, "test cache").unwrap_err();
             assert!(matches!(err, PlottingError::TypstError(_)));
             assert!(err.to_string().contains("test cache lock is poisoned"));
+        }
+
+        fn swap_ascii_case(value: &str) -> String {
+            value
+                .chars()
+                .map(|character| {
+                    if character.is_ascii_lowercase() {
+                        character.to_ascii_uppercase()
+                    } else {
+                        character.to_ascii_lowercase()
+                    }
+                })
+                .collect()
+        }
+
+        #[test]
+        fn named_family_resolution_is_case_insensitive_and_canonical() {
+            let font_ctx = fonts();
+            let canonical = font_ctx
+                .book
+                .families()
+                .next()
+                .map(|(family, _)| family.to_string())
+                .expect("Typst font search should find at least one family");
+            let requested = swap_ascii_case(&canonical);
+
+            let resolved = resolve_typst_font_family(font_ctx, &FontFamily::Name(requested));
+
+            assert_eq!(resolved, canonical);
+        }
+
+        #[test]
+        fn supported_generic_families_resolve_to_selected_canonical_families() {
+            let font_ctx = fonts();
+
+            assert_eq!(
+                resolve_typst_font_family(font_ctx, &FontFamily::Serif),
+                font_ctx.serif_family
+            );
+            assert_eq!(
+                resolve_typst_font_family(font_ctx, &FontFamily::SansSerif),
+                font_ctx.sans_family
+            );
+            assert_eq!(
+                resolve_typst_font_family(font_ctx, &FontFamily::Monospace),
+                font_ctx.mono_family
+            );
+        }
+
+        #[test]
+        fn unsupported_typst_generic_families_use_sans_serif_fallback() {
+            let font_ctx = fonts();
+
+            for family in [FontFamily::Cursive, FontFamily::Fantasy] {
+                assert_eq!(
+                    resolve_typst_font_family(font_ctx, &family),
+                    font_ctx.sans_family
+                );
+            }
+        }
+
+        #[test]
+        fn typst_svg_render_applies_distinct_available_families() {
+            let snippet = "#text(\"iiiiiiiiWWWW\")";
+            let serif = render_svg_with_font_family(
+                snippet,
+                18.0,
+                Color::BLACK,
+                0.0,
+                &FontFamily::Name("Libertinus Serif".to_string()),
+                "serif test render",
+            )
+            .expect("embedded serif Typst render should succeed");
+            let mono = render_svg_with_font_family(
+                snippet,
+                18.0,
+                Color::BLACK,
+                0.0,
+                &FontFamily::Name("DejaVu Sans Mono".to_string()),
+                "monospace test render",
+            )
+            .expect("embedded monospace Typst render should succeed");
+
+            assert_ne!(serif.svg, mono.svg);
+        }
+
+        #[test]
+        fn canonical_family_spelling_produces_the_same_cache_key_and_source() {
+            let font_ctx = fonts();
+            let canonical = font_ctx.sans_family.clone();
+            let differently_cased = swap_ascii_case(&canonical);
+            let resolved_canonical =
+                resolve_typst_font_family(font_ctx, &FontFamily::Name(canonical.clone()));
+            let resolved_differently_cased =
+                resolve_typst_font_family(font_ctx, &FontFamily::Name(differently_cased));
+
+            let canonical_key = make_key_with_font_family(
+                "#text(\"a\")",
+                12.0,
+                Color::BLACK,
+                0.0,
+                TypstBackendKind::Svg,
+                &resolved_canonical,
+            );
+            let differently_cased_key = make_key_with_font_family(
+                "#text(\"a\")",
+                12.0,
+                Color::BLACK,
+                0.0,
+                TypstBackendKind::Svg,
+                &resolved_differently_cased,
+            );
+            let other_family_key = make_key_with_font_family(
+                "#text(\"a\")",
+                12.0,
+                Color::BLACK,
+                0.0,
+                TypstBackendKind::Svg,
+                "Definitely Different Family",
+            );
+            let source = build_document_source(
+                "#text(\"a\")",
+                12.0,
+                Color::BLACK,
+                0.0,
+                &resolved_differently_cased,
+            );
+
+            assert_eq!(resolved_canonical, canonical);
+            assert_eq!(resolved_differently_cased, canonical);
+            assert_eq!(canonical_key, differently_cased_key);
+            assert_ne!(canonical_key, other_family_key);
+            assert!(source.contains(&format!("font: \"{}\"", escape_typst_string(&canonical))));
+        }
+
+        #[test]
+        fn document_source_escapes_named_family_for_typst_string() {
+            let source = build_document_source(
+                "Label",
+                12.0,
+                Color::BLACK,
+                0.0,
+                r#"Family "Quoted" \ Path"#,
+            );
+
+            assert!(source.contains(r#"font: "Family \"Quoted\" \\ Path""#));
+        }
+
+        #[test]
+        fn missing_named_font_falls_back_by_family_hint() {
+            let font_ctx = fonts();
+
+            let serif = resolve_typst_font_family(
+                font_ctx,
+                &FontFamily::Name("Definitely Missing Serif".to_string()),
+            );
+            let sans = resolve_typst_font_family(
+                font_ctx,
+                &FontFamily::Name("Definitely Missing Sans-Serif".to_string()),
+            );
+            let mono = resolve_typst_font_family(
+                font_ctx,
+                &FontFamily::Name("Definitely Missing Mono".to_string()),
+            );
+
+            assert_eq!(serif, font_ctx.serif_family);
+            assert_eq!(sans, font_ctx.sans_family);
+            assert_eq!(mono, font_ctx.mono_family);
         }
 
         #[test]
@@ -771,4 +1195,7 @@ mod imp {
 }
 
 #[cfg(feature = "typst-math")]
-pub use imp::{measure_text, render_raster, render_svg};
+pub use imp::{
+    measure_text, measure_text_with_font_family, render_raster, render_raster_with_font_family,
+    render_svg, render_svg_with_font_family,
+};


### PR DESCRIPTION
## Summary

- propagate the configured font family through raster, SVG, parallel, interactive, and Typst rendering paths
- keep theme and builder font selection consistent across backends
- update documentation and gallery coverage for runtime font selection

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo test --all-features`
- verified again in the clean P00-P18 aggregate integration matrix

This is P00 and the base of the dependency-aware backlog PR series.