### PR TITLE
Make reactive updates transactional

### DIFF
--- a/src/core/plot/construction.rs
+++ b/src/core/plot/construction.rs
@@ -1090,17 +1090,50 @@ impl Plot {
         self.series_mgr
             .series
             .iter()
-            .map(|series| series.series_type.resolve_for_render(time))
+            .map(|series| series.resolve_for_render(time))
             .collect()
     }
 
     pub(super) fn snapshot_series(&self, time: f64) -> Vec<PlotSeries> {
+        let mut streaming_snapshots: Vec<(
+            crate::data::StreamingXY,
+            crate::data::StreamingXYSnapshot,
+        )> = Vec::new();
         self.series_mgr
             .series
             .iter()
             .cloned()
             .map(|mut series| {
-                series.series_type = series.series_type.resolve(time);
+                if series.has_live_streaming_pair() {
+                    let stream = series
+                        .streaming_source
+                        .as_ref()
+                        .expect("live streaming pair must retain its source");
+                    let snapshot = if let Some((_, snapshot)) = streaming_snapshots
+                        .iter()
+                        .find(|(source, _)| source.shares_source(stream))
+                    {
+                        snapshot.clone()
+                    } else {
+                        let snapshot = stream.snapshot();
+                        streaming_snapshots.push((stream.clone(), snapshot.clone()));
+                        snapshot
+                    };
+                    series.series_type = match &series.series_type {
+                        SeriesType::Line { .. } => SeriesType::Line {
+                            x_data: PlotData::Static(snapshot.x().to_vec()),
+                            y_data: PlotData::Static(snapshot.y().to_vec()),
+                        },
+                        SeriesType::Scatter { .. } => SeriesType::Scatter {
+                            x_data: PlotData::Static(snapshot.x().to_vec()),
+                            y_data: PlotData::Static(snapshot.y().to_vec()),
+                        },
+                        _ => unreachable!("live paired source is only used by line/scatter"),
+                    };
+                    series.streaming_source = Some(stream.captured_through(snapshot.sequence()));
+                } else {
+                    series.series_type = series.series_type.resolve(time);
+                }
                 series
             })
             .collect()
@@ -1234,6 +1267,13 @@ impl Plot {
     pub(super) fn mark_reactive_sources_rendered(&self) {
         for series in &self.series_mgr.series {
             series.mark_rendered_sources();
+        }
+    }
+
+    pub(super) fn acknowledge_rendered_snapshot(&self, live_plot: &Self) {
+        self.mark_reactive_sources_rendered();
+        for series in &live_plot.series_mgr.series {
+            series.mark_unpaired_streaming_sources_rendered();
         }
     }
 

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -568,6 +568,8 @@ struct StreamingDrawOp {
     marker_style: MarkerStyle,
     marker_size_px: f32,
     draw_markers: bool,
+    source: crate::data::StreamingXY,
+    sequence: u64,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1439,7 +1441,7 @@ impl InteractivePlotSession {
             }
         }
         let image = plot.render_at(state.time_seconds)?;
-        self.inner.prepared.plot().mark_reactive_sources_rendered();
+        plot.acknowledge_rendered_snapshot(self.inner.prepared.plot());
         let image = Arc::new(image);
 
         let mut state = self
@@ -1718,7 +1720,9 @@ impl InteractivePlotSession {
             geometry,
             &draw_ops,
         )?);
-        self.inner.prepared.plot().mark_reactive_sources_rendered();
+        for op in &draw_ops {
+            op.source.mark_rendered_through(op.sequence);
+        }
 
         let mut state = self
             .inner

--- a/src/core/plot/interactive_session/helpers.rs
+++ b/src/core/plot/interactive_session/helpers.rs
@@ -50,6 +50,8 @@ pub(super) fn collect_streaming_draw_ops(
 
     let prepared_plot = plot.prepared_frame_plot(size_px, scale_factor, time_seconds);
     let mut draw_ops = Vec::new();
+    let mut streaming_snapshots: Vec<(crate::data::StreamingXY, crate::data::StreamingXYSnapshot)> =
+        Vec::new();
     let mut saw_streaming_update = false;
 
     for (series_index, series) in plot.series_mgr.series.iter().enumerate() {
@@ -70,6 +72,7 @@ pub(super) fn collect_streaming_draw_ops(
                     series,
                     x_data,
                     y_data,
+                    &mut streaming_snapshots,
                     StreamingDrawKind::Line,
                     color,
                     line_width_px,
@@ -92,6 +95,7 @@ pub(super) fn collect_streaming_draw_ops(
                     series,
                     x_data,
                     y_data,
+                    &mut streaming_snapshots,
                     StreamingDrawKind::Scatter,
                     color,
                     line_width_px,
@@ -121,6 +125,7 @@ pub(super) fn streaming_draw_op(
     series: &PlotSeries,
     x_data: &PlotData,
     y_data: &PlotData,
+    streaming_snapshots: &mut Vec<(crate::data::StreamingXY, crate::data::StreamingXYSnapshot)>,
     kind: StreamingDrawKind,
     color: Color,
     line_width_px: f32,
@@ -132,26 +137,29 @@ pub(super) fn streaming_draw_op(
     if !matches!(x_data, PlotData::Streaming(_)) || !matches!(y_data, PlotData::Streaming(_)) {
         return Ok(None);
     }
-    let appended_count = match (
-        x_data.streaming_render_state(),
-        y_data.streaming_render_state(),
-    ) {
-        (
-            Some(crate::data::StreamingRenderState::AppendOnly {
-                visible_appended: x_count,
-            }),
-            Some(crate::data::StreamingRenderState::AppendOnly {
-                visible_appended: y_count,
-            }),
-        ) => x_count.min(y_count),
+    let Some(source) = series.streaming_source.as_ref() else {
+        return Ok(None);
+    };
+    let snapshot = if let Some((_, snapshot)) = streaming_snapshots
+        .iter()
+        .find(|(cached_source, _)| cached_source.shares_source(source))
+    {
+        snapshot.clone()
+    } else {
+        let snapshot = source.snapshot();
+        streaming_snapshots.push((source.clone(), snapshot.clone()));
+        snapshot
+    };
+    let appended_count = match snapshot.render_state() {
+        crate::data::StreamingRenderState::AppendOnly { visible_appended } => visible_appended,
         _ => return Ok(None),
     };
     if appended_count == 0 {
         return Ok(None);
     }
 
-    let x_values = x_data.resolve(time_seconds);
-    let y_values = y_data.resolve(time_seconds);
+    let x_values = snapshot.x();
+    let y_values = snapshot.y();
     let len = x_values.len().min(y_values.len());
     if len == 0 || appended_count > len {
         return Ok(None);
@@ -177,7 +185,7 @@ pub(super) fn streaming_draw_op(
         return Ok(None);
     }
 
-    let _ = series;
+    let _ = time_seconds;
     Ok(Some(StreamingDrawOp {
         kind,
         points,
@@ -188,6 +196,8 @@ pub(super) fn streaming_draw_op(
         marker_style,
         marker_size_px,
         draw_markers: kind == StreamingDrawKind::Scatter || series.marker_style.is_some(),
+        source: source.clone(),
+        sequence: snapshot.sequence(),
     }))
 }
 

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::useless_conversion)]
 
 use super::*;
-use crate::data::{Observable, StreamingXY, signal};
+use crate::data::{Observable, StreamingBuffer, StreamingXY, signal};
 use crate::prelude::Plot;
 use crate::render::{Color, MarkerStyle};
 use std::sync::{Arc, atomic::Ordering};
@@ -833,6 +833,27 @@ fn test_streaming_surface_render_falls_back_after_wraparound() {
 
     assert!(!rerendered.layer_state.used_incremental_data);
     assert_eq!(stream.appended_count(), 0);
+}
+
+#[test]
+fn test_interactive_full_render_acknowledges_generic_streaming_buffers() {
+    let x = StreamingBuffer::new(16);
+    let y = StreamingBuffer::new(16);
+    x.push_many(vec![0.0, 1.0]);
+    y.push_many(vec![0.0, 1.0]);
+    let plot: Plot = Plot::new()
+        .line_source(x.clone(), y.clone())
+        .xlim(0.0, 2.0)
+        .ylim(0.0, 2.0)
+        .into();
+    let session = plot.prepare_interactive();
+
+    session
+        .render_to_surface(render_target())
+        .expect("interactive generic streaming frame should render");
+
+    assert_eq!(x.appended_since_mark(), 0);
+    assert_eq!(y.appended_since_mark(), 0);
 }
 
 #[test]

--- a/src/core/plot/prepared.rs
+++ b/src/core/plot/prepared.rs
@@ -161,10 +161,9 @@ impl PreparedPlot {
             return Ok(image);
         }
 
-        let image = self
-            .prepared_render_plot(size_px, scale_factor, time)?
-            .render()?;
-        self.plot.mark_reactive_sources_rendered();
+        let prepared_plot = self.prepared_render_plot(size_px, scale_factor, time)?;
+        let image = prepared_plot.render()?;
+        prepared_plot.acknowledge_rendered_snapshot(&self.plot);
 
         *self.cache.lock().expect("PreparedPlot cache lock poisoned") = Some(PreparedFrameCache {
             key,
@@ -339,7 +338,7 @@ impl PreparedPlot {
         );
 
         if result.is_ok() {
-            self.plot.mark_reactive_sources_rendered();
+            prepared_plot.acknowledge_rendered_snapshot(&self.plot);
         }
 
         result
@@ -662,6 +661,53 @@ mod tests {
         stream.push(1.0, 1.0);
 
         assert_eq!(hits.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_prepared_plot_acknowledges_generic_streaming_buffers() {
+        let x = crate::data::StreamingBuffer::new(16);
+        let y = crate::data::StreamingBuffer::new(16);
+        x.push_many(vec![0.0, 1.0]);
+        y.push_many(vec![0.0, 1.0]);
+        let plot: Plot = Plot::new().line_source(x.clone(), y.clone()).into();
+        let prepared = plot.prepare();
+
+        prepared
+            .render_frame((320, 240), 1.0, 0.0)
+            .expect("prepared generic streaming frame should render");
+
+        assert_eq!(x.appended_since_mark(), 0);
+        assert_eq!(y.appended_since_mark(), 0);
+    }
+
+    #[test]
+    fn test_prepared_plot_observes_legacy_lane_writes_without_pair_duplicates() {
+        let stream = StreamingXY::new(32);
+        stream.push(1.0, 10.0);
+        let plot: Plot = Plot::new()
+            .line_streaming(&stream)
+            .xlim(0.0, 3.0)
+            .ylim(0.0, 30.0)
+            .into();
+        let prepared = plot.prepare();
+        prepared
+            .render_frame((320, 240), 1.0, 0.0)
+            .expect("initial streaming frame should render");
+        let hits = Arc::new(AtomicUsize::new(0));
+        let hits_for_callback = Arc::clone(&hits);
+        let _subscription = prepared.subscribe_reactive(move || {
+            hits_for_callback.fetch_add(1, Ordering::Relaxed);
+        });
+
+        stream.x().push(2.0);
+        stream.y().push(20.0);
+
+        assert_eq!(hits.load(Ordering::Relaxed), 2);
+        assert!(prepared.is_dirty((320, 240), 1.0, 0.0));
+        prepared
+            .render_frame((320, 240), 1.0, 0.0)
+            .expect("legacy lane writes should render as an aligned pair");
+        assert!(!prepared.is_dirty((320, 240), 1.0, 0.0));
     }
 
     #[test]

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -785,7 +785,7 @@ impl Plot {
         if self.is_reactive() {
             let resolved = self.resolved_plot(0.0);
             let image = resolved.render()?;
-            self.mark_reactive_sources_rendered();
+            resolved.acknowledge_rendered_snapshot(self);
             return Ok(image);
         }
 
@@ -795,7 +795,10 @@ impl Plot {
     #[cfg(test)]
     pub(super) fn render_optimized_for_test(&self) -> Result<Image> {
         if self.is_reactive() {
-            return self.resolved_plot(0.0).render_optimized_for_test();
+            let resolved = self.resolved_plot(0.0);
+            let image = resolved.render_optimized_for_test()?;
+            resolved.acknowledge_rendered_snapshot(self);
+            return Ok(image);
         }
 
         self.render_image_with_mode(RenderExecutionMode::Optimized)
@@ -806,9 +809,10 @@ impl Plot {
         &self,
     ) -> Result<(Image, RenderDiagnostics)> {
         if self.is_reactive() {
-            return self
-                .resolved_plot(0.0)
-                .render_optimized_for_test_with_diagnostics();
+            let resolved = self.resolved_plot(0.0);
+            let result = resolved.render_optimized_for_test_with_diagnostics()?;
+            resolved.acknowledge_rendered_snapshot(self);
+            return Ok(result);
         }
 
         self.render_image_with_mode_and_diagnostics(RenderExecutionMode::Optimized)
@@ -849,7 +853,7 @@ impl Plot {
 
         let resolved = self.resolved_plot(time);
         let image = resolved.render()?;
-        self.mark_reactive_sources_rendered();
+        resolved.acknowledge_rendered_snapshot(self);
         Ok(image)
     }
 
@@ -857,14 +861,8 @@ impl Plot {
     pub fn render_png_bytes(&self) -> Result<Vec<u8>> {
         #[cfg(not(target_arch = "wasm32"))]
         {
-            let reactive = self.is_reactive();
-            let result = self
-                .save_png_bytes_with_backend()
-                .map(|(png_bytes, _, _)| png_bytes);
-            if result.is_ok() && reactive {
-                self.mark_reactive_sources_rendered();
-            }
-            result
+            self.save_png_bytes_with_backend()
+                .map(|(png_bytes, _, _)| png_bytes)
         }
 
         #[cfg(target_arch = "wasm32")]
@@ -879,14 +877,8 @@ impl Plot {
     pub fn benchmark_render_png_bytes_with_diagnostics(
         &self,
     ) -> Result<(Vec<u8>, RenderDiagnostics)> {
-        let reactive = self.is_reactive();
-        let result = self
-            .save_png_bytes_with_backend()
-            .map(|(png_bytes, _, diagnostics)| (png_bytes, diagnostics));
-        if result.is_ok() && reactive {
-            self.mark_reactive_sources_rendered();
-        }
-        result
+        self.save_png_bytes_with_backend()
+            .map(|(png_bytes, _, diagnostics)| (png_bytes, diagnostics))
     }
 
     /// Check if this plot contains any reactive data (Signal or Observable).
@@ -930,7 +922,10 @@ impl Plot {
     /// Render the plot to an external renderer (used for subplots)
     pub fn render_to_renderer(&self, renderer: &mut SkiaRenderer, dpi: f32) -> Result<()> {
         if self.is_reactive() {
-            return self.resolved_plot(0.0).render_to_renderer(renderer, dpi);
+            let resolved = self.resolved_plot(0.0);
+            resolved.render_to_renderer(renderer, dpi)?;
+            resolved.acknowledge_rendered_snapshot(self);
+            return Ok(());
         }
         if let Some(err) = self.pending_ingestion_error() {
             return Err(err);
@@ -1728,13 +1723,16 @@ impl Plot {
     /// ```
     #[cfg(not(target_arch = "wasm32"))]
     pub fn save<P: AsRef<Path>>(self, path: P) -> Result<()> {
-        let reactive = self.is_reactive();
-        let (png_bytes, _, _) = self.save_png_bytes_with_backend()?;
-        let result = crate::export::write_bytes_atomic(path, &png_bytes);
-        if result.is_ok() && reactive {
-            self.mark_reactive_sources_rendered();
+        if self.is_reactive() {
+            let resolved = self.resolved_plot(0.0);
+            let (png_bytes, _, _) = resolved.save_png_bytes_with_backend()?;
+            crate::export::write_bytes_atomic(path, &png_bytes)?;
+            resolved.acknowledge_rendered_snapshot(&self);
+            return Ok(());
         }
-        result
+
+        let (png_bytes, _, _) = self.save_png_bytes_with_backend()?;
+        crate::export::write_bytes_atomic(path, &png_bytes)
     }
 
     /// Render PNG bytes through the same backend-selection path used by `save()`.
@@ -1755,18 +1753,16 @@ impl Plot {
     pub fn benchmark_save_png_bytes_with_diagnostics(
         &self,
     ) -> Result<(Vec<u8>, &'static str, RenderDiagnostics)> {
-        let reactive = self.is_reactive();
-        let result = self.save_png_bytes_with_backend();
-        if result.is_ok() && reactive {
-            self.mark_reactive_sources_rendered();
-        }
-        result
+        self.save_png_bytes_with_backend()
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     fn save_png_bytes_with_backend(&self) -> Result<(Vec<u8>, &'static str, RenderDiagnostics)> {
         if self.is_reactive() {
-            return self.resolved_plot(0.0).save_png_bytes_with_backend();
+            let resolved = self.resolved_plot(0.0);
+            let result = resolved.save_png_bytes_with_backend()?;
+            resolved.acknowledge_rendered_snapshot(self);
+            return Ok(result);
         }
 
         let mode = self.public_png_render_mode();
@@ -1797,6 +1793,14 @@ impl Plot {
     /// Includes axes, grid, tick marks, labels, legend, and all data series.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn export_svg<P: AsRef<Path>>(self, path: P) -> Result<()> {
+        if self.is_reactive() {
+            let resolved = self.resolved_plot(0.0);
+            let svg_content = resolved.render_to_svg()?;
+            crate::export::write_bytes_atomic(path, svg_content.as_bytes())?;
+            resolved.acknowledge_rendered_snapshot(&self);
+            return Ok(());
+        }
+
         let svg_content = self.render_to_svg()?;
         crate::export::write_bytes_atomic(path, svg_content.as_bytes())
     }
@@ -2143,8 +2147,9 @@ impl Plot {
     /// or converted to other formats like PDF.
     pub fn render_to_svg(&self) -> Result<String> {
         if self.is_reactive() {
-            let svg = self.resolved_plot(0.0).render_to_svg()?;
-            self.mark_reactive_sources_rendered();
+            let resolved = self.resolved_plot(0.0);
+            let svg = resolved.render_to_svg()?;
+            resolved.acknowledge_rendered_snapshot(self);
             return Ok(svg);
         }
 
@@ -2660,12 +2665,17 @@ impl Plot {
 
         self = self.set_output_pixels(width_px, height_px);
 
-        // Render to SVG
+        if self.is_reactive() {
+            let resolved = self.resolved_plot(0.0);
+            let svg_content = resolved.render_to_svg()?;
+            let pdf_data = crate::export::svg_to_pdf(&svg_content)?;
+            crate::export::write_bytes_atomic(path, &pdf_data)?;
+            resolved.acknowledge_rendered_snapshot(&self);
+            return Ok(());
+        }
+
         let svg_content = self.render_to_svg()?;
-
-        // Convert SVG to PDF
         let pdf_data = crate::export::svg_to_pdf(&svg_content)?;
-
         crate::export::write_bytes_atomic(path, &pdf_data)
     }
 

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -3498,6 +3498,129 @@ fn test_streaming_marks_rendered() {
 }
 
 #[test]
+fn test_generic_streaming_buffers_are_acknowledged_after_render_and_svg() {
+    use crate::data::StreamingBuffer;
+
+    let x = StreamingBuffer::new(16);
+    let y = StreamingBuffer::new(16);
+    x.push_many(vec![0.0, 1.0]);
+    y.push_many(vec![0.0, 1.0]);
+    let plot: Plot = Plot::new().line_source(x.clone(), y.clone()).into();
+
+    plot.render().expect("generic streaming plot should render");
+    assert_eq!(x.appended_since_mark(), 0);
+    assert_eq!(y.appended_since_mark(), 0);
+
+    x.push(2.0);
+    y.push(4.0);
+    plot.render_to_svg()
+        .expect("generic streaming plot should render to SVG");
+    assert_eq!(x.appended_since_mark(), 0);
+    assert_eq!(y.appended_since_mark(), 0);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_generic_streaming_buffers_are_acknowledged_after_png_and_save() {
+    use crate::data::StreamingBuffer;
+
+    let x = StreamingBuffer::new(16);
+    let y = StreamingBuffer::new(16);
+    x.push_many(vec![0.0, 1.0]);
+    y.push_many(vec![0.0, 1.0]);
+    let plot: Plot = Plot::new().line_source(x.clone(), y.clone()).into();
+
+    plot.render_png_bytes()
+        .expect("generic streaming PNG bytes should render");
+    assert_eq!(x.appended_since_mark(), 0);
+    assert_eq!(y.appended_since_mark(), 0);
+
+    x.push(2.0);
+    y.push(4.0);
+    let path = std::env::temp_dir().join(format!(
+        "ruviz-generic-streaming-save-{}-{}.png",
+        std::process::id(),
+        x.version()
+    ));
+    plot.save(&path)
+        .expect("generic streaming plot should save successfully");
+    assert_eq!(x.appended_since_mark(), 0);
+    assert_eq!(y.appended_since_mark(), 0);
+    std::fs::remove_file(path).expect("temporary saved plot should be removable");
+}
+
+#[test]
+fn test_streaming_resolved_plot_acknowledges_exact_captured_sequence() {
+    use crate::data::{StreamingRenderState, StreamingXY};
+
+    let stream = StreamingXY::new(100);
+    stream.push_many(vec![(0.0, 0.0), (1.0, 1.0)]);
+    let plot = Plot::new().line_streaming(&stream).end_series();
+
+    let resolved = plot.resolved_plot(0.0);
+    stream.push(2.0, 4.0);
+    resolved.mark_reactive_sources_rendered();
+
+    assert_eq!(stream.appended_count(), 1);
+    assert_eq!(stream.read_appended_x(), vec![2.0]);
+    assert_eq!(stream.read_appended_y(), vec![4.0]);
+    assert_eq!(
+        stream.render_state(),
+        StreamingRenderState::AppendOnly {
+            visible_appended: 1
+        }
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_failed_streaming_save_does_not_acknowledge_snapshot() {
+    use crate::data::StreamingXY;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let stream = StreamingXY::new(100);
+    stream.push_many(vec![(0.0, 0.0), (1.0, 1.0)]);
+    let plot = Plot::new().line_streaming(&stream).end_series();
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should follow the Unix epoch")
+        .as_nanos();
+    let invalid_parent =
+        std::env::temp_dir().join(format!("ruviz-file-parent-{}-{unique}", std::process::id()));
+    std::fs::write(&invalid_parent, b"not a directory")
+        .expect("temporary blocker file should be writable");
+    let path = invalid_parent.join("plot.png");
+
+    assert!(plot.save(path).is_err());
+    assert_eq!(stream.appended_count(), 2);
+    std::fs::remove_file(invalid_parent).expect("temporary blocker file should be removable");
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn test_failed_streaming_svg_export_does_not_acknowledge_snapshot() {
+    use crate::data::StreamingXY;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let stream = StreamingXY::new(100);
+    stream.push_many(vec![(0.0, 0.0), (1.0, 1.0)]);
+    let plot = Plot::new().line_streaming(&stream).end_series();
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should follow the Unix epoch")
+        .as_nanos();
+    let invalid_parent =
+        std::env::temp_dir().join(format!("ruviz-svg-parent-{}-{unique}", std::process::id()));
+    std::fs::write(&invalid_parent, b"not a directory")
+        .expect("temporary blocker file should be writable");
+    let path = invalid_parent.join("plot.svg");
+
+    assert!(plot.export_svg(path).is_err());
+    assert_eq!(stream.appended_count(), 2);
+    std::fs::remove_file(invalid_parent).expect("temporary blocker file should be removable");
+}
+
+#[test]
 fn test_line_streaming_reads_updates_after_build() {
     use crate::data::StreamingXY;
 

--- a/src/core/plot/types.rs
+++ b/src/core/plot/types.rs
@@ -526,7 +526,14 @@ impl PlotSeries {
     }
 
     pub(super) fn collect_source_versions(&self, versions: &mut Vec<u64>) {
-        self.series_type.collect_source_versions(versions);
+        if let Some(stream) = &self.streaming_source {
+            stream.refresh_legacy_lanes();
+            versions.push(stream.version());
+            versions.push(stream.x().version());
+            versions.push(stream.y().version());
+        } else {
+            self.series_type.collect_source_versions(versions);
+        }
         if let Some(version) = self
             .color_source
             .as_ref()
@@ -654,7 +661,50 @@ impl PlotSeries {
     }
 
     pub(super) fn mark_rendered_sources(&self) {
-        self.series_type.mark_rendered_sources();
+        if let Some(stream) = &self.streaming_source {
+            stream.mark_rendered();
+        } else {
+            self.series_type.mark_rendered_sources();
+        }
+    }
+
+    pub(super) fn mark_unpaired_streaming_sources_rendered(&self) {
+        if self.streaming_source.is_none() {
+            self.series_type.mark_rendered_sources();
+        }
+    }
+
+    pub(super) fn has_live_streaming_pair(&self) -> bool {
+        self.streaming_source.is_some()
+            && matches!(
+                &self.series_type,
+                SeriesType::Line { x_data, y_data }
+                    | SeriesType::Scatter { x_data, y_data }
+                    if matches!(x_data, PlotData::Streaming(_))
+                        && matches!(y_data, PlotData::Streaming(_))
+            )
+    }
+
+    pub(super) fn resolve_for_render(&self, time: f64) -> Result<ResolvedSeries<'_>> {
+        if self.has_live_streaming_pair() {
+            let snapshot = self
+                .streaming_source
+                .as_ref()
+                .expect("live streaming pair must retain its source")
+                .snapshot();
+            return Ok(match &self.series_type {
+                SeriesType::Line { .. } => ResolvedSeries::Line {
+                    x: Cow::Owned(snapshot.x().to_vec()),
+                    y: Cow::Owned(snapshot.y().to_vec()),
+                },
+                SeriesType::Scatter { .. } => ResolvedSeries::Scatter {
+                    x: Cow::Owned(snapshot.x().to_vec()),
+                    y: Cow::Owned(snapshot.y().to_vec()),
+                },
+                _ => unreachable!("live paired source is only used by line/scatter"),
+            });
+        }
+        self.series_type.resolve_for_render(time)
     }
 
     pub(super) fn subscribe_push_updates(
@@ -665,9 +715,35 @@ impl PlotSeries {
         if let Some(stream) = &self.streaming_source {
             let stream = stream.clone();
             let callback = Arc::clone(callback);
-            let id = stream.subscribe_paired(move || callback());
+            stream.refresh_legacy_lanes();
+            let observed_versions = Arc::new(std::sync::Mutex::new((
+                stream.version(),
+                stream.x().version(),
+                stream.y().version(),
+            )));
+            let make_callback = |stream: crate::data::StreamingXY| {
+                let callback = Arc::clone(&callback);
+                let observed_versions = Arc::clone(&observed_versions);
+                move || {
+                    stream.refresh_legacy_lanes();
+                    let current = (stream.version(), stream.x().version(), stream.y().version());
+                    let mut observed = observed_versions
+                        .lock()
+                        .expect("Streaming subscription version lock poisoned");
+                    if *observed != current {
+                        *observed = current;
+                        drop(observed);
+                        callback();
+                    }
+                }
+            };
+            let paired_id = stream.subscribe_paired(make_callback(stream.clone()));
+            let x_id = stream.x().subscribe(make_callback(stream.clone()));
+            let y_id = stream.y().subscribe(make_callback(stream.clone()));
             teardowns.push(Box::new(move || {
-                stream.unsubscribe_paired(id);
+                stream.unsubscribe_paired(paired_id);
+                stream.x().unsubscribe(x_id);
+                stream.y().unsubscribe(y_id);
             }));
         } else {
             self.series_type.subscribe_push_updates(callback, teardowns);

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -28,7 +28,8 @@ pub use memory_pool::{MemoryPool, PoolStatistics, PooledBuffer, SharedMemoryPool
 pub use observable::{
     BatchNotifier, BatchUpdate, IntoObservable, Observable, ReactiveDataHandle,
     SlidingWindowObservable, StreamingBuffer, StreamingBufferView, StreamingRenderState,
-    StreamingXY, SubscriberCallback, SubscriberId, WeakObservable, lift, lift2, map,
+    StreamingXY, StreamingXYSnapshot, SubscriberCallback, SubscriberId, WeakObservable, lift,
+    lift2, map,
 };
 pub use platform::{
     MemoryLimits, OptimizationConfig, PerformanceHints, PlatformInfo, PlatformOptimizer,

--- a/src/data/observable.rs
+++ b/src/data/observable.rs
@@ -31,7 +31,9 @@
 //! ```
 
 use crate::core::{PlottingError, Result};
+use std::collections::VecDeque;
 use std::ops::Deref;
+use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, Weak};
 
@@ -51,6 +53,151 @@ struct DropHookId(u64);
 struct Subscriber {
     id: SubscriberId,
     callback: SharedSubscriberCallback,
+}
+
+#[derive(Default)]
+struct NotificationStatus {
+    batch_depth: usize,
+    dirty: bool,
+    dispatching: bool,
+}
+
+#[derive(Default)]
+struct NotificationState {
+    status: Mutex<NotificationStatus>,
+}
+
+#[derive(Default)]
+struct PairNotificationStatus {
+    pending: usize,
+    dispatching: bool,
+}
+
+#[derive(Default)]
+struct PairNotificationState {
+    status: Mutex<PairNotificationStatus>,
+}
+
+impl PairNotificationState {
+    fn queue(&self) -> bool {
+        let mut status = self.status.lock().expect("Pair notification lock poisoned");
+        status.pending = status.pending.saturating_add(1);
+        if status.dispatching {
+            false
+        } else {
+            status.dispatching = true;
+            true
+        }
+    }
+
+    fn take_pending(&self) -> bool {
+        let mut status = self.status.lock().expect("Pair notification lock poisoned");
+        if status.pending > 0 {
+            status.pending -= 1;
+            true
+        } else {
+            status.dispatching = false;
+            false
+        }
+    }
+}
+
+struct DispatchReset<'a> {
+    notifications: &'a NotificationState,
+    armed: bool,
+}
+
+impl Drop for DispatchReset<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.notifications
+                .status
+                .lock()
+                .expect("Notification lock poisoned")
+                .dispatching = false;
+        }
+    }
+}
+
+impl NotificationState {
+    fn begin_batch(&self) {
+        let mut status = self.status.lock().expect("Notification lock poisoned");
+        status.batch_depth = status.batch_depth.saturating_add(1);
+    }
+
+    fn end_batch(&self) {
+        let mut status = self.status.lock().expect("Notification lock poisoned");
+        assert!(status.batch_depth > 0, "Unbalanced observable batch");
+        status.batch_depth -= 1;
+    }
+
+    fn flush(&self, subscribers: &RwLock<Vec<Subscriber>>, lock_error: &str) {
+        let should_dispatch = {
+            let mut status = self.status.lock().expect("Notification lock poisoned");
+            if status.batch_depth == 0 && status.dirty && !status.dispatching {
+                status.dispatching = true;
+                true
+            } else {
+                false
+            }
+        };
+        if should_dispatch {
+            self.drain(subscribers, lock_error);
+        }
+    }
+
+    fn request(&self, subscribers: &RwLock<Vec<Subscriber>>, lock_error: &str) {
+        let should_dispatch = {
+            let mut status = self.status.lock().expect("Notification lock poisoned");
+            status.dirty = true;
+            if status.batch_depth == 0 && !status.dispatching {
+                status.dispatching = true;
+                true
+            } else {
+                false
+            }
+        };
+        if should_dispatch {
+            self.drain(subscribers, lock_error);
+        }
+    }
+
+    fn drain(&self, subscribers: &RwLock<Vec<Subscriber>>, lock_error: &str) {
+        let mut reset = DispatchReset {
+            notifications: self,
+            armed: true,
+        };
+        let mut first_panic = None;
+        loop {
+            let should_notify = {
+                let mut status = self.status.lock().expect("Notification lock poisoned");
+                if status.batch_depth > 0 || !status.dirty {
+                    status.dispatching = false;
+                    reset.armed = false;
+                    false
+                } else {
+                    status.dirty = false;
+                    true
+                }
+            };
+            if !should_notify {
+                break;
+            }
+
+            let callbacks = collect_subscriber_callbacks(subscribers, lock_error);
+            for callback in callbacks {
+                if let Err(payload) = catch_unwind(AssertUnwindSafe(|| callback())) {
+                    if first_panic.is_none() {
+                        first_panic = Some(payload);
+                    }
+                }
+            }
+        }
+
+        if let Some(payload) = first_panic {
+            resume_unwind(payload);
+        }
+    }
 }
 
 struct DropHookEntry {
@@ -148,6 +295,8 @@ pub struct Observable<T> {
     subscribers: Arc<RwLock<Vec<Subscriber>>>,
     /// Counter for generating unique subscriber IDs
     next_subscriber_id: Arc<AtomicU64>,
+    /// Shared batching and non-recursive dispatch state.
+    notifications: Arc<NotificationState>,
     /// Internal lifecycle hooks for derived subscriptions and cleanup.
     lifecycle: Arc<ObservableLifecycle>,
 }
@@ -159,6 +308,7 @@ impl<T> Clone for Observable<T> {
             version: Arc::clone(&self.version),
             subscribers: Arc::clone(&self.subscribers),
             next_subscriber_id: Arc::clone(&self.next_subscriber_id),
+            notifications: Arc::clone(&self.notifications),
             lifecycle: Arc::clone(&self.lifecycle),
         }
     }
@@ -206,6 +356,7 @@ impl<T> Observable<T> {
             version: Arc::new(AtomicU64::new(0)),
             subscribers: Arc::new(RwLock::new(Vec::new())),
             next_subscriber_id: Arc::new(AtomicU64::new(0)),
+            notifications: Arc::new(NotificationState::default()),
             lifecycle: Arc::new(ObservableLifecycle::new()),
         }
     }
@@ -402,11 +553,8 @@ impl<T> Observable<T> {
 
     /// Notify all subscribers of a change
     fn notify_subscribers(&self) {
-        let callbacks =
-            collect_subscriber_callbacks(&self.subscribers, "Subscribers lock poisoned");
-        for callback in callbacks {
-            callback();
-        }
+        self.notifications
+            .request(&self.subscribers, "Subscribers lock poisoned");
     }
 
     fn on_last_drop<F>(&self, hook: F) -> DropHookId
@@ -435,6 +583,7 @@ impl<T> Observable<T> {
             version: Arc::downgrade(&self.version),
             subscribers: Arc::downgrade(&self.subscribers),
             next_subscriber_id: Arc::downgrade(&self.next_subscriber_id),
+            notifications: Arc::downgrade(&self.notifications),
             lifecycle: Arc::downgrade(&self.lifecycle),
         }
     }
@@ -464,6 +613,7 @@ pub struct WeakObservable<T> {
     version: Weak<AtomicU64>,
     subscribers: Weak<RwLock<Vec<Subscriber>>>,
     next_subscriber_id: Weak<AtomicU64>,
+    notifications: Weak<NotificationState>,
     lifecycle: Weak<ObservableLifecycle>,
 }
 
@@ -474,6 +624,7 @@ impl<T> Clone for WeakObservable<T> {
             version: Weak::clone(&self.version),
             subscribers: Weak::clone(&self.subscribers),
             next_subscriber_id: Weak::clone(&self.next_subscriber_id),
+            notifications: Weak::clone(&self.notifications),
             lifecycle: Weak::clone(&self.lifecycle),
         }
     }
@@ -488,6 +639,7 @@ impl<T> WeakObservable<T> {
         let version = self.version.upgrade()?;
         let subscribers = self.subscribers.upgrade()?;
         let next_subscriber_id = self.next_subscriber_id.upgrade()?;
+        let notifications = self.notifications.upgrade()?;
         let lifecycle = self.lifecycle.upgrade()?;
 
         Some(Observable {
@@ -495,6 +647,7 @@ impl<T> WeakObservable<T> {
             version,
             subscribers,
             next_subscriber_id,
+            notifications,
             lifecycle,
         })
     }
@@ -531,16 +684,41 @@ impl<T> WeakObservable<T> {
 /// ```
 pub struct BatchUpdate<'a> {
     observables: Vec<&'a dyn BatchNotifier>,
+    notification_keys: Vec<*const NotificationState>,
 }
 
 /// Trait for types that can participate in batch updates
 pub trait BatchNotifier {
     fn notify(&self);
+
+    #[doc(hidden)]
+    fn begin_batch(&self) {}
+
+    #[doc(hidden)]
+    fn end_batch(&self) {}
+
+    #[doc(hidden)]
+    fn flush_batch(&self) {
+        self.notify();
+    }
 }
 
 impl<T> BatchNotifier for Observable<T> {
     fn notify(&self) {
         self.notify_subscribers();
+    }
+
+    fn begin_batch(&self) {
+        self.notifications.begin_batch();
+    }
+
+    fn end_batch(&self) {
+        self.notifications.end_batch();
+    }
+
+    fn flush_batch(&self) {
+        self.notifications
+            .flush(&self.subscribers, "Subscribers lock poisoned");
     }
 }
 
@@ -549,11 +727,18 @@ impl<'a> BatchUpdate<'a> {
     pub fn new() -> Self {
         Self {
             observables: Vec::new(),
+            notification_keys: Vec::new(),
         }
     }
 
     /// Add an observable to the batch
     pub fn add<T>(&mut self, observable: &'a Observable<T>) {
+        let key = Arc::as_ptr(&observable.notifications);
+        if self.notification_keys.contains(&key) {
+            return;
+        }
+        observable.begin_batch();
+        self.notification_keys.push(key);
         self.observables.push(observable);
     }
 }
@@ -567,7 +752,20 @@ impl<'a> Default for BatchUpdate<'a> {
 impl<'a> Drop for BatchUpdate<'a> {
     fn drop(&mut self) {
         for obs in &self.observables {
-            obs.notify();
+            obs.end_batch();
+        }
+        let mut first_panic = None;
+        for obs in &self.observables {
+            if let Err(payload) = catch_unwind(AssertUnwindSafe(|| obs.flush_batch())) {
+                if first_panic.is_none() {
+                    first_panic = Some(payload);
+                }
+            }
+        }
+        if !std::thread::panicking() {
+            if let Some(payload) = first_panic {
+                resume_unwind(payload);
+            }
         }
     }
 }
@@ -1082,6 +1280,8 @@ pub struct StreamingBuffer<T> {
     write_pos: Arc<std::sync::atomic::AtomicUsize>,
     /// Total elements written (used to determine if full)
     total_written: Arc<AtomicU64>,
+    /// Number of explicit clears, used by paired legacy-lane reconciliation.
+    clear_generation: Arc<AtomicU64>,
     /// Version counter for change detection
     version: Arc<AtomicU64>,
     /// Append count since last mark_rendered()
@@ -1118,6 +1318,7 @@ impl<T: Clone> StreamingBuffer<T> {
             capacity,
             write_pos: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             total_written: Arc::new(AtomicU64::new(0)),
+            clear_generation: Arc::new(AtomicU64::new(0)),
             version: Arc::new(AtomicU64::new(0)),
             appended_since_render: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             subscribers: Arc::new(RwLock::new(Vec::new())),
@@ -1127,21 +1328,23 @@ impl<T: Clone> StreamingBuffer<T> {
 
     /// Push a single value (O(1) operation)
     pub fn push(&self, value: T) {
-        {
-            let mut data = self.data.write().expect("Lock poisoned");
-            let write_pos = self.write_pos.load(Ordering::Relaxed);
-            let pos = write_pos % self.capacity;
-            data[pos] = Some(value);
-            self.write_pos
-                .store(write_pos.wrapping_add(1), Ordering::Release);
-            let total = self.total_written.load(Ordering::Relaxed);
-            self.total_written
-                .store(total.saturating_add(1), Ordering::Release);
-            let appended = self.appended_since_render.load(Ordering::Relaxed);
-            self.appended_since_render
-                .store(appended.saturating_add(1), Ordering::Release);
-        }
+        self.push_locked(value);
         self.bump_version();
+    }
+
+    fn push_locked(&self, value: T) {
+        let mut data = self.data.write().expect("Lock poisoned");
+        let write_pos = self.write_pos.load(Ordering::Relaxed);
+        let pos = write_pos % self.capacity;
+        data[pos] = Some(value);
+        self.write_pos
+            .store(write_pos.wrapping_add(1), Ordering::Release);
+        let total = self.total_written.load(Ordering::Relaxed);
+        self.total_written
+            .store(total.saturating_add(1), Ordering::Release);
+        let appended = self.appended_since_render.load(Ordering::Relaxed);
+        self.appended_since_render
+            .store(appended.saturating_add(1), Ordering::Release);
     }
 
     /// Push multiple values efficiently
@@ -1153,27 +1356,34 @@ impl<T: Clone> StreamingBuffer<T> {
             return;
         }
 
-        {
-            let mut data = self.data.write().expect("Lock poisoned");
-            let mut write_pos = self.write_pos.load(Ordering::Relaxed);
-            for value in values {
-                let pos = write_pos % self.capacity;
-                data[pos] = Some(value);
-                write_pos = write_pos.wrapping_add(1);
-            }
-            self.write_pos.store(write_pos, Ordering::Release);
-            let total = self.total_written.load(Ordering::Relaxed);
-            self.total_written
-                .store(total.saturating_add(count as u64), Ordering::Release);
-            let appended = self.appended_since_render.load(Ordering::Relaxed);
-            self.appended_since_render
-                .store(appended.saturating_add(count), Ordering::Release);
-        }
+        self.push_many_locked(values);
         self.bump_version();
+    }
+
+    fn push_many_locked(&self, values: Vec<T>) {
+        let count = values.len();
+        let mut data = self.data.write().expect("Lock poisoned");
+        let mut write_pos = self.write_pos.load(Ordering::Relaxed);
+        for value in values {
+            let pos = write_pos % self.capacity;
+            data[pos] = Some(value);
+            write_pos = write_pos.wrapping_add(1);
+        }
+        self.write_pos.store(write_pos, Ordering::Release);
+        let total = self.total_written.load(Ordering::Relaxed);
+        self.total_written
+            .store(total.saturating_add(count as u64), Ordering::Release);
+        let appended = self.appended_since_render.load(Ordering::Relaxed);
+        self.appended_since_render
+            .store(appended.saturating_add(count), Ordering::Release);
     }
 
     /// Get all valid data in order (oldest to newest)
     pub fn read(&self) -> Vec<T> {
+        self.read_locked()
+    }
+
+    fn read_locked(&self) -> Vec<T> {
         let data = self.data.read().expect("Lock poisoned");
         let total = self.total_written.load(Ordering::Acquire);
         let write_pos = self.write_pos.load(Ordering::Acquire);
@@ -1341,16 +1551,19 @@ impl<T: Clone> StreamingBuffer<T> {
 
     /// Clear all data
     pub fn clear(&self) {
-        {
-            let mut data = self.data.write().expect("Lock poisoned");
-            for slot in data.iter_mut() {
-                *slot = None;
-            }
-            self.write_pos.store(0, Ordering::Release);
-            self.total_written.store(0, Ordering::Release);
-            self.appended_since_render.store(0, Ordering::Release);
-        }
+        self.clear_locked();
         self.bump_version();
+    }
+
+    fn clear_locked(&self) {
+        let mut data = self.data.write().expect("Lock poisoned");
+        for slot in data.iter_mut() {
+            *slot = None;
+        }
+        self.write_pos.store(0, Ordering::Release);
+        self.total_written.store(0, Ordering::Release);
+        self.appended_since_render.store(0, Ordering::Release);
+        self.clear_generation.fetch_add(1, Ordering::Release);
     }
 
     /// Subscribe to changes
@@ -1383,7 +1596,15 @@ impl<T: Clone> StreamingBuffer<T> {
 
     /// Bump version and notify subscribers
     fn bump_version(&self) {
+        self.increment_version();
+        self.notify_subscribers();
+    }
+
+    fn increment_version(&self) {
         self.version.fetch_add(1, Ordering::Release);
+    }
+
+    fn notify_subscribers(&self) {
         let callbacks = collect_subscriber_callbacks(&self.subscribers, "Lock poisoned");
         for callback in callbacks {
             callback();
@@ -1398,6 +1619,7 @@ impl<T: Clone> Clone for StreamingBuffer<T> {
             capacity: self.capacity,
             write_pos: Arc::clone(&self.write_pos),
             total_written: Arc::clone(&self.total_written),
+            clear_generation: Arc::clone(&self.clear_generation),
             version: Arc::clone(&self.version),
             appended_since_render: Arc::clone(&self.appended_since_render),
             subscribers: Arc::clone(&self.subscribers),
@@ -1406,46 +1628,196 @@ impl<T: Clone> Clone for StreamingBuffer<T> {
     }
 }
 
-/// Paired streaming buffers for X/Y time-series data
+/// An owned, aligned capture of a [`StreamingXY`] pair.
+#[derive(Clone, Debug)]
+pub struct StreamingXYSnapshot {
+    x: Vec<f64>,
+    y: Vec<f64>,
+    sequence: u64,
+    rendered_through: u64,
+    render_state: StreamingRenderState,
+    appended_start: usize,
+}
+
+impl StreamingXYSnapshot {
+    /// Captured X values, aligned with [`StreamingXYSnapshot::y`].
+    pub fn x(&self) -> &[f64] {
+        &self.x
+    }
+
+    /// Captured Y values, aligned with [`StreamingXYSnapshot::x`].
+    pub fn y(&self) -> &[f64] {
+        &self.y
+    }
+
+    /// Pair sequence captured with the values.
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    /// Highest pair sequence acknowledged when this snapshot was captured.
+    pub fn rendered_through(&self) -> u64 {
+        self.rendered_through
+    }
+
+    /// Rendering work pending at capture time.
+    pub fn render_state(&self) -> StreamingRenderState {
+        self.render_state
+    }
+
+    /// Aligned visible X tail that may be appended incrementally.
+    pub fn appended_x(&self) -> &[f64] {
+        &self.x[self.appended_start..]
+    }
+
+    /// Aligned visible Y tail that may be appended incrementally.
+    pub fn appended_y(&self) -> &[f64] {
+        &self.y[self.appended_start..]
+    }
+}
+
+#[derive(Debug)]
+struct StreamingXYProgress {
+    sequence: u64,
+    rendered_through: u64,
+    total_written: u64,
+    last_clear_sequence: Option<u64>,
+    synced_x_total: u64,
+    synced_y_total: u64,
+    synced_x_version: u64,
+    synced_y_version: u64,
+    synced_x_clear_generation: u64,
+    synced_y_clear_generation: u64,
+}
+
+/// Paired streaming buffers for X/Y time-series data.
 ///
-/// Provides synchronized updates and version tracking for plot integration
+/// Mutations through this type commit both lanes before any lane or pair
+/// subscriber is notified.
 pub struct StreamingXY {
     x: StreamingBuffer<f64>,
     y: StreamingBuffer<f64>,
+    mutation_gate: Arc<Mutex<()>>,
+    paired_data: Arc<Mutex<VecDeque<(f64, f64)>>>,
+    progress: Arc<Mutex<StreamingXYProgress>>,
     subscribers: Arc<RwLock<Vec<Subscriber>>>,
     next_subscriber_id: Arc<AtomicU64>,
+    notifications: Arc<NotificationState>,
+    pair_notifications: Arc<PairNotificationState>,
+    acknowledge_through: Option<u64>,
+    #[cfg(test)]
+    pair_commit_hook: Arc<Mutex<Option<SharedSubscriberCallback>>>,
 }
 
 impl StreamingXY {
     /// Create a new paired streaming buffer
     pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
         Self {
-            x: StreamingBuffer::new(capacity),
-            y: StreamingBuffer::new(capacity),
+            x: StreamingBuffer::with_capacity(capacity),
+            y: StreamingBuffer::with_capacity(capacity),
+            mutation_gate: Arc::new(Mutex::new(())),
+            paired_data: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
+            progress: Arc::new(Mutex::new(StreamingXYProgress {
+                sequence: 0,
+                rendered_through: 0,
+                total_written: 0,
+                last_clear_sequence: None,
+                synced_x_total: 0,
+                synced_y_total: 0,
+                synced_x_version: 0,
+                synced_y_version: 0,
+                synced_x_clear_generation: 0,
+                synced_y_clear_generation: 0,
+            })),
             subscribers: Arc::new(RwLock::new(Vec::new())),
             next_subscriber_id: Arc::new(AtomicU64::new(0)),
+            notifications: Arc::new(NotificationState::default()),
+            pair_notifications: Arc::new(PairNotificationState::default()),
+            acknowledge_through: None,
+            #[cfg(test)]
+            pair_commit_hook: Arc::new(Mutex::new(None)),
         }
     }
 
     /// Push a single X/Y point
     pub fn push(&self, x: f64, y: f64) {
-        self.x.push(x);
-        self.y.push(y);
-        self.notify_subscribers();
+        let should_dispatch = {
+            let _gate = self.mutation_gate.lock().expect("Mutation gate poisoned");
+            self.reconcile_legacy_lanes_locked();
+            self.x.push_locked(x);
+            self.run_pair_commit_hook();
+            self.y.push_locked(y);
+            self.x.increment_version();
+            self.y.increment_version();
+            let mut paired_data = self.paired_data.lock().expect("Paired data lock poisoned");
+            if paired_data.len() == self.x.capacity() {
+                paired_data.pop_front();
+            }
+            paired_data.push_back((x, y));
+            self.record_push_locked(1);
+            self.pair_notifications.queue()
+        };
+        if should_dispatch {
+            self.drain_pair_notifications();
+        }
     }
 
     /// Push multiple X/Y points
     pub fn push_many(&self, points: impl IntoIterator<Item = (f64, f64)>) {
-        let mut pushed_any = false;
-        for (x, y) in points {
-            self.x.push(x);
-            self.y.push(y);
-            pushed_any = true;
+        let points: Vec<_> = points.into_iter().collect();
+        if points.is_empty() {
+            return;
         }
 
-        if pushed_any {
-            self.notify_subscribers();
+        let count = points.len();
+        let x = points.iter().map(|(x, _)| *x).collect();
+        let y = points.iter().map(|(_, y)| *y).collect();
+        let should_dispatch = {
+            let _gate = self.mutation_gate.lock().expect("Mutation gate poisoned");
+            self.reconcile_legacy_lanes_locked();
+            self.x.push_many_locked(x);
+            self.run_pair_commit_hook();
+            self.y.push_many_locked(y);
+            self.x.increment_version();
+            self.y.increment_version();
+            let mut paired_data = self.paired_data.lock().expect("Paired data lock poisoned");
+            for point in points {
+                if paired_data.len() == self.x.capacity() {
+                    paired_data.pop_front();
+                }
+                paired_data.push_back(point);
+            }
+            self.record_push_locked(count);
+            self.pair_notifications.queue()
+        };
+        if should_dispatch {
+            self.drain_pair_notifications();
         }
+    }
+
+    fn record_push_locked(&self, count: usize) {
+        let mut progress = self.progress.lock().expect("StreamingXY progress poisoned");
+        progress.sequence = progress.sequence.wrapping_add(count as u64);
+        progress.total_written = progress.total_written.saturating_add(count as u64);
+        progress.synced_x_total = self.x.total_written();
+        progress.synced_y_total = self.y.total_written();
+        progress.synced_x_version = self.x.version();
+        progress.synced_y_version = self.y.version();
+        progress.synced_x_clear_generation = self.x.clear_generation.load(Ordering::Acquire);
+        progress.synced_y_clear_generation = self.y.clear_generation.load(Ordering::Acquire);
+        self.sync_lane_watermarks(&progress);
+    }
+
+    fn sync_lane_watermarks(&self, progress: &StreamingXYProgress) {
+        let pending =
+            usize::try_from(Self::pending_sample_count_locked(progress)).unwrap_or(usize::MAX);
+        self.x
+            .appended_since_render
+            .store(pending, Ordering::Release);
+        self.y
+            .appended_since_render
+            .store(pending, Ordering::Release);
     }
 
     /// Get the X buffer
@@ -1460,12 +1832,12 @@ impl StreamingXY {
 
     /// Read all X data
     pub fn read_x(&self) -> Vec<f64> {
-        self.x.read()
+        self.x.read_locked()
     }
 
     /// Read all Y data
     pub fn read_y(&self) -> Vec<f64> {
-        self.y.read()
+        self.y.read_locked()
     }
 
     /// Zero-copy view into X buffer
@@ -1487,29 +1859,50 @@ impl StreamingXY {
     /// Returns views for both buffers, useful for iterating over pairs.
     /// Note: Both locks are held until both views are dropped.
     pub fn read_view(&self) -> (StreamingBufferView<'_, f64>, StreamingBufferView<'_, f64>) {
-        (self.x.read_view(), self.y.read_view())
+        let gate = self.mutation_gate.lock().expect("Mutation gate poisoned");
+        let x = self.x.read_view();
+        let y = self.y.read_view();
+        drop(gate);
+        (x, y)
     }
 
     /// Read only appended X data since last render
     pub fn read_appended_x(&self) -> Vec<f64> {
-        self.x.read_appended()
+        self.snapshot().appended_x().to_vec()
     }
 
     /// Read only appended Y data since last render
     pub fn read_appended_y(&self) -> Vec<f64> {
-        self.y.read_appended()
+        self.snapshot().appended_y().to_vec()
     }
 
     /// Get the number of points appended since last render
     pub fn appended_count(&self) -> usize {
-        // Both buffers should have same count
-        self.x.appended_since_mark()
+        self.refresh_legacy_lanes();
+        let progress = self.progress.lock().expect("StreamingXY progress poisoned");
+        let appended = Self::pending_sample_count_locked(&progress);
+        usize::try_from(appended).unwrap_or(usize::MAX)
     }
 
     /// Mark both buffers as rendered
     pub fn mark_rendered(&self) {
-        self.x.mark_rendered();
-        self.y.mark_rendered();
+        let sequence = self
+            .acknowledge_through
+            .unwrap_or_else(|| self.snapshot().sequence());
+        self.mark_rendered_through(sequence);
+    }
+
+    /// Monotonically acknowledge rendering through an exact captured sequence.
+    pub fn mark_rendered_through(&self, sequence: u64) {
+        let _gate = self.mutation_gate.lock().expect("Mutation gate poisoned");
+        self.reconcile_legacy_lanes_locked();
+        let mut progress = self.progress.lock().expect("StreamingXY progress poisoned");
+        if Self::sequence_after(sequence, progress.rendered_through)
+            && !Self::sequence_after(sequence, progress.sequence)
+        {
+            progress.rendered_through = sequence;
+        }
+        self.sync_lane_watermarks(&progress);
     }
 
     /// Check if partial rendering is possible
@@ -1522,22 +1915,7 @@ impl StreamingXY {
 
     /// Describe whether the paired buffers can be rendered incrementally.
     pub fn render_state(&self) -> StreamingRenderState {
-        match (self.x.render_state(), self.y.render_state()) {
-            (StreamingRenderState::Unchanged, StreamingRenderState::Unchanged) => {
-                StreamingRenderState::Unchanged
-            }
-            (
-                StreamingRenderState::AppendOnly {
-                    visible_appended: x,
-                },
-                StreamingRenderState::AppendOnly {
-                    visible_appended: y,
-                },
-            ) => StreamingRenderState::AppendOnly {
-                visible_appended: x.min(y),
-            },
-            _ => StreamingRenderState::FullRedrawRequired,
-        }
+        self.snapshot().render_state()
     }
 
     /// Get the combined version (max of X and Y versions)
@@ -1552,15 +1930,256 @@ impl StreamingXY {
 
     /// Check if empty
     pub fn is_empty(&self) -> bool {
-        self.x.is_empty()
+        self.len() == 0
     }
 
     /// Clear both buffers
     pub fn clear(&self) {
-        self.x.clear();
-        self.y.clear();
-        self.notify_subscribers();
+        let should_dispatch = {
+            let _gate = self.mutation_gate.lock().expect("Mutation gate poisoned");
+            self.x.clear_locked();
+            self.y.clear_locked();
+            let mut paired_data = self.paired_data.lock().expect("Paired data lock poisoned");
+            paired_data.clear();
+            let mut progress = self.progress.lock().expect("StreamingXY progress poisoned");
+            self.x.increment_version();
+            self.y.increment_version();
+            progress.sequence = progress.sequence.wrapping_add(1);
+            progress.total_written = 0;
+            progress.last_clear_sequence = Some(progress.sequence);
+            progress.synced_x_total = 0;
+            progress.synced_y_total = 0;
+            progress.synced_x_version = self.x.version();
+            progress.synced_y_version = self.y.version();
+            progress.synced_x_clear_generation = self.x.clear_generation.load(Ordering::Acquire);
+            progress.synced_y_clear_generation = self.y.clear_generation.load(Ordering::Acquire);
+            self.sync_lane_watermarks(&progress);
+            self.pair_notifications.queue()
+        };
+        if should_dispatch {
+            self.drain_pair_notifications();
+        }
     }
+
+    /// Capture aligned owned values and the exact rendering watermark state.
+    pub fn snapshot(&self) -> StreamingXYSnapshot {
+        let _pair_gate = self.mutation_gate.lock().expect("Mutation gate poisoned");
+        let mut paired_data = self.paired_data.lock().expect("Paired data lock poisoned");
+        let mut progress = self.progress.lock().expect("StreamingXY progress poisoned");
+        self.reconcile_legacy_lanes(&mut paired_data, &mut progress);
+
+        let mut x = Vec::with_capacity(paired_data.len());
+        let mut y = Vec::with_capacity(paired_data.len());
+        for &(x_value, y_value) in paired_data.iter() {
+            x.push(x_value);
+            y.push(y_value);
+        }
+        let render_state = Self::render_state_locked(&progress, x.len(), self.x.capacity());
+        let visible_appended = usize::try_from(Self::pending_sample_count_locked(&progress))
+            .unwrap_or(usize::MAX)
+            .min(x.len());
+        let appended_start = x.len().saturating_sub(visible_appended);
+        StreamingXYSnapshot {
+            x,
+            y,
+            sequence: progress.sequence,
+            rendered_through: progress.rendered_through,
+            render_state,
+            appended_start,
+        }
+    }
+
+    fn reconcile_legacy_lanes(
+        &self,
+        paired_data: &mut VecDeque<(f64, f64)>,
+        progress: &mut StreamingXYProgress,
+    ) {
+        let x_version = self.x.version();
+        let y_version = self.y.version();
+        let x_total = self.x.total_written();
+        let y_total = self.y.total_written();
+        let x_clear_generation = self.x.clear_generation.load(Ordering::Acquire);
+        let y_clear_generation = self.y.clear_generation.load(Ordering::Acquire);
+
+        let x_changed = x_version != progress.synced_x_version
+            || x_total != progress.synced_x_total
+            || x_clear_generation != progress.synced_x_clear_generation;
+        let y_changed = y_version != progress.synced_y_version
+            || y_total != progress.synced_y_total
+            || y_clear_generation != progress.synced_y_clear_generation;
+        if !x_changed || !y_changed {
+            return;
+        }
+
+        let x_was_cleared = x_clear_generation != progress.synced_x_clear_generation;
+        let y_was_cleared = y_clear_generation != progress.synced_y_clear_generation;
+        if x_was_cleared != y_was_cleared {
+            return;
+        }
+
+        let x_appended = x_total.saturating_sub(progress.synced_x_total);
+        let y_appended = y_total.saturating_sub(progress.synced_y_total);
+        if !x_was_cleared && (x_appended == 0 || x_appended != y_appended) {
+            return;
+        }
+        if x_was_cleared && x_total != y_total {
+            return;
+        }
+
+        let x_values = self.x.read_locked();
+        let y_values = self.y.read_locked();
+        if self.x.version() != x_version
+            || self.y.version() != y_version
+            || self.x.total_written() != x_total
+            || self.y.total_written() != y_total
+            || self.x.clear_generation.load(Ordering::Acquire) != x_clear_generation
+            || self.y.clear_generation.load(Ordering::Acquire) != y_clear_generation
+        {
+            return;
+        }
+
+        if x_was_cleared {
+            paired_data.clear();
+            for (&x_value, &y_value) in x_values.iter().zip(&y_values) {
+                paired_data.push_back((x_value, y_value));
+            }
+            progress.sequence = progress.sequence.wrapping_add(1);
+            progress.total_written = x_total;
+            progress.last_clear_sequence = Some(progress.sequence);
+            progress.synced_x_total = x_total;
+            progress.synced_y_total = y_total;
+            progress.synced_x_version = x_version;
+            progress.synced_y_version = y_version;
+            progress.synced_x_clear_generation = x_clear_generation;
+            progress.synced_y_clear_generation = y_clear_generation;
+            self.sync_lane_watermarks(progress);
+            return;
+        }
+
+        let visible = usize::try_from(x_appended)
+            .unwrap_or(usize::MAX)
+            .min(x_values.len())
+            .min(y_values.len());
+        let x_start = x_values.len().saturating_sub(visible);
+        let y_start = y_values.len().saturating_sub(visible);
+        for (&x_value, &y_value) in x_values[x_start..].iter().zip(&y_values[y_start..]) {
+            if paired_data.len() == self.x.capacity() {
+                paired_data.pop_front();
+            }
+            paired_data.push_back((x_value, y_value));
+        }
+
+        progress.sequence = progress.sequence.wrapping_add(x_appended);
+        progress.total_written = progress.total_written.saturating_add(x_appended);
+        progress.synced_x_total = x_total;
+        progress.synced_y_total = y_total;
+        progress.synced_x_version = x_version;
+        progress.synced_y_version = y_version;
+        progress.synced_x_clear_generation = x_clear_generation;
+        progress.synced_y_clear_generation = y_clear_generation;
+        self.sync_lane_watermarks(progress);
+    }
+
+    fn reconcile_legacy_lanes_locked(&self) {
+        let mut paired_data = self.paired_data.lock().expect("Paired data lock poisoned");
+        let mut progress = self.progress.lock().expect("StreamingXY progress poisoned");
+        self.reconcile_legacy_lanes(&mut paired_data, &mut progress);
+    }
+
+    fn sequence_after(sequence: u64, reference: u64) -> bool {
+        let distance = sequence.wrapping_sub(reference);
+        distance != 0 && distance < (1_u64 << 63)
+    }
+
+    fn sequence_distance(sequence: u64, reference: u64) -> u64 {
+        sequence.wrapping_sub(reference)
+    }
+
+    fn render_state_locked(
+        progress: &StreamingXYProgress,
+        visible_after: usize,
+        capacity: usize,
+    ) -> StreamingRenderState {
+        if progress.sequence == progress.rendered_through {
+            return StreamingRenderState::Unchanged;
+        }
+        if progress
+            .last_clear_sequence
+            .is_some_and(|sequence| Self::sequence_after(sequence, progress.rendered_through))
+        {
+            return StreamingRenderState::FullRedrawRequired;
+        }
+
+        let appended = Self::sequence_distance(progress.sequence, progress.rendered_through);
+        let appended = usize::try_from(appended).unwrap_or(usize::MAX);
+        let total_before = progress.total_written.saturating_sub(appended as u64);
+        let visible_before = usize::try_from(total_before)
+            .unwrap_or(usize::MAX)
+            .min(capacity);
+        if visible_before == 0 {
+            return StreamingRenderState::AppendOnly {
+                visible_appended: visible_after,
+            };
+        }
+        if visible_before.saturating_add(appended) <= capacity {
+            return StreamingRenderState::AppendOnly {
+                visible_appended: appended.min(visible_after),
+            };
+        }
+        StreamingRenderState::FullRedrawRequired
+    }
+
+    fn pending_sample_count_locked(progress: &StreamingXYProgress) -> u64 {
+        if progress
+            .last_clear_sequence
+            .is_some_and(|sequence| Self::sequence_after(sequence, progress.rendered_through))
+        {
+            progress.total_written
+        } else {
+            Self::sequence_distance(progress.sequence, progress.rendered_through)
+        }
+    }
+
+    pub(crate) fn captured_through(&self, sequence: u64) -> Self {
+        let mut captured = self.clone();
+        captured.acknowledge_through = Some(sequence);
+        captured
+    }
+
+    pub(crate) fn shares_source(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.progress, &other.progress)
+    }
+
+    pub(crate) fn refresh_legacy_lanes(&self) {
+        let _pair_gate = self.mutation_gate.lock().expect("Mutation gate poisoned");
+        self.reconcile_legacy_lanes_locked();
+    }
+
+    #[cfg(test)]
+    fn set_pair_commit_hook<F>(&self, hook: F)
+    where
+        F: Fn() + Send + Sync + 'static,
+    {
+        *self
+            .pair_commit_hook
+            .lock()
+            .expect("Pair commit hook lock poisoned") = Some(Arc::new(hook));
+    }
+
+    #[cfg(test)]
+    fn run_pair_commit_hook(&self) {
+        let hook = self
+            .pair_commit_hook
+            .lock()
+            .expect("Pair commit hook lock poisoned")
+            .clone();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
+    #[cfg(not(test))]
+    fn run_pair_commit_hook(&self) {}
 
     pub(crate) fn subscribe_paired<F>(&self, callback: F) -> SubscriberId
     where
@@ -1592,9 +2211,26 @@ impl StreamingXY {
     }
 
     fn notify_subscribers(&self) {
-        let callbacks = collect_subscriber_callbacks(&self.subscribers, "Lock poisoned");
-        for callback in callbacks {
-            callback();
+        self.notifications
+            .request(&self.subscribers, "Lock poisoned");
+    }
+
+    fn drain_pair_notifications(&self) {
+        let mut first_panic = None;
+        while self.pair_notifications.take_pending() {
+            let mut run = |notify: &dyn Fn()| {
+                if let Err(payload) = catch_unwind(AssertUnwindSafe(notify)) {
+                    if first_panic.is_none() {
+                        first_panic = Some(payload);
+                    }
+                }
+            };
+            run(&|| self.x.notify_subscribers());
+            run(&|| self.y.notify_subscribers());
+            run(&|| self.notify_subscribers());
+        }
+        if let Some(payload) = first_panic {
+            resume_unwind(payload);
         }
     }
 }
@@ -1604,8 +2240,16 @@ impl Clone for StreamingXY {
         Self {
             x: self.x.clone(),
             y: self.y.clone(),
+            mutation_gate: Arc::clone(&self.mutation_gate),
+            paired_data: Arc::clone(&self.paired_data),
+            progress: Arc::clone(&self.progress),
             subscribers: Arc::clone(&self.subscribers),
             next_subscriber_id: Arc::clone(&self.next_subscriber_id),
+            notifications: Arc::clone(&self.notifications),
+            pair_notifications: Arc::clone(&self.pair_notifications),
+            acknowledge_through: self.acknowledge_through,
+            #[cfg(test)]
+            pair_commit_hook: Arc::clone(&self.pair_commit_hook),
         }
     }
 }

--- a/src/data/observable/tests.rs
+++ b/src/data/observable/tests.rs
@@ -207,6 +207,205 @@ fn test_batch_update() {
 }
 
 #[test]
+fn test_batch_update_defers_and_deduplicates_notifications() {
+    let obs = Observable::new(0);
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let notifications_for_callback = Arc::clone(&notifications);
+    obs.subscribe(move || {
+        notifications_for_callback.fetch_add(1, AtomicOrdering::Relaxed);
+    });
+
+    {
+        let mut batch = BatchUpdate::new();
+        batch.add(&obs);
+        batch.add(&obs);
+        obs.set(1);
+        obs.set(2);
+        assert_eq!(notifications.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    assert_eq!(notifications.load(AtomicOrdering::Relaxed), 1);
+    assert_eq!(obs.get(), 2);
+}
+
+#[test]
+fn test_batch_update_noop_and_nested_batches_notify_once_at_outer_drop() {
+    let obs = Observable::new(0);
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let notifications_for_callback = Arc::clone(&notifications);
+    obs.subscribe(move || {
+        notifications_for_callback.fetch_add(1, AtomicOrdering::Relaxed);
+    });
+
+    {
+        let mut no_op = BatchUpdate::new();
+        no_op.add(&obs);
+    }
+    assert_eq!(notifications.load(AtomicOrdering::Relaxed), 0);
+
+    {
+        let mut outer = BatchUpdate::new();
+        outer.add(&obs);
+        obs.set(1);
+        {
+            let mut inner = BatchUpdate::new();
+            inner.add(&obs);
+            inner.add(&obs);
+            obs.set(2);
+        }
+        assert_eq!(notifications.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    assert_eq!(notifications.load(AtomicOrdering::Relaxed), 1);
+}
+
+#[test]
+fn test_observable_reentrant_mutations_are_drained_without_recursive_dispatch() {
+    let obs = Observable::new(0);
+    let callback_depth = Arc::new(AtomicUsize::new(0));
+    let max_depth = Arc::new(AtomicUsize::new(0));
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let obs_for_callback = obs.clone();
+    let depth_for_callback = Arc::clone(&callback_depth);
+    let max_depth_for_callback = Arc::clone(&max_depth);
+    let notifications_for_callback = Arc::clone(&notifications);
+
+    obs.subscribe(move || {
+        let depth = depth_for_callback.fetch_add(1, AtomicOrdering::SeqCst) + 1;
+        max_depth_for_callback.fetch_max(depth, AtomicOrdering::SeqCst);
+        let notification = notifications_for_callback.fetch_add(1, AtomicOrdering::SeqCst);
+        if notification == 0 {
+            obs_for_callback.set(2);
+        }
+        depth_for_callback.fetch_sub(1, AtomicOrdering::SeqCst);
+    });
+
+    obs.set(1);
+
+    assert_eq!(notifications.load(AtomicOrdering::SeqCst), 2);
+    assert_eq!(max_depth.load(AtomicOrdering::SeqCst), 1);
+    assert_eq!(obs.get(), 2);
+}
+
+#[test]
+fn test_observable_callback_runs_after_value_and_subscriber_locks_are_released() {
+    let obs = Observable::new(0);
+    let callback_id = Arc::new(Mutex::new(None));
+    let callback_id_for_callback = Arc::clone(&callback_id);
+    let obs_for_callback = obs.clone();
+
+    let id = obs.subscribe(move || {
+        assert_eq!(
+            *obs_for_callback
+                .try_read()
+                .expect("value lock must be free"),
+            1
+        );
+        let id = callback_id_for_callback
+            .lock()
+            .expect("callback id lock poisoned")
+            .expect("callback id should be installed");
+        assert!(obs_for_callback.unsubscribe(id));
+    });
+    *callback_id.lock().expect("callback id lock poisoned") = Some(id);
+
+    obs.set(1);
+    obs.set(2);
+}
+
+#[test]
+fn test_observable_notifications_recover_after_callback_panic() {
+    let obs = Observable::new(0);
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let panic_once = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let notifications_for_callback = Arc::clone(&notifications);
+    let panic_once_for_callback = Arc::clone(&panic_once);
+    obs.subscribe(move || {
+        notifications_for_callback.fetch_add(1, AtomicOrdering::SeqCst);
+        assert!(
+            !panic_once_for_callback.swap(false, AtomicOrdering::SeqCst),
+            "intentional callback panic"
+        );
+    });
+
+    let first = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| obs.set(1)));
+    assert!(first.is_err());
+
+    obs.set(2);
+    assert_eq!(notifications.load(AtomicOrdering::SeqCst), 2);
+}
+
+#[test]
+fn test_observable_panic_drains_reentrant_dirty_notification_before_unwind() {
+    let obs = Observable::new(0);
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let obs_for_callback = obs.clone();
+    let notifications_for_callback = Arc::clone(&notifications);
+    obs.subscribe(move || {
+        let notification = notifications_for_callback.fetch_add(1, AtomicOrdering::SeqCst);
+        if notification == 0 {
+            obs_for_callback.set(2);
+            panic!("intentional callback panic after reentrant mutation");
+        }
+    });
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| obs.set(1)));
+
+    assert!(result.is_err());
+    assert_eq!(obs.get(), 2);
+    assert_eq!(notifications.load(AtomicOrdering::SeqCst), 2);
+}
+
+#[test]
+fn test_batch_update_releases_all_observables_before_callback_panic() {
+    let first = Observable::new(0);
+    let second = Observable::new(0);
+    let second_notifications = Arc::new(AtomicUsize::new(0));
+    let second_notifications_for_callback = Arc::clone(&second_notifications);
+    first.subscribe(|| panic!("intentional batch callback panic"));
+    second.subscribe(move || {
+        second_notifications_for_callback.fetch_add(1, AtomicOrdering::SeqCst);
+    });
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut batch = BatchUpdate::new();
+        batch.add(&first);
+        batch.add(&second);
+        first.set(1);
+        second.set(1);
+    }));
+    assert!(result.is_err());
+    assert_eq!(second_notifications.load(AtomicOrdering::SeqCst), 1);
+
+    second.set(2);
+    assert_eq!(second_notifications.load(AtomicOrdering::SeqCst), 2);
+}
+
+#[test]
+fn test_batch_update_callback_panic_does_not_double_panic_during_unwind() {
+    let first = Observable::new(0);
+    let second = Observable::new(0);
+    let second_notifications = Arc::new(AtomicUsize::new(0));
+    let second_notifications_for_callback = Arc::clone(&second_notifications);
+    first.subscribe(|| panic!("intentional batch callback panic"));
+    second.subscribe(move || {
+        second_notifications_for_callback.fetch_add(1, AtomicOrdering::SeqCst);
+    });
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let mut batch = BatchUpdate::new();
+        batch.add(&first);
+        batch.add(&second);
+        first.set(1);
+        second.set(1);
+        panic!("outer panic must remain the active unwind");
+    }));
+
+    assert!(result.is_err());
+    assert_eq!(second_notifications.load(AtomicOrdering::SeqCst), 1);
+}
+
+#[test]
 fn test_update_with() {
     let obs = Observable::new(vec![1, 2, 3]);
     let old_len = obs.update_with(|v| {
@@ -640,6 +839,415 @@ fn test_streaming_xy_clear() {
 
     xy.clear();
     assert!(xy.is_empty());
+}
+
+#[test]
+fn test_streaming_xy_snapshot_is_owned_aligned_and_atomic_for_lane_callbacks() {
+    let xy = StreamingXY::new(8);
+    let snapshots = Arc::new(Mutex::new(Vec::new()));
+
+    for lane in [xy.x(), xy.y()] {
+        let xy_for_callback = xy.clone();
+        let snapshots_for_callback = Arc::clone(&snapshots);
+        lane.subscribe(move || {
+            let snapshot = xy_for_callback.snapshot();
+            assert_eq!(snapshot.x().len(), snapshot.y().len());
+            assert_eq!(xy_for_callback.x().version(), xy_for_callback.y().version());
+            snapshots_for_callback
+                .lock()
+                .expect("snapshot lock poisoned")
+                .push((snapshot.x().to_vec(), snapshot.y().to_vec()));
+        });
+    }
+
+    xy.push_many(vec![(1.0, 10.0), (2.0, 20.0)]);
+    let snapshot = xy.snapshot();
+    xy.push(3.0, 30.0);
+
+    assert_eq!(snapshot.x(), &[1.0, 2.0]);
+    assert_eq!(snapshot.y(), &[10.0, 20.0]);
+    let snapshots = snapshots.lock().expect("snapshot lock poisoned");
+    assert_eq!(snapshots.len(), 4);
+    assert!(snapshots.iter().all(|(x, y)| x.len() == y.len()));
+    assert_eq!(snapshots[0], (vec![1.0, 2.0], vec![10.0, 20.0]));
+    assert_eq!(snapshots[1], (vec![1.0, 2.0], vec![10.0, 20.0]));
+}
+
+#[test]
+fn test_streaming_xy_snapshot_ignores_unpaired_lane_tail() {
+    let xy = StreamingXY::new(8);
+    xy.push(1.0, 10.0);
+    xy.x().push(2.0);
+    xy.push(3.0, 30.0);
+
+    assert_eq!(xy.read_x(), vec![1.0, 2.0, 3.0]);
+    let snapshot = xy.snapshot();
+    assert_eq!(snapshot.x(), &[1.0, 3.0]);
+    assert_eq!(snapshot.y(), &[10.0, 30.0]);
+}
+
+#[test]
+fn test_streaming_xy_snapshot_reconciles_aligned_legacy_lane_writes() {
+    let xy = StreamingXY::new(8);
+    xy.push(1.0, 10.0);
+    xy.mark_rendered();
+    xy.x().push(2.0);
+    xy.y().push(20.0);
+
+    let snapshot = xy.snapshot();
+    assert_eq!(snapshot.x(), &[1.0, 2.0]);
+    assert_eq!(snapshot.y(), &[10.0, 20.0]);
+    assert_eq!(
+        snapshot.render_state(),
+        StreamingRenderState::AppendOnly {
+            visible_appended: 1
+        }
+    );
+}
+
+#[test]
+fn test_streaming_xy_paired_push_preserves_aligned_legacy_lane_writes() {
+    let xy = StreamingXY::new(8);
+    xy.push(1.0, 10.0);
+    xy.x().push(2.0);
+    xy.y().push(20.0);
+
+    xy.push(3.0, 30.0);
+
+    let snapshot = xy.snapshot();
+    assert_eq!(snapshot.x(), &[1.0, 2.0, 3.0]);
+    assert_eq!(snapshot.y(), &[10.0, 20.0, 30.0]);
+}
+
+#[test]
+fn test_streaming_xy_legacy_clear_and_refill_same_count_replaces_paired_data() {
+    let xy = StreamingXY::new(8);
+    xy.push_many(vec![(1.0, 10.0), (2.0, 20.0)]);
+    xy.mark_rendered();
+
+    xy.x().clear();
+    xy.y().clear();
+    xy.x().push_many(vec![7.0, 8.0]);
+    xy.y().push_many(vec![70.0, 80.0]);
+
+    let snapshot = xy.snapshot();
+    assert_eq!(snapshot.x(), &[7.0, 8.0]);
+    assert_eq!(snapshot.y(), &[70.0, 80.0]);
+    assert_eq!(
+        snapshot.render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+}
+
+#[test]
+fn test_streaming_xy_mark_rendered_reconciles_direct_aligned_lane_writes() {
+    let xy = StreamingXY::new(8);
+    xy.push(1.0, 10.0);
+    xy.mark_rendered();
+    let version = xy.version();
+
+    xy.x().push(2.0);
+    xy.y().push(20.0);
+    assert!(xy.version() != version);
+
+    xy.mark_rendered();
+
+    let snapshot = xy.snapshot();
+    assert_eq!(snapshot.x(), &[1.0, 2.0]);
+    assert_eq!(snapshot.y(), &[10.0, 20.0]);
+    assert_eq!(snapshot.render_state(), StreamingRenderState::Unchanged);
+}
+
+#[test]
+fn test_streaming_xy_captured_ack_keeps_newer_direct_lane_pair_dirty() {
+    let xy = StreamingXY::new(8);
+    xy.push(1.0, 10.0);
+    let captured = xy.snapshot();
+    xy.x().push(2.0);
+    xy.y().push(20.0);
+
+    xy.mark_rendered_through(captured.sequence());
+
+    assert_eq!(xy.appended_count(), 1);
+    assert_eq!(xy.x().appended_since_mark(), 1);
+    assert_eq!(xy.y().appended_since_mark(), 1);
+    assert_eq!(xy.read_appended_x(), vec![2.0]);
+    assert_eq!(xy.read_appended_y(), vec![20.0]);
+}
+
+#[test]
+fn test_streaming_xy_read_view_waits_for_atomic_pair_commit() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let xy = StreamingXY::new(8);
+    xy.push(1.0, 10.0);
+    let (mid_commit_tx, mid_commit_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    xy.set_pair_commit_hook({
+        let release_rx = Arc::clone(&release_rx);
+        move || {
+            mid_commit_tx
+                .send(())
+                .expect("mid-commit receiver should remain alive");
+            release_rx
+                .lock()
+                .expect("release receiver lock poisoned")
+                .recv()
+                .expect("pair commit should be released");
+        }
+    });
+
+    let writer_xy = xy.clone();
+    let writer = thread::spawn(move || writer_xy.push(2.0, 20.0));
+    mid_commit_rx
+        .recv()
+        .expect("writer should pause between lane mutations");
+
+    let (reader_started_tx, reader_started_rx) = mpsc::channel();
+    let (view_tx, view_rx) = mpsc::channel();
+    let reader_xy = xy.clone();
+    let reader = thread::spawn(move || {
+        reader_started_tx
+            .send(())
+            .expect("reader-start receiver should remain alive");
+        let (x, y) = reader_xy.read_view();
+        view_tx
+            .send((
+                x.iter().cloned().collect::<Vec<_>>(),
+                y.iter().cloned().collect::<Vec<_>>(),
+            ))
+            .expect("view receiver should remain alive");
+    });
+    reader_started_rx
+        .recv()
+        .expect("reader should start while the pair commit is paused");
+    assert!(
+        view_rx.recv_timeout(Duration::from_millis(250)).is_err(),
+        "paired read must block until both lanes commit"
+    );
+
+    release_tx.send(()).expect("writer should still be paused");
+    let (x, y) = view_rx
+        .recv()
+        .expect("paired view should finish after commit");
+    writer.join().expect("writer should finish");
+    reader.join().expect("reader should finish");
+    assert_eq!(
+        x,
+        vec![Some(1.0), Some(2.0), None, None, None, None, None, None]
+    );
+    assert_eq!(
+        y,
+        vec![Some(10.0), Some(20.0), None, None, None, None, None, None]
+    );
+}
+
+#[test]
+fn test_streaming_xy_old_and_out_of_order_acknowledgements_are_monotonic() {
+    let xy = StreamingXY::new(8);
+    xy.push_many(vec![(1.0, 10.0), (2.0, 20.0)]);
+    let older = xy.snapshot();
+    xy.push(3.0, 30.0);
+    let newer = xy.snapshot();
+
+    xy.mark_rendered_through(older.sequence());
+    assert_eq!(xy.appended_count(), 1);
+    assert_eq!(xy.read_appended_x(), vec![3.0]);
+    assert_eq!(xy.read_appended_y(), vec![30.0]);
+
+    xy.mark_rendered_through(newer.sequence());
+    assert_eq!(xy.appended_count(), 0);
+    let rendered_through = xy.snapshot().rendered_through();
+    xy.mark_rendered_through(older.sequence());
+    assert_eq!(xy.snapshot().rendered_through(), rendered_through);
+    assert_eq!(xy.render_state(), StreamingRenderState::Unchanged);
+}
+
+#[test]
+fn test_streaming_xy_acknowledgement_updates_public_lane_watermarks() {
+    let xy = StreamingXY::new(8);
+    xy.push_many(vec![(1.0, 10.0), (2.0, 20.0)]);
+    let older = xy.snapshot();
+    xy.push(3.0, 30.0);
+
+    xy.mark_rendered_through(older.sequence());
+    assert_eq!(xy.x().appended_since_mark(), 1);
+    assert_eq!(xy.y().appended_since_mark(), 1);
+    assert_eq!(xy.x().read_appended(), vec![3.0]);
+    assert_eq!(xy.y().read_appended(), vec![30.0]);
+
+    xy.mark_rendered();
+    assert_eq!(xy.x().appended_since_mark(), 0);
+    assert_eq!(xy.y().appended_since_mark(), 0);
+}
+
+#[test]
+fn test_streaming_xy_wraparound_and_clear_require_full_redraw() {
+    let xy = StreamingXY::new(3);
+    xy.push_many(vec![(1.0, 10.0), (2.0, 20.0), (3.0, 30.0)]);
+    xy.mark_rendered();
+
+    xy.push(4.0, 40.0);
+    let wrapped = xy.snapshot();
+    assert_eq!(wrapped.x(), &[2.0, 3.0, 4.0]);
+    assert_eq!(wrapped.y(), &[20.0, 30.0, 40.0]);
+    assert_eq!(
+        wrapped.render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+    xy.mark_rendered_through(wrapped.sequence());
+
+    xy.clear();
+    let cleared = xy.snapshot();
+    assert!(cleared.x().is_empty());
+    assert!(cleared.y().is_empty());
+    assert_eq!(
+        cleared.render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+}
+
+#[test]
+fn test_streaming_xy_sequence_wrap_keeps_new_samples_dirty() {
+    let xy = StreamingXY::new(8);
+    {
+        let mut progress = xy.progress.lock().expect("progress lock poisoned");
+        progress.sequence = u64::MAX - 1;
+        progress.rendered_through = u64::MAX - 1;
+    }
+
+    xy.push(1.0, 10.0);
+    let before_wrap = xy.snapshot();
+    xy.push(2.0, 20.0);
+    let after_wrap = xy.snapshot();
+
+    assert_eq!(before_wrap.sequence(), u64::MAX);
+    assert_eq!(after_wrap.sequence(), 0);
+    assert_eq!(xy.appended_count(), 2);
+    xy.mark_rendered_through(before_wrap.sequence());
+    assert_eq!(xy.appended_count(), 1);
+    xy.mark_rendered_through(after_wrap.sequence());
+    assert_eq!(xy.render_state(), StreamingRenderState::Unchanged);
+}
+
+#[test]
+fn test_streaming_xy_paired_callback_can_unsubscribe_and_push_reentrantly() {
+    let xy = StreamingXY::new(8);
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let callback_id = Arc::new(Mutex::new(None));
+    let xy_for_callback = xy.clone();
+    let notifications_for_callback = Arc::clone(&notifications);
+    let callback_id_for_callback = Arc::clone(&callback_id);
+
+    let id = xy.subscribe_paired(move || {
+        notifications_for_callback.fetch_add(1, AtomicOrdering::SeqCst);
+        let id = callback_id_for_callback
+            .lock()
+            .expect("callback id lock poisoned")
+            .expect("callback id should be installed");
+        assert!(xy_for_callback.unsubscribe_paired(id));
+        xy_for_callback.push(2.0, 20.0);
+    });
+    *callback_id.lock().expect("callback id lock poisoned") = Some(id);
+
+    xy.push(1.0, 10.0);
+
+    assert_eq!(notifications.load(AtomicOrdering::SeqCst), 1);
+    let snapshot = xy.snapshot();
+    assert_eq!(snapshot.x(), &[1.0, 2.0]);
+    assert_eq!(snapshot.y(), &[10.0, 20.0]);
+}
+
+#[test]
+fn test_streaming_xy_paired_notifications_recover_after_callback_panic() {
+    let xy = StreamingXY::new(8);
+    let notifications = Arc::new(AtomicUsize::new(0));
+    let panic_once = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let notifications_for_callback = Arc::clone(&notifications);
+    let panic_once_for_callback = Arc::clone(&panic_once);
+    xy.subscribe_paired(move || {
+        notifications_for_callback.fetch_add(1, AtomicOrdering::SeqCst);
+        assert!(
+            !panic_once_for_callback.swap(false, AtomicOrdering::SeqCst),
+            "intentional paired callback panic"
+        );
+    });
+
+    let first = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| xy.push(1.0, 10.0)));
+    assert!(first.is_err());
+
+    xy.push(2.0, 20.0);
+    assert_eq!(notifications.load(AtomicOrdering::SeqCst), 2);
+}
+
+#[test]
+fn test_streaming_xy_direct_lane_versions_preserve_combined_max_semantics() {
+    let xy = StreamingXY::new(8);
+
+    xy.x().push(1.0);
+    assert_eq!(xy.x().version(), 1);
+    assert_eq!(xy.y().version(), 0);
+    assert_eq!(xy.version(), 1);
+
+    xy.y().push(10.0);
+    assert_eq!(xy.x().version(), 1);
+    assert_eq!(xy.y().version(), 1);
+    assert_eq!(xy.version(), 1);
+    assert_eq!(xy.appended_count(), 1);
+}
+
+#[test]
+fn test_streaming_xy_concurrent_pair_writers_publish_ordered_aligned_metadata() {
+    use std::sync::Barrier;
+
+    let xy = StreamingXY::new(256);
+    let observed_sequences = Arc::new(Mutex::new(Vec::new()));
+    let observed_sequences_for_callback = Arc::clone(&observed_sequences);
+    let xy_for_callback = xy.clone();
+    xy.subscribe_paired(move || {
+        let snapshot = xy_for_callback.snapshot();
+        assert_eq!(snapshot.x().len(), snapshot.y().len());
+        assert_eq!(xy_for_callback.x().version(), xy_for_callback.y().version());
+        assert!(
+            snapshot
+                .x()
+                .iter()
+                .zip(snapshot.y())
+                .all(|(&x, &y)| y == x * 10.0)
+        );
+        observed_sequences_for_callback
+            .lock()
+            .expect("sequence lock poisoned")
+            .push(snapshot.sequence());
+    });
+
+    let start = Arc::new(Barrier::new(3));
+    let mut writers = Vec::new();
+    for lane in 0..2 {
+        let writer_xy = xy.clone();
+        let writer_start = Arc::clone(&start);
+        writers.push(thread::spawn(move || {
+            writer_start.wait();
+            for index in 0..100 {
+                let x = f64::from(lane * 100 + index);
+                writer_xy.push(x, x * 10.0);
+            }
+        }));
+    }
+    start.wait();
+    for writer in writers {
+        writer.join().expect("pair writer should finish");
+    }
+
+    let snapshot = xy.snapshot();
+    assert_eq!(snapshot.x().len(), 200);
+    assert_eq!(snapshot.sequence(), 200);
+    assert_eq!(xy.x().version(), xy.y().version());
+    let observed_sequences = observed_sequences.lock().expect("sequence lock poisoned");
+    assert_eq!(observed_sequences.len(), 200);
+    assert!(observed_sequences.windows(2).all(|pair| pair[0] <= pair[1]));
 }
 
 // ========================================================================


### PR DESCRIPTION
## Summary

- stage reactive mutations before committing observable state
- roll back failed updates without exposing partial state
- add regression coverage for transactional update behavior

## Validation

- `cargo test`
- `cargo test --all-features`
- aggregate reactive and interactive verification

Depends on #76.