### PR TITLE
Fix ndarray feature contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,52 @@ jobs:
       - name: Run doc tests
         run: cargo test --doc --verbose
 
+  test-feature-contract:
+    name: Feature Contract (${{ matrix.contract.name }})
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    strategy:
+      fail-fast: false
+      matrix:
+        contract:
+          - name: No defaults + Typst disabled
+            cache-key: no-default
+            command: cargo test --test typst_feature_gate_ui --no-default-features typst_requires_feature -- --exact
+          - name: ndarray_support
+            cache-key: ndarray-support
+            command: cargo test --test data_format_compatibility_test --no-default-features --features ndarray_support test_ndarray_data -- --exact
+          - name: ndarray legacy alias
+            cache-key: ndarray-alias
+            command: cargo test --test data_format_compatibility_test --no-default-features --features ndarray test_ndarray_data -- --exact
+          - name: Typst enabled
+            cache-key: typst-math
+            command: >-
+              cargo test --test typst_feature_gate_ui --no-default-features --features typst-math typst_with_feature_compiles -- --exact &&
+              cargo test --lib --no-default-features --features typst-math core::plot::tests::typst::test_invalid_typst_snippet_returns_typst_error -- --exact
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.94.1
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-feature-contract-${{ matrix.contract.cache-key }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Create test output directory
+        run: mkdir -p generated/tests/render
+
+      - name: Verify feature contract
+        run: ${{ matrix.contract.command }}
+
   test-visual-heavy:
     name: Test Visual Heavy Lane
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ sha2 = "0.10"
 plotters = { version = "0.3.7", default-features = false, features = ["bitmap_backend", "line_series"] }
 
 [features]
-default = ["ndarray", "parallel"]
+default = ["ndarray_support", "parallel"]
 
 # Display and window features
 window = ["winit", "raw-window-handle", "dep:softbuffer", "dep:rfd", "dep:arboard"]
@@ -151,10 +151,11 @@ interactive-gpu = ["interactive", "gpu"]  # Interactive mode WITH GPU accelerati
 serde = ["dep:serde", "serde_json", "palette/serde"]
 
 # Data format support
-ndarray_support = ["ndarray"]
+ndarray_support = ["dep:ndarray"]
 polars_support = ["polars"]
 nalgebra_support = ["dep:nalgebra"]
-# Backward-compatibility alias (historical feature name)
+# Backward-compatibility aliases (historical feature names)
+ndarray = ["ndarray_support"]
 nalgebra = ["nalgebra_support"]
 
 # Performance optimization features

--- a/README.md
+++ b/README.md
@@ -119,11 +119,12 @@ helpers.
 
 ## Feature Flags
 
-Default features are `ndarray` and `parallel`.
+Default features are `ndarray_support` and `parallel`.
 
 | Feature | Description |
 |---------|-------------|
-| `ndarray_support` | ndarray data support |
+| `ndarray_support` | ndarray data support (canonical) |
+| `ndarray` | compatibility alias for `ndarray_support` |
 | `polars_support` | polars data support |
 | `nalgebra_support` | nalgebra data support |
 | `parallel` | enables the internal parallel renderer and backend metadata |

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -9,16 +9,39 @@ Use this lane for PR gating and quick local iteration.
 
 ```bash
 # 1) Unit tests
-cargo test --lib
+cargo test --lib --verbose
 
 # 2) Integration compile gate
-cargo test --tests --no-run
+cargo test --tests --no-run --verbose
 
 # 3) Fast deterministic integration suites
-cargo test --test simple_api_test --test data_format_compatibility_test --test backend_parity_test
+cargo test --test simple_api_test --test data_format_compatibility_test --test backend_parity_test --verbose
 
 # 4) Doctests
-cargo test --doc
+cargo test --doc --verbose
+```
+
+The fast integration command proves the default `ndarray_support` + `parallel`
+configuration, including the `test_ndarray_data` runtime test.
+
+### Feature-contract matrix (default CI)
+
+Use these focused rows when changing Cargo feature gates. The matrix avoids
+rerunning the full default suite, which is already covered by the fast lane.
+
+```bash
+# No default features; Typst APIs must remain gated off
+cargo test --test typst_feature_gate_ui --no-default-features typst_requires_feature -- --exact
+
+# Canonical ndarray feature
+cargo test --test data_format_compatibility_test --no-default-features --features ndarray_support test_ndarray_data -- --exact
+
+# Backward-compatible ndarray feature alias
+cargo test --test data_format_compatibility_test --no-default-features --features ndarray test_ndarray_data -- --exact
+
+# Typst APIs enabled and a runtime error path exercised
+cargo test --test typst_feature_gate_ui --no-default-features --features typst-math typst_with_feature_compiles -- --exact
+cargo test --lib --no-default-features --features typst-math core::plot::tests::typst::test_invalid_typst_snippet_returns_typst_error -- --exact
 ```
 
 ### Visual/heavy lane (manual or scheduled)

--- a/benchmarks/plotting/run_rust_features.py
+++ b/benchmarks/plotting/run_rust_features.py
@@ -19,7 +19,7 @@ FEATURE_MATRIX = [
     },
     {
         "label": "default",
-        "cargoFeatures": ["ndarray", "parallel", "serde"],
+        "cargoFeatures": ["ndarray_support", "parallel", "serde"],
         "cargoArgs": ["--features", "serde"],
         "requestGpu": False,
     },

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -79,18 +79,19 @@ ruviz uses feature flags to enable optional functionality. Choose based on your 
 ### Default Features
 
 ```toml
-ruviz = "0.4.19"  # Includes: ndarray, parallel
+ruviz = "0.4.19"  # Includes: ndarray_support, parallel
 ```
 
 **Enabled by default**:
-- `ndarray` - ndarray support for scientific computing
+- `ndarray_support` - ndarray support for scientific computing
 - `parallel` - internal parallel renderer support and backend metadata
 
 ### Core Features
 
 | Feature | Description | Use Case |
 |---------|-------------|----------|
-| `ndarray_support` | ndarray integration | Scientific computing, numpy-like arrays |
+| `ndarray_support` | ndarray integration (canonical) | Scientific computing, numpy-like arrays |
+| `ndarray` | Compatibility alias for `ndarray_support` | Existing manifests using the historical name |
 | `nalgebra_support` | nalgebra integration | Dense vectors/matrices, linear algebra |
 | `polars_support` | polars integration | Data analysis, DataFrame support |
 | `parallel` | Internal parallel renderer support | Opt-in renderer experiments, metadata |
@@ -230,7 +231,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 **Settings** (`.vscode/settings.json`):
 ```json
 {
-  "rust-analyzer.cargo.features": ["ndarray", "parallel"],
+  "rust-analyzer.cargo.features": ["ndarray_support", "parallel"],
   "rust-analyzer.checkOnSave.command": "clippy"
 }
 ```
@@ -252,7 +253,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 **Configuration** (with coc.nvim):
 ```json
 {
-  "rust-analyzer.cargo.features": ["ndarray", "parallel"]
+  "rust-analyzer.cargo.features": ["ndarray_support", "parallel"]
 }
 ```
 

--- a/examples/performance/plotting_benchmark_runner.rs
+++ b/examples/performance/plotting_benchmark_runner.rs
@@ -1199,8 +1199,8 @@ fn detect_compiled_features() -> Vec<String> {
     if cfg!(feature = "gpu") {
         features.push("gpu".to_string());
     }
-    if cfg!(feature = "ndarray") {
-        features.push("ndarray".to_string());
+    if cfg!(feature = "ndarray_support") {
+        features.push("ndarray_support".to_string());
     }
     if cfg!(feature = "serde") {
         features.push("serde".to_string());

--- a/tests/data_format_compatibility_test.rs
+++ b/tests/data_format_compatibility_test.rs
@@ -76,7 +76,7 @@ fn test_integer_data() {
 }
 
 #[test]
-#[cfg(feature = "ndarray_support")]
+#[cfg(any(feature = "ndarray_support", feature = "ndarray"))]
 fn test_ndarray_data() {
     use ndarray::Array1;
 


### PR DESCRIPTION
## Summary

- make the documented ndarray feature names map to the intended optional dependency
- preserve the legacy feature alias without enabling unrelated defaults
- cover no-default and ndarray-only consumer configurations

## Validation

- `cargo test --lib --no-default-features`
- `cargo test --lib --no-default-features --features ndarray_support`
- `cargo test --lib --no-default-features --features ndarray`
- aggregate all-feature verification

Depends on #76.