### PR TITLE
Validate margins and honor subplot DPI

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -27,6 +27,7 @@
 //! ```
 
 use crate::core::units::{REFERENCE_DPI, RenderScale, in_to_px, pt_to_px, px_to_in};
+use crate::core::{PlottingError, Result};
 use crate::render::{FontFamily, FontWeight};
 
 // =============================================================================
@@ -498,6 +499,108 @@ impl MarginConfig {
             center_plot,
         }
     }
+
+    /// Validate margin values against the configured figure dimensions.
+    pub(crate) fn validate_for_figure(&self, figure: &FigureConfig) -> Result<()> {
+        fn invalid(message: impl Into<String>) -> PlottingError {
+            PlottingError::InvalidInput(message.into())
+        }
+
+        fn validate_non_negative(values: &[(&str, f32)], mode: &str) -> Result<()> {
+            for (name, value) in values {
+                if !value.is_finite() || *value < 0.0 {
+                    return Err(invalid(format!(
+                        "{mode} margin {name} must be a finite, non-negative value ({name}={value})"
+                    )));
+                }
+            }
+            Ok(())
+        }
+
+        match self {
+            MarginConfig::Proportional {
+                left,
+                right,
+                top,
+                bottom,
+            } => {
+                validate_non_negative(
+                    &[
+                        ("left", *left),
+                        ("right", *right),
+                        ("top", *top),
+                        ("bottom", *bottom),
+                    ],
+                    "Proportional",
+                )?;
+                if left + right >= 1.0 || top + bottom >= 1.0 {
+                    return Err(invalid(format!(
+                        "Opposing proportional margins must sum to less than 1 (left+right={}, top+bottom={})",
+                        left + right,
+                        top + bottom
+                    )));
+                }
+            }
+            MarginConfig::Auto { min, max } => {
+                validate_non_negative(&[("min", *min), ("max", *max)], "Auto")?;
+                if min > max {
+                    return Err(invalid(format!(
+                        "Auto margin minimum must not exceed maximum (min={min}, max={max})"
+                    )));
+                }
+                if 2.0 * min >= figure.width || 2.0 * min >= figure.height {
+                    return Err(invalid(format!(
+                        "Auto margin minimum must leave positive figure space (min={min}, width={}, height={})",
+                        figure.width, figure.height
+                    )));
+                }
+            }
+            MarginConfig::Fixed {
+                left,
+                right,
+                top,
+                bottom,
+            } => {
+                validate_non_negative(
+                    &[
+                        ("left", *left),
+                        ("right", *right),
+                        ("top", *top),
+                        ("bottom", *bottom),
+                    ],
+                    "Fixed",
+                )?;
+                if left + right >= figure.width || top + bottom >= figure.height {
+                    return Err(invalid(format!(
+                        "Opposing fixed margins must leave positive figure space (left+right={}, top+bottom={}, width={}, height={})",
+                        left + right,
+                        top + bottom,
+                        figure.width,
+                        figure.height
+                    )));
+                }
+            }
+            MarginConfig::ContentDriven { edge_buffer, .. } => {
+                validate_non_negative(&[("edge_buffer", *edge_buffer)], "Content-driven")?;
+                let edge_buffer_px = pt_to_px(*edge_buffer, figure.dpi);
+                if !edge_buffer_px.is_finite() {
+                    return Err(invalid(format!(
+                        "Content-driven margin edge_buffer is out of pixel range (edge_buffer={edge_buffer}, dpi={})",
+                        figure.dpi
+                    )));
+                }
+                let edge_buffer_in = *edge_buffer / crate::core::POINTS_PER_INCH;
+                if edge_buffer_in >= figure.width / 2.0 || edge_buffer_in >= figure.height / 2.0 {
+                    return Err(invalid(format!(
+                        "Content-driven margin edge_buffer must leave positive figure space (edge_buffer={edge_buffer}, width={}, height={})",
+                        figure.width, figure.height
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 impl Default for MarginConfig {
@@ -795,14 +898,20 @@ impl PlotConfig {
                 }
             }
             MarginConfig::Auto { min, max } => {
+                let (min, max) =
+                    if min.is_finite() && max.is_finite() && *min >= 0.0 && *min <= *max {
+                        (*min, *max)
+                    } else {
+                        (0.3, 1.0)
+                    };
                 // Estimate top margin based on title
                 let top = if has_title {
                     (crate::core::pt_to_in(self.typography.title_size())
                         + crate::core::pt_to_in(self.spacing.title_pad)
                         + 0.15)
-                        .clamp(*min, *max)
+                        .clamp(min, max)
                 } else {
-                    *min
+                    min
                 };
 
                 // Estimate bottom margin based on xlabel and tick labels
@@ -812,12 +921,12 @@ impl PlotConfig {
                         + crate::core::pt_to_in(self.spacing.label_pad)
                         + crate::core::pt_to_in(self.spacing.tick_pad)
                         + 0.1)
-                        .clamp(*min, *max)
+                        .clamp(min, max)
                 } else {
                     (crate::core::pt_to_in(self.typography.tick_size())
                         + crate::core::pt_to_in(self.spacing.tick_pad)
                         + 0.1)
-                        .clamp(*min, *max)
+                        .clamp(min, max)
                 };
 
                 // Estimate left margin based on ylabel and y-tick labels
@@ -827,14 +936,14 @@ impl PlotConfig {
                         + crate::core::pt_to_in(self.typography.tick_size()) * 4.0
                         + crate::core::pt_to_in(self.spacing.label_pad)
                         + 0.2)
-                        .clamp(*min, *max)
+                        .clamp(min, max)
                 } else {
                     (crate::core::pt_to_in(self.typography.tick_size()) * 4.0 + 0.15)
-                        .clamp(*min, *max)
+                        .clamp(min, max)
                 };
 
                 // Right margin is typically smaller
-                let right = (*min).max(0.2);
+                let right = min.max(0.2);
 
                 ComputedMargins {
                     left,
@@ -1100,6 +1209,28 @@ mod tests {
 
         // Left should be larger than right (for y-axis labels)
         assert!(margins.left > margins.right);
+    }
+
+    #[test]
+    fn test_compute_margins_invalid_auto_bounds_use_fallback() {
+        for margins in [
+            MarginConfig::Auto { min: 1.0, max: 0.5 },
+            MarginConfig::Auto {
+                min: f32::NAN,
+                max: 1.0,
+            },
+        ] {
+            let config = PlotConfig {
+                margins,
+                ..PlotConfig::default()
+            };
+            let computed = config.compute_margins(true, true, true);
+
+            assert!(computed.left.is_finite());
+            assert!(computed.right.is_finite());
+            assert!(computed.top.is_finite());
+            assert!(computed.bottom.is_finite());
+        }
     }
 
     #[test]

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -484,9 +484,19 @@ impl PlottingError {
     /// Validate dimensions are reasonable
     pub fn validate_dimensions(width: u32, height: u32) -> Result<()> {
         const MIN_DIMENSION: u32 = 100;
-        const MAX_DIMENSION: u32 = 16384; // 16K pixels max
 
         if width < MIN_DIMENSION || height < MIN_DIMENSION {
+            return Err(PlottingError::InvalidDimensions { width, height });
+        }
+
+        Self::validate_subplot_dimensions(width, height)
+    }
+
+    /// Validate child subplot dimensions without the top-level 100-pixel minimum.
+    pub(crate) fn validate_subplot_dimensions(width: u32, height: u32) -> Result<()> {
+        const MAX_DIMENSION: u32 = 16384; // 16K pixels max
+
+        if width == 0 || height == 0 {
             return Err(PlottingError::InvalidDimensions { width, height });
         }
 
@@ -582,6 +592,11 @@ mod tests {
 
         // Too large
         assert!(PlottingError::validate_dimensions(20000, 20000).is_err());
+
+        // Child subplots accept any positive size but retain the maximum.
+        assert!(PlottingError::validate_subplot_dimensions(1, 1).is_ok());
+        assert!(PlottingError::validate_subplot_dimensions(0, 1).is_err());
+        assert!(PlottingError::validate_subplot_dimensions(20000, 1).is_err());
     }
 
     #[test]

--- a/src/core/plot/construction.rs
+++ b/src/core/plot/construction.rs
@@ -1152,6 +1152,7 @@ impl Plot {
         let device_scale = Self::sanitize_prepared_scale_factor(scale_factor);
         let size_px = (size_px.0.max(1), size_px.1.max(1));
         let mut plot = self.resolved_plot(time);
+        plot.render.allow_subplot_dimensions = true;
         let dpi = Self::exact_canvas_dpi_for_figure(
             &plot.display.config.figure,
             size_px,

--- a/src/core/plot/construction.rs
+++ b/src/core/plot/construction.rs
@@ -631,6 +631,13 @@ impl Plot {
             self.display.config.figure.height = height as f32 / dpi;
         }
         self.display.dimensions = (width, height);
+        self.render.explicit_output_pixels = Some((width, height));
+        self
+    }
+
+    pub(crate) fn set_subplot_output_pixels(mut self, width: u32, height: u32) -> Self {
+        self = self.set_output_pixels(width, height);
+        self.render.allow_subplot_dimensions = true;
         self
     }
 
@@ -885,7 +892,9 @@ impl Plot {
 
     /// Calculate canvas dimensions from config
     pub(super) fn config_canvas_size(&self) -> (u32, u32) {
-        self.display.config.figure.canvas_size()
+        self.render
+            .explicit_output_pixels
+            .unwrap_or_else(|| self.display.config.figure.canvas_size())
     }
 
     pub(crate) fn fitted_output_size_for_max_pixels(&self, max_size_px: (u32, u32)) -> (u32, u32) {
@@ -1042,7 +1051,11 @@ impl Plot {
     }
 
     pub(super) fn render_scale(&self) -> RenderScale {
-        self.display.config.figure.render_scale()
+        if let Some((width, height)) = self.render.explicit_output_pixels {
+            RenderScale::from_canvas_size(width, height, self.display.config.figure.dpi)
+        } else {
+            self.display.config.figure.render_scale()
+        }
     }
 
     pub(super) fn render_scale_with_device(&self, device_scale: f32) -> RenderScale {

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -2134,6 +2134,7 @@ fn compute_plot_layout(
     visible: DataBounds,
 ) -> Result<ComputedSessionLayout> {
     let layout_plot = plot.prepared_frame_plot(size_px, scale_factor, time_seconds);
+    layout_plot.validate_runtime_environment()?;
     let dpi = layout_plot.display.config.figure.dpi;
 
     let mut renderer = SkiaRenderer::with_font_family(

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -96,6 +96,30 @@ fn test_render_to_image_uses_fitted_size_when_requested() {
     assert!(snapshot.plot_area.max.y <= f64::from(fitted_size.1));
 }
 
+#[test]
+fn test_small_interactive_frame_renders() {
+    let plot: Plot = Plot::new()
+        .ticks(false)
+        .grid(false)
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .into();
+    let session = plot.prepare_interactive();
+
+    let frame = session
+        .render_to_surface(SurfaceTarget {
+            size_px: (80, 80),
+            scale_factor: 1.0,
+            time_seconds: 0.0,
+        })
+        .expect("interactive frames may be smaller than the public figure minimum");
+
+    assert_eq!((frame.image.width, frame.image.height), (80, 80));
+    assert_eq!(
+        (frame.layers.base.width, frame.layers.base.height),
+        (80, 80)
+    );
+}
+
 fn color_centroid<F>(image: &Image, predicate: F) -> Option<ViewportPoint>
 where
     F: Fn(&[u8]) -> bool,

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -935,10 +935,10 @@ impl Plot {
         if let Some(err) = self.pending_ingestion_error() {
             return Err(err);
         }
-        let image = self
-            .clone()
-            .dpi(dpi.round().max(1.0) as u32)
-            .set_output_pixels(renderer.width(), renderer.height())
+        let mut plot = self.clone();
+        plot.display.config.figure.dpi = dpi;
+        let image = plot
+            .set_subplot_output_pixels(renderer.width(), renderer.height())
             .render_image_with_mode(RenderExecutionMode::Reference)?;
         renderer.draw_subplot(image, 0, 0)
     }

--- a/src/core/plot/render_pipeline.rs
+++ b/src/core/plot/render_pipeline.rs
@@ -40,6 +40,10 @@ pub struct RenderPipeline {
     pub(crate) auto_optimized: bool,
     /// Allow internally prepared interactive frames below the public minimum DPI.
     pub(crate) allow_subminimum_dpi: bool,
+    /// Exact output pixels requested by an internal rendering target.
+    pub(crate) explicit_output_pixels: Option<(u32, u32)>,
+    /// Allow positive child subplot canvases below the top-level dimension minimum.
+    pub(crate) allow_subplot_dimensions: bool,
     /// Enable GPU acceleration for coordinate transformations
     #[cfg(feature = "gpu")]
     pub(crate) enable_gpu: bool,
@@ -62,6 +66,8 @@ impl RenderPipeline {
             backend: None,
             auto_optimized: false,
             allow_subminimum_dpi: false,
+            explicit_output_pixels: None,
+            allow_subplot_dimensions: false,
             #[cfg(feature = "gpu")]
             enable_gpu: false,
         }

--- a/src/core/plot/series_internal.rs
+++ b/src/core/plot/series_internal.rs
@@ -1834,7 +1834,12 @@ impl Plot {
             )));
         }
         let (width, height) = self.config_canvas_size();
-        PlottingError::validate_dimensions(width, height)?;
+        if self.render.allow_subplot_dimensions {
+            PlottingError::validate_subplot_dimensions(width, height)?;
+        } else {
+            PlottingError::validate_dimensions(width, height)?;
+        }
+        self.display.config.margins.validate_for_figure(figure)?;
         Ok(())
     }
 

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -1,7 +1,9 @@
 #![allow(clippy::useless_conversion)]
 
 use super::*;
-use crate::core::{FigureConfig, LineConfig as CoreLineConfig, SpineConfig as CoreSpineConfig};
+use crate::core::{
+    FigureConfig, LineConfig as CoreLineConfig, MarginConfig, SpineConfig as CoreSpineConfig,
+};
 use tempfile::tempdir;
 
 #[derive(Debug)]
@@ -1432,6 +1434,96 @@ fn test_public_render_rejects_configured_subminimum_dpi() {
 }
 
 #[test]
+#[allow(clippy::field_reassign_with_default)]
+fn test_all_public_margin_shapes_fail_cleanly_across_render_paths() {
+    fn expect_error<T>(result: Result<T>, message: &str) -> PlottingError {
+        match result {
+            Ok(_) => panic!("{message}"),
+            Err(err) => err,
+        }
+    }
+
+    let malformed = [
+        (
+            "proportional constructor",
+            MarginConfig::proportional_custom(f32::NAN, 0.1, 0.1, 0.1),
+        ),
+        ("auto constructor", MarginConfig::auto_with_bounds(1.0, 0.5)),
+        (
+            "fixed constructor",
+            MarginConfig::fixed(-0.1, 0.2, 0.2, 0.2),
+        ),
+        (
+            "content-driven constructor",
+            MarginConfig::content_driven_custom(f32::INFINITY, true),
+        ),
+        (
+            "oversized content-driven constructor",
+            MarginConfig::content_driven_custom(f32::MAX, true),
+        ),
+        (
+            "direct variant construction",
+            MarginConfig::Proportional {
+                left: 0.6,
+                right: 0.5,
+                top: 0.1,
+                bottom: 0.1,
+            },
+        ),
+    ];
+
+    for (name, margins) in malformed {
+        let mut config = PlotConfig::default();
+        config.margins = margins;
+        let plot = Plot::with_config(config);
+
+        let raster_err = expect_error(
+            plot.clone().render(),
+            &format!("{name} should fail raster rendering"),
+        );
+        assert!(
+            matches!(raster_err, PlottingError::InvalidInput(_)),
+            "unexpected raster error for {name}: {raster_err}"
+        );
+
+        let svg_err = expect_error(
+            plot.clone().render_to_svg(),
+            &format!("{name} should fail SVG rendering"),
+        );
+        assert!(
+            matches!(svg_err, PlottingError::InvalidInput(_)),
+            "unexpected SVG error for {name}: {svg_err}"
+        );
+
+        let interactive_err = expect_error(
+            plot.prepare_interactive().render_to_image(ImageTarget {
+                size_px: (640, 480),
+                scale_factor: 1.0,
+                time_seconds: 0.0,
+            }),
+            &format!("{name} should fail interactive rendering"),
+        );
+        assert!(
+            matches!(interactive_err, PlottingError::InvalidInput(_)),
+            "unexpected interactive error for {name}: {interactive_err}"
+        );
+    }
+}
+
+#[test]
+fn test_auto_margin_maximum_may_exceed_half_the_figure() {
+    let config = PlotConfig {
+        figure: FigureConfig::new(1.0, 1.0, 100.0),
+        margins: MarginConfig::auto_with_bounds(0.1, 1.0),
+        ..PlotConfig::default()
+    };
+
+    Plot::with_config(config)
+        .render()
+        .expect("an auto-margin upper bound is not itself allocated on every side");
+}
+
+#[test]
 fn test_prepared_frame_subminimum_dpi_bypass_is_scoped_to_low_output() {
     let plot = Plot::new().size(4.0, 3.0).dpi(100);
 
@@ -1896,6 +1988,31 @@ fn test_render_to_renderer_basic() {
     // Should render without error
     let result = plot.render_to_renderer(&mut renderer, 96.0);
     assert!(result.is_ok());
+}
+
+#[test]
+fn test_render_to_renderer_preserves_fractional_dpi_output_pixels() {
+    use crate::render::{SkiaRenderer, Theme};
+
+    let plot = Plot::new();
+    let mut renderer = SkiaRenderer::new(101, 101, Theme::dark()).unwrap();
+
+    plot.render_to_renderer(&mut renderer, 100.5).unwrap();
+
+    let image = renderer.into_image();
+    assert_eq!((image.width, image.height), (101, 101));
+    let bottom_right = &image.pixels[image.pixels.len() - 4..];
+    assert_eq!(bottom_right, &[255, 255, 255, 255]);
+}
+
+#[test]
+fn test_explicit_top_level_output_retains_dimension_minimum() {
+    let err = Plot::new()
+        .set_output_pixels(99, 101)
+        .render()
+        .expect_err("top-level output below 100 pixels should still fail");
+
+    assert!(matches!(err, PlottingError::InvalidDimensions { .. }));
 }
 
 #[test]

--- a/src/core/subplot.rs
+++ b/src/core/subplot.rs
@@ -2,7 +2,7 @@
 ///
 /// Provides grid-based layout system for arranging multiple plots
 /// within a single figure, similar to matplotlib's subplot functionality.
-use crate::core::{Plot, PlottingError, Result};
+use crate::core::{Plot, PlottingError, REFERENCE_DPI, Result};
 use crate::render::skia::SkiaRenderer;
 use tiny_skia::Rect;
 
@@ -182,6 +182,25 @@ pub struct SubplotFigure {
 }
 
 impl SubplotFigure {
+    fn scaled_dimension(value: u32, dpi: f32, name: &str) -> Result<u32> {
+        let scaled = f64::from(value) * f64::from(dpi) / f64::from(REFERENCE_DPI);
+        if !scaled.is_finite() || scaled < 1.0 || scaled > f64::from(u32::MAX) {
+            return Err(PlottingError::InvalidInput(format!(
+                "Scaled subplot figure {name} is out of range ({name}={value}, dpi={dpi})"
+            )));
+        }
+        Ok(scaled.round() as u32)
+    }
+
+    fn rect_pixel(value: f32, name: &str) -> Result<u32> {
+        if !value.is_finite() || value < 0.0 || value > u32::MAX as f32 {
+            return Err(PlottingError::InvalidInput(format!(
+                "Subplot {name} is out of pixel range ({name}={value})"
+            )));
+        }
+        Ok(value.floor() as u32)
+    }
+
     /// Create a new subplot figure
     ///
     /// # Example
@@ -335,31 +354,57 @@ impl SubplotFigure {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn save<P: AsRef<std::path::Path>>(self, path: P) -> Result<()> {
-        self.save_with_dpi(path, 96.0)
+        self.save_with_dpi(path, REFERENCE_DPI)
     }
 
     /// Render all subplots with specified DPI
     pub fn save_with_dpi<P: AsRef<std::path::Path>>(self, path: P, dpi: f32) -> Result<()> {
+        if !dpi.is_finite() || dpi <= 0.0 {
+            return Err(PlottingError::InvalidInput(format!(
+                "Subplot figure DPI must be a finite, positive value (dpi={dpi})"
+            )));
+        }
+        if dpi < crate::core::constants::dpi::MIN as f32 {
+            return Err(PlottingError::InvalidInput(format!(
+                "Subplot figure DPI must be at least {} (dpi={dpi})",
+                crate::core::constants::dpi::MIN
+            )));
+        }
+        if dpi > crate::core::constants::dpi::MAX as f32 {
+            return Err(PlottingError::PerformanceLimit {
+                limit_type: "DPI".to_string(),
+                actual: dpi.ceil() as usize,
+                maximum: crate::core::constants::dpi::MAX as usize,
+            });
+        }
+
+        let width = Self::scaled_dimension(self.width, dpi, "width")?;
+        let height = Self::scaled_dimension(self.height, dpi, "height")?;
+        PlottingError::validate_dimensions(width, height)?;
+        let dpi_scale = dpi / REFERENCE_DPI;
+
         // Create main renderer for the figure
         let theme = crate::render::Theme::default();
-        let mut renderer = SkiaRenderer::new(self.width, self.height, theme)?;
+        let mut renderer = SkiaRenderer::new(width, height, theme)?;
+        renderer.set_render_scale(crate::core::RenderScale::from_canvas_size(
+            width, height, dpi,
+        ));
 
         // Calculate suptitle height to reserve space for it
         let suptitle_height = if self.suptitle.is_some() {
-            45.0_f32 // Reserve space for title (30px position + 15px padding)
+            45.0_f32 * dpi_scale // Reserve space for title (30px position + 15px padding)
         } else {
             0.0_f32
         };
 
         // Render figure title if present
-        // Use fixed pixel sizes since main renderer uses figure dimensions (not DPI-scaled)
         if let Some(title) = &self.suptitle {
-            let title_y = 30.0_f32; // Fixed position in pixels
-            let title_size = 16.0_f32; // Fixed size in pixels
+            let title_y = 30.0_f32 * dpi_scale;
+            let title_size = 16.0_f32 * dpi_scale;
 
             renderer.draw_text_centered(
                 title,
-                self.width as f32 / 2.0,
+                width as f32 / 2.0,
                 title_y,
                 title_size,
                 crate::render::Color::new(0, 0, 0),
@@ -370,20 +415,15 @@ impl SubplotFigure {
         for (index, plot_opt) in self.plots.iter().enumerate() {
             if let Some(plot) = plot_opt {
                 // Calculate subplot area with suptitle offset
-                let subplot_rect = self.grid.subplot_rect(
-                    index,
-                    self.width,
-                    self.height,
-                    self.margin,
-                    suptitle_height,
-                )?;
+                let subplot_rect =
+                    self.grid
+                        .subplot_rect(index, width, height, self.margin, suptitle_height)?;
 
                 // Calculate typography scale factor based on subplot size and DPI
-                // Subplots are rendered to fixed-size canvases, so we need to:
-                // 1. Scale down for small subplot dimensions
-                // 2. Use a normalized DPI (96) to avoid giant fonts at high DPI
+                // Use reference-DPI dimensions so small subplots get the same
+                // typography adjustment at every requested output DPI.
                 let reference_dim = 300.0_f32;
-                let subplot_min_dim = subplot_rect.width().min(subplot_rect.height());
+                let subplot_min_dim = subplot_rect.width().min(subplot_rect.height()) / dpi_scale;
                 let size_scale = (subplot_min_dim / reference_dim).clamp(0.35, 1.0);
 
                 // Clone plot and scale typography for small subplots
@@ -391,22 +431,19 @@ impl SubplotFigure {
 
                 // Create a temporary renderer for this subplot
                 let subplot_theme = scaled_plot.get_theme();
-                let mut subplot_renderer = SkiaRenderer::new(
-                    subplot_rect.width() as u32,
-                    subplot_rect.height() as u32,
-                    subplot_theme,
-                )?;
+                let subplot_width = Self::rect_pixel(subplot_rect.width(), "width")?;
+                let subplot_height = Self::rect_pixel(subplot_rect.height(), "height")?;
+                PlottingError::validate_subplot_dimensions(subplot_width, subplot_height)?;
+                let mut subplot_renderer =
+                    SkiaRenderer::new(subplot_width, subplot_height, subplot_theme)?;
 
-                // Render subplot at normalized DPI (96) since canvas is already sized
-                // This prevents fonts from being scaled up with figure DPI
-                let subplot_dpi = 96.0_f32;
-                scaled_plot.render_to_renderer(&mut subplot_renderer, subplot_dpi)?;
+                scaled_plot.render_to_renderer(&mut subplot_renderer, dpi)?;
 
                 // Copy subplot renderer to main renderer at correct position
                 renderer.draw_subplot(
                     subplot_renderer.into_image(),
-                    subplot_rect.left() as u32,
-                    subplot_rect.top() as u32,
+                    Self::rect_pixel(subplot_rect.left(), "x position")?,
+                    Self::rect_pixel(subplot_rect.top(), "y position")?,
                 )?;
             }
         }
@@ -466,10 +503,18 @@ pub fn subplots(rows: usize, cols: usize, width: u32, height: u32) -> Result<Sub
 /// ```
 pub fn subplots_default(rows: usize, cols: usize) -> Result<SubplotFigure> {
     // Default figure size scales with subplot count
-    let base_width = 400;
-    let base_height = 300;
-    let width = (base_width * cols).min(1600) as u32;
-    let height = (base_height * rows).min(1200) as u32;
+    let width = 400_usize
+        .checked_mul(cols)
+        .ok_or_else(|| PlottingError::InvalidInput("Default subplot width overflow".to_string()))?
+        .min(1600);
+    let height = 300_usize
+        .checked_mul(rows)
+        .ok_or_else(|| PlottingError::InvalidInput("Default subplot height overflow".to_string()))?
+        .min(1200);
+    let width = u32::try_from(width)
+        .map_err(|_| PlottingError::InvalidInput("Default subplot width overflow".to_string()))?;
+    let height = u32::try_from(height)
+        .map_err(|_| PlottingError::InvalidInput("Default subplot height overflow".to_string()))?;
 
     SubplotFigure::new(rows, cols, width, height)
 }
@@ -660,6 +705,132 @@ mod tests {
             differing_pixels > 250,
             "legend should visibly change subplot output; differing pixels={differing_pixels}"
         );
+    }
+
+    #[test]
+    fn test_subplot_save_with_dpi_scales_canvas_and_composition() {
+        fn ink_bounds(image: &image::RgbaImage) -> (u32, u32, u32, u32) {
+            let mut bounds = (image.width(), image.height(), 0, 0);
+            for (x, y, pixel) in image.enumerate_pixels() {
+                if pixel.0[..3].iter().all(|channel| *channel > 245) {
+                    continue;
+                }
+                bounds.0 = bounds.0.min(x);
+                bounds.1 = bounds.1.min(y);
+                bounds.2 = bounds.2.max(x);
+                bounds.3 = bounds.3.max(y);
+            }
+            bounds
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let path_100 = dir.path().join("subplot-100.png");
+        let path_200 = dir.path().join("subplot-200.png");
+        let plot: Plot = Plot::new()
+            .line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 0.25])
+            .title("Child")
+            .into();
+        let figure = SubplotFigure::new(1, 1, 400, 300)
+            .unwrap()
+            .suptitle("Figure")
+            .subplot_at(0, plot)
+            .unwrap();
+
+        figure.clone().save(&path_100).unwrap();
+        figure.save_with_dpi(&path_200, 200.0).unwrap();
+
+        let image_100 = image::open(path_100).unwrap().to_rgba8();
+        let image_200 = image::open(path_200).unwrap().to_rgba8();
+        assert_eq!(image_100.dimensions(), (400, 300));
+        assert_eq!(image_200.dimensions(), (800, 600));
+
+        let bounds_100 = ink_bounds(&image_100);
+        let bounds_200 = ink_bounds(&image_200);
+        for (at_100, at_200) in [
+            (bounds_100.0, bounds_200.0),
+            (bounds_100.1, bounds_200.1),
+            (bounds_100.2, bounds_200.2),
+            (bounds_100.3, bounds_200.3),
+        ] {
+            assert!(
+                (i64::from(at_200) - 2 * i64::from(at_100)).abs() <= 5,
+                "subplot composition should scale with DPI: 100-DPI bounds={bounds_100:?}, 200-DPI bounds={bounds_200:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_subplot_children_may_be_smaller_than_top_level_minimum() {
+        let dir = tempfile::tempdir().unwrap();
+        let low_dpi_path = dir.path().join("low-dpi-rows.png");
+        let small_columns_path = dir.path().join("small-columns.png");
+        let plot = Plot::new();
+
+        SubplotFigure::new(2, 1, 400, 300)
+            .unwrap()
+            .subplot_at(0, plot.clone())
+            .unwrap()
+            .subplot_at(1, plot.clone())
+            .unwrap()
+            .save_with_dpi(&low_dpi_path, 72.0)
+            .unwrap();
+        SubplotFigure::new(1, 2, 200, 100)
+            .unwrap()
+            .subplot_at(0, plot.clone())
+            .unwrap()
+            .subplot_at(1, plot)
+            .unwrap()
+            .save(&small_columns_path)
+            .unwrap();
+
+        assert_eq!(image::image_dimensions(low_dpi_path).unwrap(), (288, 216));
+        assert_eq!(
+            image::image_dimensions(small_columns_path).unwrap(),
+            (200, 100)
+        );
+    }
+
+    #[test]
+    fn test_subplot_save_with_dpi_rejects_invalid_or_oversized_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("invalid.png");
+
+        for dpi in [f32::NAN, 0.0, 50.0, 3000.0] {
+            assert!(
+                SubplotFigure::new(1, 1, 400, 300)
+                    .unwrap()
+                    .save_with_dpi(&path, dpi)
+                    .is_err(),
+                "dpi={dpi} should fail"
+            );
+        }
+
+        assert!(
+            SubplotFigure::new(1, 1, u32::MAX, 300)
+                .unwrap()
+                .save(&path)
+                .is_err()
+        );
+        assert!(subplots_default(1, usize::MAX).is_err());
+    }
+
+    #[test]
+    fn test_subplot_save_rejects_malformed_child_margins_without_panicking() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("invalid-child-margins.png");
+        let plot = Plot::with_config(crate::core::PlotConfig {
+            margins: crate::core::MarginConfig::content_driven_custom(f32::MAX, true),
+            ..crate::core::PlotConfig::default()
+        });
+
+        let err = SubplotFigure::new(1, 1, 400, 300)
+            .unwrap()
+            .subplot_at(0, plot)
+            .unwrap()
+            .save(path)
+            .expect_err("malformed child margins should return an error");
+
+        assert!(matches!(err, PlottingError::InvalidInput(_)));
     }
 
     #[test]

--- a/tests/runtime_hardening_test.rs
+++ b/tests/runtime_hardening_test.rs
@@ -1,4 +1,4 @@
-use ruviz::core::{FigureConfig, PlotConfig, PlottingError};
+use ruviz::core::{FigureConfig, MarginConfig, PlotConfig, PlottingError};
 use ruviz::prelude::*;
 
 #[test]
@@ -112,4 +112,32 @@ fn render_rejects_non_finite_output_configuration_with_context() {
         .expect_err("non-finite figure dimensions should fail validation");
 
     assert!(matches!(err, PlottingError::InvalidInput(message) if message.contains("width")));
+}
+
+#[test]
+#[allow(clippy::field_reassign_with_default)]
+fn render_rejects_every_malformed_public_margin_shape() {
+    let malformed = [
+        MarginConfig::proportional_custom(f32::NAN, 0.1, 0.1, 0.1),
+        MarginConfig::auto_with_bounds(1.0, 0.5),
+        MarginConfig::fixed(-0.1, 0.2, 0.2, 0.2),
+        MarginConfig::content_driven_custom(f32::INFINITY, true),
+        MarginConfig::content_driven_custom(f32::MAX, true),
+        MarginConfig::Fixed {
+            left: 4.0,
+            right: 3.0,
+            top: 0.2,
+            bottom: 0.2,
+        },
+    ];
+
+    for margins in malformed {
+        let mut config = PlotConfig::default();
+        config.margins = margins;
+        let err = Plot::with_config(config)
+            .render()
+            .expect_err("malformed public margins should fail validation");
+
+        assert!(matches!(err, PlottingError::InvalidInput(_)));
+    }
 }


### PR DESCRIPTION
## Summary

- reject invalid margin and figure geometry before rendering
- keep subplot output dimensions and DPI internally consistent
- add layout and runtime-hardening regression coverage

## Validation

- `cargo test --test runtime_hardening_test`
- `cargo test --all-features`
- aggregate deterministic visual verification

Depends on #76.