### PR TITLE
Add scale-aware coordinate transforms

### DIFF
--- a/src/axes/scale.rs
+++ b/src/axes/scale.rs
@@ -198,6 +198,54 @@ pub enum AxisScale {
     },
 }
 
+#[inline]
+pub(crate) fn linear_range_is_degenerate(range: f64) -> bool {
+    range.abs() < f64::EPSILON
+}
+
+#[inline]
+pub(crate) fn linear_normalized_position_with_range(
+    value: f64,
+    min: f64,
+    max: f64,
+    range: f64,
+) -> f64 {
+    if range.is_infinite() && value.is_finite() && min.is_finite() && max.is_finite() {
+        (value / 2.0 - min / 2.0) / (max / 2.0 - min / 2.0)
+    } else {
+        (value - min) / range
+    }
+}
+
+#[inline]
+fn linear_inverse_normalized_position(normalized: f64, min: f64, max: f64) -> f64 {
+    let range = max - min;
+    if range.is_infinite() && min.is_finite() && max.is_finite() {
+        (1.0 - normalized) * min + normalized * max
+    } else {
+        normalized * range + min
+    }
+}
+
+#[inline]
+fn log_normalization_bounds(min: f64, max: f64) -> (f64, f64) {
+    if min.is_finite() && min > 0.0 && max.is_finite() && max > 0.0 {
+        (min, max)
+    } else {
+        (min.max(f64::EPSILON), max.max(f64::EPSILON))
+    }
+}
+
+#[inline]
+fn log_ratio(value: f64, base: f64) -> f64 {
+    let ratio = value / base;
+    if ratio.is_finite() && ratio > 0.5 && ratio < 2.0 {
+        ((value - base) / base).ln_1p()
+    } else {
+        value.ln() - base.ln()
+    }
+}
+
 impl AxisScale {
     /// Create a logarithmic scale
     pub fn log() -> Self {
@@ -217,23 +265,29 @@ impl AxisScale {
         match self {
             AxisScale::Linear => {
                 let range = max - min;
-                if range.abs() < f64::EPSILON {
+                if linear_range_is_degenerate(range) {
                     0.5
                 } else {
-                    (value - min) / range
+                    linear_normalized_position_with_range(value, min, max, range)
                 }
             }
             AxisScale::Log => {
-                let min = min.max(f64::EPSILON);
-                let max = max.max(f64::EPSILON);
                 if value <= 0.0 {
                     return 0.0;
                 }
 
+                if min.is_finite() && min > 0.0 && max.is_finite() && max > 0.0 {
+                    if min == max {
+                        return 0.5;
+                    }
+                    return log_ratio(value, min) / log_ratio(max, min);
+                }
+
+                let (min, max) = log_normalization_bounds(min, max);
                 let log_min = min.log10();
                 let log_max = max.log10();
                 let log_range = log_max - log_min;
-                if log_range.abs() < f64::EPSILON {
+                if log_range.abs() <= f64::EPSILON {
                     0.5
                 } else {
                     (value.log10() - log_min) / log_range
@@ -252,11 +306,65 @@ impl AxisScale {
                 let transformed_max = symlog(max);
                 let transformed_value = symlog(value);
                 let range = transformed_max - transformed_min;
-                if range.abs() < f64::EPSILON {
+                if range.abs() <= f64::EPSILON {
                     0.5
                 } else {
                     (transformed_value - transformed_min) / range
                 }
+            }
+        }
+    }
+
+    /// Convert a normalized scale position back into a value in the provided range.
+    ///
+    /// This is the mathematical inverse of [`Self::normalized_position`] for valid,
+    /// non-degenerate ranges. Range direction is preserved, so `0.0` maps to
+    /// `min` and `1.0` maps to `max` even when the range is reversed.
+    pub fn inverse_normalized_position(&self, normalized: f64, min: f64, max: f64) -> f64 {
+        match self {
+            AxisScale::Linear => linear_inverse_normalized_position(normalized, min, max),
+            AxisScale::Log => {
+                if min.is_finite() && min > 0.0 && max.is_finite() && max > 0.0 {
+                    if normalized == 0.0 {
+                        return min;
+                    }
+                    if normalized == 1.0 {
+                        return max;
+                    }
+                    if min == max {
+                        return min;
+                    }
+
+                    let log_range = log_ratio(max, min);
+                    if log_range.abs() < 0.5 {
+                        return min * (normalized * log_range).exp();
+                    }
+                }
+
+                let (min, max) = log_normalization_bounds(min, max);
+                let log_min = min.log10();
+                let log_max = max.log10();
+                10.0_f64.powf(normalized * (log_max - log_min) + log_min)
+            }
+            AxisScale::SymLog { linthresh } => {
+                let symlog = |input: f64| {
+                    if input.abs() <= *linthresh {
+                        input / *linthresh
+                    } else {
+                        input.signum() * (1.0 + (input.abs() / *linthresh).log10())
+                    }
+                };
+                let inverse_symlog = |input: f64| {
+                    if input.abs() <= 1.0 {
+                        input * *linthresh
+                    } else {
+                        input.signum() * *linthresh * 10.0_f64.powf(input.abs() - 1.0)
+                    }
+                };
+
+                let transformed_min = symlog(min);
+                let transformed_max = symlog(max);
+                inverse_symlog(normalized * (transformed_max - transformed_min) + transformed_min)
             }
         }
     }
@@ -421,5 +529,137 @@ mod tests {
 
         let log_mid = AxisScale::Log.normalized_position(10.0, 100.0, 1.0);
         assert!((log_mid - 0.5).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_axis_scale_inverse_normalization_endpoints_and_midpoints() {
+        let cases = [
+            (AxisScale::Linear, 0.0, 10.0, 5.0),
+            (AxisScale::Log, 1.0, 100.0, 10.0),
+            (AxisScale::symlog(1.0), -100.0, 100.0, 0.0),
+        ];
+
+        for (scale, min, max, midpoint) in cases {
+            assert!((scale.inverse_normalized_position(0.0, min, max) - min).abs() < 1e-10);
+            assert!((scale.inverse_normalized_position(0.5, min, max) - midpoint).abs() < 1e-10);
+            assert!((scale.inverse_normalized_position(1.0, min, max) - max).abs() < 1e-10);
+        }
+    }
+
+    #[test]
+    fn test_axis_scale_inverse_normalization_roundtrips_reversed_ranges() {
+        let cases = [
+            (AxisScale::Linear, 20.0, -10.0, vec![20.0, 7.0, -10.0]),
+            (AxisScale::Log, 1000.0, 1.0, vec![1000.0, 10.0, 1.0]),
+            (
+                AxisScale::symlog(2.0),
+                200.0,
+                -50.0,
+                vec![200.0, 10.0, 0.0, -2.0, -50.0],
+            ),
+        ];
+
+        for (scale, min, max, values) in cases {
+            for value in values {
+                let normalized = scale.normalized_position(value, min, max);
+                let recovered = scale.inverse_normalized_position(normalized, min, max);
+                let tolerance = value.abs().max(1.0) * 1e-10;
+                assert!(
+                    (recovered - value).abs() <= tolerance,
+                    "{scale:?} failed to round-trip {value} in {min}..{max}: {recovered}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_axis_scale_log_invalid_value_behavior_is_preserved() {
+        assert_eq!(AxisScale::Log.normalized_position(0.0, 1.0, 100.0), 0.0);
+        assert_eq!(AxisScale::Log.normalized_position(-1.0, 1.0, 100.0), 0.0);
+        assert!(AxisScale::Log.inverse_normalized_position(0.5, 1.0, 100.0) > 0.0);
+        assert!(AxisScale::Log.validate_range(0.0, 100.0).is_err());
+    }
+
+    #[test]
+    fn test_axis_scale_log_normalization_supports_sub_epsilon_domains() {
+        let low = f64::EPSILON / 16.0;
+        let high = f64::EPSILON / 2.0;
+        let midpoint = 10.0_f64.powf(low.log10() + (high.log10() - low.log10()) * 0.5);
+
+        for (min, max) in [(low, high), (high, low)] {
+            assert_eq!(AxisScale::Log.normalized_position(min, min, max), 0.0);
+            assert_eq!(AxisScale::Log.normalized_position(max, min, max), 1.0);
+
+            for value in [min, midpoint, max] {
+                let normalized = AxisScale::Log.normalized_position(value, min, max);
+                let recovered = AxisScale::Log.inverse_normalized_position(normalized, min, max);
+                assert!(
+                    ((recovered - value) / value).abs() <= 1e-12,
+                    "failed to round-trip {value} in {min}..{max}: {recovered}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_axis_scale_log_normalization_supports_close_positive_bounds() {
+        let min = 1.0_f64;
+        let midpoint = f64::from_bits(min.to_bits() + 1);
+        let max = f64::from_bits(min.to_bits() + 2);
+
+        assert_eq!(AxisScale::Log.normalized_position(min, min, max), 0.0);
+        assert_eq!(AxisScale::Log.normalized_position(max, min, max), 1.0);
+        let normalized = AxisScale::Log.normalized_position(midpoint, min, max);
+        assert!((normalized - 0.5).abs() <= f64::EPSILON);
+        assert_eq!(
+            AxisScale::Log.inverse_normalized_position(normalized, min, max),
+            midpoint
+        );
+    }
+
+    #[test]
+    fn test_axis_scale_linear_exact_epsilon_span_is_not_degenerate() {
+        let min = 0.0;
+        let max = f64::EPSILON;
+
+        assert_eq!(AxisScale::Linear.normalized_position(min, min, max), 0.0);
+        assert_eq!(
+            AxisScale::Linear.normalized_position(max / 2.0, min, max),
+            0.5
+        );
+        assert_eq!(AxisScale::Linear.normalized_position(max, min, max), 1.0);
+
+        let translated_min = 1.0;
+        let translated_max = translated_min + f64::EPSILON;
+        assert_eq!(
+            AxisScale::Linear.normalized_position(translated_min, translated_min, translated_max),
+            0.0
+        );
+        assert_eq!(
+            AxisScale::Linear.normalized_position(translated_max, translated_min, translated_max),
+            1.0
+        );
+    }
+
+    #[test]
+    fn test_axis_scale_linear_normalization_supports_finite_extreme_ranges() {
+        for (min, max) in [(-f64::MAX, f64::MAX), (f64::MAX, -f64::MAX)] {
+            assert_eq!(AxisScale::Linear.normalized_position(min, min, max), 0.0);
+            assert_eq!(AxisScale::Linear.normalized_position(0.0, min, max), 0.5);
+            assert_eq!(AxisScale::Linear.normalized_position(max, min, max), 1.0);
+
+            assert_eq!(
+                AxisScale::Linear.inverse_normalized_position(0.0, min, max),
+                min
+            );
+            assert_eq!(
+                AxisScale::Linear.inverse_normalized_position(0.5, min, max),
+                0.0
+            );
+            assert_eq!(
+                AxisScale::Linear.inverse_normalized_position(1.0, min, max),
+                max
+            );
+        }
     }
 }

--- a/src/core/plot/raster_batches.rs
+++ b/src/core/plot/raster_batches.rs
@@ -281,8 +281,8 @@ fn project_linear_xy_points(
 ) -> Arc<[Point2f]> {
     let x_range = x_max - x_min;
     let y_range = y_max - y_min;
-    let x_is_degenerate = x_range.abs() < f64::EPSILON;
-    let y_is_degenerate = y_range.abs() < f64::EPSILON;
+    let x_is_degenerate = crate::axes::scale::linear_range_is_degenerate(x_range);
+    let y_is_degenerate = crate::axes::scale::linear_range_is_degenerate(y_range);
     let left = plot_area.left();
     let bottom = plot_area.bottom();
     let width = plot_area.width();
@@ -295,12 +295,12 @@ fn project_linear_xy_points(
             let normalized_x = if x_is_degenerate {
                 0.5
             } else {
-                (x - x_min) / x_range
+                crate::axes::scale::linear_normalized_position_with_range(x, x_min, x_max, x_range)
             };
             let normalized_y = if y_is_degenerate {
                 0.5
             } else {
-                (y - y_min) / y_range
+                crate::axes::scale::linear_normalized_position_with_range(y, y_min, y_max, y_range)
             };
             Point2f::new(
                 left + normalized_x as f32 * width,
@@ -322,13 +322,22 @@ fn project_scaled_xy_points(
     x_scale: &crate::axes::AxisScale,
     y_scale: &crate::axes::AxisScale,
 ) -> Arc<[Point2f]> {
+    let transform = crate::core::CoordinateTransform::from_plot_area(
+        plot_area.left(),
+        plot_area.top(),
+        plot_area.width(),
+        plot_area.height(),
+        x_min,
+        x_max,
+        y_min,
+        y_max,
+    );
+
     x_data
         .iter()
         .zip(y_data.iter())
         .map(|(&x, &y)| {
-            let (px, py) = crate::render::skia::map_data_to_pixels_scaled(
-                x, y, x_min, x_max, y_min, y_max, plot_area, x_scale, y_scale,
-            );
+            let (px, py) = transform.data_to_screen_scaled(x, y, x_scale, y_scale);
             Point2f::new(px, py)
         })
         .collect::<Vec<_>>()
@@ -444,6 +453,66 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
+        assert_eq!(points.as_ref(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_scaled_projection_uses_core_transform_with_reversed_ranges() {
+        let plot_area = tiny_skia::Rect::from_xywh(20.0, 30.0, 600.0, 400.0);
+        assert!(plot_area.is_some(), "test rectangle should be valid");
+        let Some(plot_area) = plot_area else {
+            return;
+        };
+        let x_data = [100.0, 10.0, 1.0];
+        let y_data = [100.0, 0.0, -100.0];
+
+        let points = project_xy_points(
+            &x_data,
+            &y_data,
+            100.0,
+            1.0,
+            100.0,
+            -100.0,
+            plot_area,
+            &AxisScale::Log,
+            &AxisScale::symlog(1.0),
+        );
+
+        let expected = [
+            Point2f::new(20.0, 430.0),
+            Point2f::new(320.0, 230.0),
+            Point2f::new(620.0, 30.0),
+        ];
+        assert_eq!(points.as_ref(), expected.as_slice());
+    }
+
+    #[test]
+    fn test_linear_projection_fast_path_uses_shared_epsilon_and_extreme_range_rules() {
+        let plot_area = tiny_skia::Rect::from_xywh(10.0, 20.0, 200.0, 100.0);
+        assert!(plot_area.is_some(), "test rectangle should be valid");
+        let Some(plot_area) = plot_area else {
+            return;
+        };
+        let x_data = [0.0, f64::EPSILON / 2.0, f64::EPSILON];
+        let y_data = [-f64::MAX, 0.0, f64::MAX];
+
+        let points = project_xy_points(
+            &x_data,
+            &y_data,
+            0.0,
+            f64::EPSILON,
+            -f64::MAX,
+            f64::MAX,
+            plot_area,
+            &AxisScale::Linear,
+            &AxisScale::Linear,
+        );
+
+        let expected = [
+            Point2f::new(10.0, 120.0),
+            Point2f::new(110.0, 70.0),
+            Point2f::new(210.0, 20.0),
+        ];
         assert_eq!(points.as_ref(), expected.as_slice());
     }
 }

--- a/src/core/transform.rs
+++ b/src/core/transform.rs
@@ -26,6 +26,7 @@
 //! let (data_x, data_y) = transform.screen_to_data(screen_x, screen_y);
 //! ```
 
+use crate::axes::AxisScale;
 use std::ops::Range;
 
 /// Unified coordinate transformation between data space and screen space.
@@ -145,32 +146,44 @@ impl CoordinateTransform {
     pub fn data_to_screen(&self, data_x: f64, data_y: f64) -> (f32, f32) {
         let x_range = self.data_x.end - self.data_x.start;
         let y_range = self.data_y.end - self.data_y.start;
-
-        // Normalize to [0, 1], handling division by zero
-        let norm_x = if x_range.abs() > f64::EPSILON {
-            (data_x - self.data_x.start) / x_range
+        let normalized_x = if x_range.abs() > f64::EPSILON {
+            crate::axes::scale::linear_normalized_position_with_range(
+                data_x,
+                self.data_x.start,
+                self.data_x.end,
+                x_range,
+            )
         } else {
             0.5
         };
-
-        let norm_y = if y_range.abs() > f64::EPSILON {
-            (data_y - self.data_y.start) / y_range
+        let normalized_y = if y_range.abs() > f64::EPSILON {
+            crate::axes::scale::linear_normalized_position_with_range(
+                data_y,
+                self.data_y.start,
+                self.data_y.end,
+                y_range,
+            )
         } else {
             0.5
         };
+        self.normalized_to_screen(normalized_x, normalized_y)
+    }
 
-        let screen_width = self.screen_x.end - self.screen_x.start;
-        let screen_height = self.screen_y.end - self.screen_y.start;
-
-        let screen_x = self.screen_x.start + (norm_x as f32) * screen_width;
-        let screen_y = if self.y_inverted {
-            // Y is inverted in screen coordinates (0 at top)
-            self.screen_y.start + (1.0 - norm_y as f32) * screen_height
-        } else {
-            self.screen_y.start + (norm_y as f32) * screen_height
-        };
-
-        (screen_x, screen_y)
+    /// Transform data coordinates to screen coordinates using axis scales.
+    ///
+    /// This is the core scale-aware forward transform. It preserves the direction
+    /// of both data and screen ranges and applies the configured Y-axis inversion.
+    #[inline]
+    pub fn data_to_screen_scaled(
+        &self,
+        data_x: f64,
+        data_y: f64,
+        x_scale: &AxisScale,
+        y_scale: &AxisScale,
+    ) -> (f32, f32) {
+        let normalized_x = x_scale.normalized_position(data_x, self.data_x.start, self.data_x.end);
+        let normalized_y = y_scale.normalized_position(data_y, self.data_y.start, self.data_y.end);
+        self.normalized_to_screen(normalized_x, normalized_y)
     }
 
     /// Transform screen coordinates to data coordinates.
@@ -185,20 +198,53 @@ impl CoordinateTransform {
     /// A tuple of (data_x, data_y) in data space
     #[inline]
     pub fn screen_to_data(&self, screen_x: f32, screen_y: f32) -> (f64, f64) {
+        self.screen_to_data_scaled(screen_x, screen_y, &AxisScale::Linear, &AxisScale::Linear)
+    }
+
+    /// Transform screen coordinates to data coordinates using axis scales.
+    ///
+    /// This is the core scale-aware inverse transform and is the inverse of
+    /// [`Self::data_to_screen_scaled`] for valid, non-degenerate ranges.
+    #[inline]
+    pub fn screen_to_data_scaled(
+        &self,
+        screen_x: f32,
+        screen_y: f32,
+        x_scale: &AxisScale,
+        y_scale: &AxisScale,
+    ) -> (f64, f64) {
+        let (normalized_x, normalized_y) = self.screen_to_normalized(screen_x, screen_y);
+        let data_x =
+            x_scale.inverse_normalized_position(normalized_x, self.data_x.start, self.data_x.end);
+        let data_y =
+            y_scale.inverse_normalized_position(normalized_y, self.data_y.start, self.data_y.end);
+        (data_x, data_y)
+    }
+
+    #[inline]
+    fn normalized_to_screen(&self, normalized_x: f64, normalized_y: f64) -> (f32, f32) {
         let screen_width = self.screen_x.end - self.screen_x.start;
         let screen_height = self.screen_y.end - self.screen_y.start;
+        let screen_x = self.screen_x.start + normalized_x as f32 * screen_width;
+        let screen_y = if self.y_inverted {
+            self.screen_y.start + (1.0 - normalized_y as f32) * screen_height
+        } else {
+            self.screen_y.start + normalized_y as f32 * screen_height
+        };
+        (screen_x, screen_y)
+    }
 
-        let norm_x = (screen_x - self.screen_x.start) / screen_width;
-        let norm_y = if self.y_inverted {
+    #[inline]
+    fn screen_to_normalized(&self, screen_x: f32, screen_y: f32) -> (f64, f64) {
+        let screen_width = self.screen_x.end - self.screen_x.start;
+        let screen_height = self.screen_y.end - self.screen_y.start;
+        let normalized_x = (screen_x - self.screen_x.start) / screen_width;
+        let normalized_y = if self.y_inverted {
             1.0 - (screen_y - self.screen_y.start) / screen_height
         } else {
             (screen_y - self.screen_y.start) / screen_height
         };
-
-        let data_x = self.data_x.start + (norm_x as f64) * (self.data_x.end - self.data_x.start);
-        let data_y = self.data_y.start + (norm_y as f64) * (self.data_y.end - self.data_y.start);
-
-        (data_x, data_y)
+        (normalized_x as f64, normalized_y as f64)
     }
 
     /// Check if a data point is within the data bounds.
@@ -420,5 +466,80 @@ mod tests {
         let (sx, sy) = transform.screen_center();
         assert!((sx - 450.0).abs() < f32::EPSILON);
         assert!((sy - 350.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_scaled_transform_endpoints_midpoints_and_reversed_screen_ranges() {
+        let transform =
+            CoordinateTransform::new(1.0..100.0, -100.0..100.0, 700.0..100.0, 500.0..50.0);
+        let x_scale = AxisScale::Log;
+        let y_scale = AxisScale::symlog(1.0);
+
+        let (start_x, start_y) = transform.data_to_screen_scaled(1.0, -100.0, &x_scale, &y_scale);
+        assert!((start_x - 700.0).abs() < f32::EPSILON);
+        assert!((start_y - 50.0).abs() < f32::EPSILON);
+
+        let (mid_x, mid_y) = transform.data_to_screen_scaled(10.0, 0.0, &x_scale, &y_scale);
+        assert!((mid_x - 400.0).abs() < f32::EPSILON);
+        assert!((mid_y - 275.0).abs() < f32::EPSILON);
+
+        let (end_x, end_y) = transform.data_to_screen_scaled(100.0, 100.0, &x_scale, &y_scale);
+        assert!((end_x - 100.0).abs() < f32::EPSILON);
+        assert!((end_y - 500.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn test_scaled_transform_roundtrips_reversed_data_and_screen_ranges() {
+        let transform =
+            CoordinateTransform::new(1000.0..1.0, 100.0..-100.0, 900.0..75.0, 40.0..640.0);
+        let x_scale = AxisScale::Log;
+        let y_scale = AxisScale::symlog(2.0);
+        let points = [(1000.0, 100.0), (100.0, 10.0), (10.0, 0.0), (1.0, -100.0)];
+
+        for (data_x, data_y) in points {
+            let (screen_x, screen_y) =
+                transform.data_to_screen_scaled(data_x, data_y, &x_scale, &y_scale);
+            let (recovered_x, recovered_y) =
+                transform.screen_to_data_scaled(screen_x, screen_y, &x_scale, &y_scale);
+            let x_tolerance = data_x.abs().max(1.0) * 1e-5;
+            let y_tolerance = data_y.abs().max(1.0) * 1e-5;
+            assert!((recovered_x - data_x).abs() <= x_tolerance);
+            assert!((recovered_y - data_y).abs() <= y_tolerance);
+        }
+    }
+
+    #[test]
+    fn test_scaled_linear_transform_uses_exact_epsilon_and_extreme_range_rules() {
+        let min = 1.0;
+        let max = min + f64::EPSILON;
+        let transform =
+            CoordinateTransform::new(min..max, -f64::MAX..f64::MAX, 10.0..210.0, 20.0..120.0);
+        let linear = AxisScale::Linear;
+
+        assert_eq!(
+            transform.data_to_screen_scaled(min, -f64::MAX, &linear, &linear),
+            (10.0, 120.0)
+        );
+        assert_eq!(
+            transform.data_to_screen_scaled(max, f64::MAX, &linear, &linear),
+            (210.0, 20.0)
+        );
+        assert_eq!(
+            transform.screen_to_data_scaled(10.0, 120.0, &linear, &linear),
+            (min, -f64::MAX)
+        );
+        assert_eq!(
+            transform.screen_to_data_scaled(210.0, 20.0, &linear, &linear),
+            (max, f64::MAX)
+        );
+    }
+
+    #[test]
+    fn test_linear_transform_preserves_exact_epsilon_degeneracy_semantics() {
+        let transform =
+            CoordinateTransform::new(1.0..1.0 + f64::EPSILON, 0.0..1.0, 10.0..210.0, 20.0..120.0);
+
+        assert_eq!(transform.data_to_screen(1.0, 0.5).0, 110.0);
+        assert_eq!(transform.data_to_screen(1.0 + f64::EPSILON, 0.5).0, 110.0);
     }
 }

--- a/src/render/parallel.rs
+++ b/src/render/parallel.rs
@@ -179,21 +179,15 @@ impl ParallelRenderer {
         output_vec.clear();
         output_vec.reserve(point_count);
 
+        let transform = crate::core::CoordinateTransform::new(
+            bounds.x_min..bounds.x_max,
+            bounds.y_min..bounds.y_max,
+            plot_area.left..plot_area.right,
+            plot_area.top..plot_area.bottom,
+        );
         let project = |data_x: f64, data_y: f64| {
-            let pixel_x = if (bounds.x_max - bounds.x_min).abs() < f64::EPSILON {
-                plot_area.left + plot_area.width() * 0.5
-            } else {
-                let normalized_x = x_scale.normalized_position(data_x, bounds.x_min, bounds.x_max);
-                plot_area.left + normalized_x as f32 * plot_area.width()
-            };
-
-            let pixel_y = if (bounds.y_max - bounds.y_min).abs() < f64::EPSILON {
-                plot_area.top + plot_area.height() * 0.5
-            } else {
-                let normalized_y = y_scale.normalized_position(data_y, bounds.y_min, bounds.y_max);
-                plot_area.bottom - normalized_y as f32 * plot_area.height()
-            };
-
+            let (pixel_x, pixel_y) =
+                transform.data_to_screen_scaled(data_x, data_y, x_scale, y_scale);
             Point2f::new(pixel_x, pixel_y)
         };
 
@@ -250,7 +244,18 @@ impl ParallelRenderer {
         output_vec.clear();
         output_vec.reserve(point_count);
 
+        let x_range = bounds.x_max - bounds.x_min;
+        let y_range = bounds.y_max - bounds.y_min;
+        let x_is_degenerate = crate::axes::scale::linear_range_is_degenerate(x_range);
+        let y_is_degenerate = crate::axes::scale::linear_range_is_degenerate(y_range);
+
         #[cfg(feature = "simd")]
+        if !x_is_degenerate
+            && !y_is_degenerate
+            && x_range.is_finite()
+            && y_range.is_finite()
+            && bounds.x_min as f32 != bounds.x_max as f32
+            && bounds.y_min as f32 != bounds.y_max as f32
         {
             // Convert to SIMD-compatible types
             let simd_bounds = CoordinateBounds {
@@ -315,8 +320,26 @@ impl ParallelRenderer {
 
         // Fallback: simple coordinate transformation without SIMD
         for i in 0..point_count {
-            let x_norm = (x_data[i] - bounds.x_min) / (bounds.x_max - bounds.x_min);
-            let y_norm = (y_data[i] - bounds.y_min) / (bounds.y_max - bounds.y_min);
+            let x_norm = if x_is_degenerate {
+                0.5
+            } else {
+                crate::axes::scale::linear_normalized_position_with_range(
+                    x_data[i],
+                    bounds.x_min,
+                    bounds.x_max,
+                    x_range,
+                )
+            };
+            let y_norm = if y_is_degenerate {
+                0.5
+            } else {
+                crate::axes::scale::linear_normalized_position_with_range(
+                    y_data[i],
+                    bounds.y_min,
+                    bounds.y_max,
+                    y_range,
+                )
+            };
 
             let pixel_x = plot_area.left + x_norm as f32 * (plot_area.right - plot_area.left);
             let pixel_y = plot_area.bottom - y_norm as f32 * (plot_area.bottom - plot_area.top);
@@ -832,6 +855,63 @@ mod tests {
         assert!((points[0].y - 80.0).abs() <= 1e-5);
         assert!(points[0].x.is_finite());
         assert!(points[0].y.is_finite());
+    }
+
+    #[test]
+    fn test_linear_parallel_path_uses_shared_epsilon_and_extreme_range_rules() {
+        let renderer = ParallelRenderer::new();
+        let plot_area = PlotArea {
+            left: 10.0,
+            right: 210.0,
+            top: 20.0,
+            bottom: 120.0,
+        };
+
+        let min = 1.0;
+        let max = min + f64::EPSILON;
+        let epsilon_points = renderer
+            .transform_coordinates_parallel_scaled(
+                &[min, max],
+                &[0.0, 1.0],
+                DataBounds {
+                    x_min: min,
+                    x_max: max,
+                    y_min: 0.0,
+                    y_max: 1.0,
+                },
+                plot_area.clone(),
+                &AxisScale::Linear,
+                &AxisScale::Linear,
+            )
+            .unwrap();
+        assert_eq!(
+            epsilon_points,
+            vec![Point2f::new(10.0, 120.0), Point2f::new(210.0, 20.0)]
+        );
+
+        let extreme_points = renderer
+            .transform_coordinates_parallel_scaled(
+                &[-f64::MAX, 0.0, f64::MAX],
+                &[0.0, 0.5, 1.0],
+                DataBounds {
+                    x_min: -f64::MAX,
+                    x_max: f64::MAX,
+                    y_min: 0.0,
+                    y_max: 1.0,
+                },
+                plot_area,
+                &AxisScale::Linear,
+                &AxisScale::Linear,
+            )
+            .unwrap();
+        assert_eq!(
+            extreme_points,
+            vec![
+                Point2f::new(10.0, 120.0),
+                Point2f::new(110.0, 70.0),
+                Point2f::new(210.0, 20.0),
+            ]
+        );
     }
 
     #[test]

--- a/src/render/skia/tests.rs
+++ b/src/render/skia/tests.rs
@@ -362,6 +362,25 @@ fn test_data_to_pixel_mapping() {
 }
 
 #[test]
+fn test_scaled_data_to_pixel_mapping_handles_log_symlog_and_reversed_domains() {
+    let plot_area = Rect::from_xywh(100.0, 50.0, 600.0, 400.0).unwrap();
+    let (px, py) = map_data_to_pixels_scaled(
+        10.0,
+        0.0,
+        100.0,
+        1.0,
+        100.0,
+        -100.0,
+        plot_area,
+        &crate::axes::AxisScale::Log,
+        &crate::axes::AxisScale::symlog(1.0),
+    );
+
+    assert!((px - 400.0).abs() < f32::EPSILON);
+    assert!((py - 250.0).abs() < f32::EPSILON);
+}
+
+#[test]
 fn test_tick_generation() {
     let ticks = generate_ticks(0.0, 10.0, 5);
     assert!(!ticks.is_empty());

--- a/src/render/skia/utils.rs
+++ b/src/render/skia/utils.rs
@@ -168,9 +168,8 @@ pub fn map_data_to_pixels(
 
 /// Map data coordinates to pixel coordinates with axis scale transformations
 ///
-/// This version applies logarithmic or symlog transformations to the data
-/// before mapping to pixel coordinates. The base coordinate transformation
-/// is delegated to [`CoordinateTransform`].
+/// The scale-aware coordinate transformation is delegated to
+/// [`CoordinateTransform`].
 pub fn map_data_to_pixels_scaled(
     data_x: f64,
     data_y: f64,
@@ -182,13 +181,17 @@ pub fn map_data_to_pixels_scaled(
     x_scale: &crate::axes::AxisScale,
     y_scale: &crate::axes::AxisScale,
 ) -> (f32, f32) {
-    let normalized_x = x_scale.normalized_position(data_x, data_x_min, data_x_max);
-    let normalized_y = y_scale.normalized_position(data_y, data_y_min, data_y_max);
-
-    let pixel_x = plot_area.left() + normalized_x as f32 * plot_area.width();
-    let pixel_y = plot_area.bottom() - normalized_y as f32 * plot_area.height();
-
-    (pixel_x, pixel_y)
+    let transform = CoordinateTransform::from_plot_area(
+        plot_area.left(),
+        plot_area.top(),
+        plot_area.width(),
+        plot_area.height(),
+        data_x_min,
+        data_x_max,
+        data_y_min,
+        data_y_max,
+    );
+    transform.data_to_screen_scaled(data_x, data_y, x_scale, y_scale)
 }
 
 /// Generate intelligent ticks using matplotlib's MaxNLocator algorithm


### PR DESCRIPTION
## Summary

- centralize linear, logarithmic, SymLog, and reversed-axis transforms
- use consistent forward and inverse coordinate mapping
- add scale and boundary regression coverage

## Validation

- `cargo test`
- `cargo test --all-features`
- aggregate public-API scale runtime probes

Depends on #76.