### PR TITLE
Gate releases on exact CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,9 @@ jobs:
       - name: Install Linux desktop build dependencies
         uses: ./.github/actions/install-linux-desktop-build-deps
 
+      - name: Test release workflow gate
+        run: uv run python -m unittest scripts/test_wait_for_github_checks.py
+
       - name: Check published docs do not reference generated preview assets
         run: uv run python scripts/check_no_generated_asset_refs.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
+  actions: read
   contents: write
-  checks: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -29,29 +29,40 @@ jobs:
   check-ci:
     name: Wait for CI
     runs-on: ubuntu-latest
+    outputs:
+      release_sha: ${{ steps.release-target.outputs.release_sha }}
     steps:
       - name: Checkout workflow utilities
-        if: github.event_name != 'workflow_dispatch'
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
 
-      - name: Skip CI wait during manual recovery
+      - name: Manual recovery - skip tag-push CI gate
         if: github.event_name == 'workflow_dispatch'
-        run: echo "Manual release dispatch skips push-check waiting."
+        run: echo "Manual recovery for ${RELEASE_TAG} explicitly skips the tag-push CI gate."
 
-      - name: Wait for required CI checks to complete
-        if: github.event_name != 'workflow_dispatch'
+      - name: Resolve release target and enforce tag-push CI gate
+        id: release-target
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_PUSHED_AT: ${{ github.event.repository.pushed_at }}
         run: |
-          python3 scripts/wait_for_github_checks.py \
-            --repo "${{ github.repository }}" \
-            --sha "${{ github.sha }}" \
-            --timeout 2400 \
-            --interval 15 \
-            --check "Test Fast Lane" \
-            --check "NPM Package" \
-            --check "Python" \
-            --check "Python Packaging"
+          args=(
+            --repo "${GITHUB_REPOSITORY}"
+            --workflow "ci.yml"
+            --tag "${RELEASE_TAG}"
+            --ref "${RELEASE_REF}"
+            --timeout 2400
+            --interval 15
+          )
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            args+=(--sha "${GITHUB_SHA}" --pushed-at "${RELEASE_PUSHED_AT}")
+          else
+            args+=(--skip-ci)
+          fi
+
+          python3 scripts/wait_for_github_checks.py "${args[@]}"
 
   build-release:
     name: Build Release
@@ -61,7 +72,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -196,12 +207,12 @@ jobs:
   build-python-sdist:
     name: Build Python sdist
     runs-on: ubuntu-latest
-    needs: [build-release, build-python-widget-bundle]
+    needs: [check-ci, build-release, build-python-widget-bundle]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Download canonical widget bundle
         uses: actions/download-artifact@v4
@@ -232,12 +243,12 @@ jobs:
   build-python-wheel-macos-intel:
     name: Build Python wheel (macOS Intel)
     runs-on: macos-15-intel
-    needs: [build-release, build-python-widget-bundle]
+    needs: [check-ci, build-release, build-python-widget-bundle]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Download canonical widget bundle
         uses: actions/download-artifact@v4
@@ -269,12 +280,12 @@ jobs:
   build-python-wheel-macos-arm:
     name: Build Python wheel (macOS Apple Silicon)
     runs-on: macos-14
-    needs: [build-release, build-python-widget-bundle]
+    needs: [check-ci, build-release, build-python-widget-bundle]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Download canonical widget bundle
         uses: actions/download-artifact@v4
@@ -306,12 +317,12 @@ jobs:
   build-python-wheel-windows:
     name: Build Python wheel (Windows)
     runs-on: windows-latest
-    needs: [build-release, build-python-widget-bundle]
+    needs: [check-ci, build-release, build-python-widget-bundle]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Download canonical widget bundle
         uses: actions/download-artifact@v4
@@ -343,12 +354,12 @@ jobs:
   build-python-wheel-linux:
     name: Build Python wheel (Linux)
     runs-on: ubuntu-latest
-    needs: [build-release, build-python-widget-bundle]
+    needs: [check-ci, build-release, build-python-widget-bundle]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Download canonical widget bundle
         uses: actions/download-artifact@v4
@@ -377,12 +388,12 @@ jobs:
   build-python-widget-bundle:
     name: Build canonical Python widget bundle
     runs-on: ubuntu-latest
-    needs: build-release
+    needs: [check-ci, build-release]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -430,14 +441,14 @@ jobs:
   publish-ruviz:
     name: Publish ruviz to crates.io
     runs-on: ubuntu-latest
-    needs: build-release
+    needs: [check-ci, build-release]
     # Only publish on non-prerelease tags
     if: ${{ !contains((github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag) || github.ref_name, '-') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -467,13 +478,13 @@ jobs:
   publish-ruviz-web:
     name: Publish ruviz-web to crates.io
     runs-on: ubuntu-latest
-    needs: publish-ruviz
+    needs: [check-ci, publish-ruviz]
     if: ${{ !contains((github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag) || github.ref_name, '-') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -525,13 +536,13 @@ jobs:
   publish-ruviz-gpui:
     name: Publish ruviz-gpui to crates.io
     runs-on: ubuntu-latest
-    needs: publish-ruviz
+    needs: [check-ci, publish-ruviz]
     if: ${{ !contains((github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag) || github.ref_name, '-') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -587,7 +598,7 @@ jobs:
   publish-npm-web:
     name: Publish ruviz JS SDK to npm
     runs-on: ubuntu-latest
-    needs: [publish-ruviz, publish-ruviz-web]
+    needs: [check-ci, publish-ruviz, publish-ruviz-web]
     if: ${{ !contains((github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag) || github.ref_name, '-') }}
     permissions:
       contents: read
@@ -596,7 +607,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -681,6 +692,7 @@ jobs:
     name: Publish Python package to PyPI
     runs-on: ubuntu-latest
     needs:
+      - check-ci
       - build-python-sdist
       - build-python-wheel-linux
       - build-python-wheel-macos-intel
@@ -696,7 +708,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -760,13 +772,13 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [build-release, publish-ruviz, publish-ruviz-web, publish-ruviz-gpui, publish-npm-web, publish-python]
+    needs: [check-ci, build-release, publish-ruviz, publish-ruviz-web, publish-ruviz-gpui, publish-npm-web, publish-python]
     if: ${{ always() && needs.build-release.result == 'success' && (needs.publish-ruviz.result == 'success' || needs.publish-ruviz.result == 'skipped') && (needs.publish-ruviz-web.result == 'success' || needs.publish-ruviz-web.result == 'skipped') && (needs.publish-ruviz-gpui.result == 'success' || needs.publish-ruviz-gpui.result == 'skipped') && (needs.publish-npm-web.result == 'success' || needs.publish-npm-web.result == 'skipped') && needs.publish-python.result == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.RELEASE_REF }}
+          ref: ${{ needs.check-ci.outputs.release_sha }}
 
       - name: Prepare release notes body
         run: |

--- a/scripts/test_wait_for_github_checks.py
+++ b/scripts/test_wait_for_github_checks.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import unittest
+import urllib.error
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("wait_for_github_checks.py")
+SPEC = importlib.util.spec_from_file_location("wait_for_github_checks", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+wait_for_github_checks = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = wait_for_github_checks
+SPEC.loader.exec_module(wait_for_github_checks)
+
+ReleaseTarget = wait_for_github_checks.ReleaseTarget
+PUSHED_AT = 1_700_000_000
+CURRENT_RUN_CREATED_AT = "2023-11-14T22:13:20Z"
+
+
+def workflow_run(
+    *,
+    run_id: int,
+    run_number: int,
+    attempt: int,
+    branch: str = "v1.2.3",
+    sha: str = "commit-sha",
+    status: str = "completed",
+    conclusion: str | None = "success",
+    created_at: str = CURRENT_RUN_CREATED_AT,
+) -> dict[str, object]:
+    return {
+        "id": run_id,
+        "run_number": run_number,
+        "run_attempt": attempt,
+        "event": "push",
+        "head_branch": branch,
+        "head_sha": sha,
+        "created_at": created_at,
+        "status": status,
+        "conclusion": conclusion,
+        "html_url": f"https://github.example/actions/runs/{run_id}/attempts/{attempt}",
+    }
+
+
+def main_args(*, skip_ci: bool = False) -> argparse.Namespace:
+    return argparse.Namespace(
+        repo="owner/repo",
+        workflow="ci.yml",
+        tag="v1.2.3",
+        ref="refs/tags/v1.2.3",
+        sha=None if skip_ci else "commit-sha",
+        pushed_at=None if skip_ci else PUSHED_AT,
+        skip_ci=skip_ci,
+        timeout=10,
+        interval=0,
+    )
+
+
+class ReleaseTargetTests(unittest.TestCase):
+    def test_lightweight_tag_resolves_directly_to_the_ci_commit(self) -> None:
+        ref_payload = {
+            "ref": "refs/tags/v1.2.3",
+            "object": {"type": "commit", "sha": "commit-sha"},
+        }
+
+        target = wait_for_github_checks.resolve_release_target(
+            "v1.2.3",
+            "refs/tags/v1.2.3",
+            "commit-sha",
+            PUSHED_AT,
+            ref_payload,
+            lambda sha: self.fail(f"unexpected annotated tag lookup for {sha}"),
+        )
+
+        self.assertEqual(target.commit_sha, "commit-sha")
+
+    def test_annotated_tag_is_peeled_to_the_ci_commit(self) -> None:
+        ref_payload = {
+            "ref": "refs/tags/v1.2.3",
+            "object": {"type": "tag", "sha": "annotated-tag-sha"},
+        }
+        tag_payloads = {
+            "annotated-tag-sha": {
+                "object": {"type": "commit", "sha": "commit-sha"},
+            }
+        }
+
+        target = wait_for_github_checks.resolve_release_target(
+            "v1.2.3",
+            "refs/tags/v1.2.3",
+            "annotated-tag-sha",
+            PUSHED_AT,
+            ref_payload,
+            tag_payloads.__getitem__,
+        )
+
+        self.assertEqual(
+            target,
+            ReleaseTarget(
+                tag="v1.2.3",
+                ref="refs/tags/v1.2.3",
+                commit_sha="commit-sha",
+                pushed_at=PUSHED_AT,
+            ),
+        )
+
+    def test_annotated_tag_accepts_a_peeled_event_sha(self) -> None:
+        ref_payload = {
+            "ref": "refs/tags/v1.2.3",
+            "object": {"type": "tag", "sha": "annotated-tag-sha"},
+        }
+        tag_payloads = {
+            "annotated-tag-sha": {
+                "object": {"type": "commit", "sha": "commit-sha"},
+            }
+        }
+
+        target = wait_for_github_checks.resolve_release_target(
+            "v1.2.3",
+            "refs/tags/v1.2.3",
+            "commit-sha",
+            PUSHED_AT,
+            ref_payload,
+            tag_payloads.__getitem__,
+        )
+
+        self.assertEqual(target.commit_sha, "commit-sha")
+
+
+class WorkflowRunSelectionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.target = ReleaseTarget(
+            tag="v1.2.3",
+            ref="refs/tags/v1.2.3",
+            commit_sha="commit-sha",
+            pushed_at=PUSHED_AT,
+        )
+
+    def test_same_sha_main_run_cannot_satisfy_the_tag_gate(self) -> None:
+        runs = [
+            workflow_run(
+                run_id=300,
+                run_number=300,
+                attempt=1,
+                branch="main",
+            ),
+            workflow_run(
+                run_id=299,
+                run_number=299,
+                attempt=1,
+                status="in_progress",
+                conclusion=None,
+            ),
+        ]
+
+        selected = wait_for_github_checks.select_workflow_run(runs, self.target)
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["id"], 299)
+
+    def test_previous_push_run_is_ignored_until_the_current_run_appears(self) -> None:
+        stale = workflow_run(
+            run_id=350,
+            run_number=350,
+            attempt=1,
+            created_at="2023-11-14T22:13:19Z",
+        )
+
+        self.assertIsNone(
+            wait_for_github_checks.select_workflow_run([stale], self.target)
+        )
+
+        current = workflow_run(
+            run_id=351,
+            run_number=351,
+            attempt=1,
+            status="queued",
+            conclusion=None,
+        )
+        selected = wait_for_github_checks.select_workflow_run(
+            [stale, current], self.target
+        )
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["id"], 351)
+
+    def test_newest_exact_run_wins_over_a_stale_success(self) -> None:
+        runs = [
+            workflow_run(run_id=400, run_number=400, attempt=1),
+            workflow_run(
+                run_id=401,
+                run_number=401,
+                attempt=1,
+                status="in_progress",
+                conclusion=None,
+            ),
+        ]
+
+        selected = wait_for_github_checks.select_workflow_run(runs, self.target)
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertEqual(selected["id"], 401)
+        self.assertEqual(
+            wait_for_github_checks.summarize_workflow_run(selected)[0],
+            "pending",
+        )
+
+    def test_exact_attempt_validation_rejects_an_older_attempt(self) -> None:
+        selected = workflow_run(run_id=400, run_number=400, attempt=2)
+        stale_attempt = workflow_run(run_id=400, run_number=400, attempt=1)
+
+        with self.assertRaisesRegex(ValueError, "selected attempt"):
+            wait_for_github_checks.validate_workflow_attempt(
+                selected,
+                stale_attempt,
+                self.target,
+            )
+
+    def test_current_run_detects_a_newer_attempt(self) -> None:
+        selected = workflow_run(run_id=400, run_number=400, attempt=1)
+        current = workflow_run(
+            run_id=400,
+            run_number=400,
+            attempt=2,
+            status="queued",
+            conclusion=None,
+        )
+
+        self.assertFalse(
+            wait_for_github_checks.attempt_is_current(selected, current, self.target)
+        )
+
+    def test_pending_failure_success_and_missing_states(self) -> None:
+        fixtures = [
+            ("missing", None, "pending"),
+            (
+                "pending",
+                workflow_run(
+                    run_id=10,
+                    run_number=10,
+                    attempt=1,
+                    status="queued",
+                    conclusion=None,
+                ),
+                "pending",
+            ),
+            (
+                "nonterminal-success",
+                workflow_run(
+                    run_id=11,
+                    run_number=11,
+                    attempt=1,
+                    status="in_progress",
+                    conclusion="success",
+                ),
+                "pending",
+            ),
+            (
+                "failure",
+                workflow_run(
+                    run_id=12,
+                    run_number=12,
+                    attempt=1,
+                    conclusion="failure",
+                ),
+                "failure",
+            ),
+            (
+                "success",
+                workflow_run(run_id=13, run_number=13, attempt=1),
+                "success",
+            ),
+        ]
+
+        for name, run, expected in fixtures:
+            with self.subTest(name=name):
+                state, _ = wait_for_github_checks.summarize_workflow_run(run)
+                self.assertEqual(state, expected)
+
+
+class MainTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ref_payload = {
+            "ref": "refs/tags/v1.2.3",
+            "object": {"type": "commit", "sha": "commit-sha"},
+        }
+
+    def test_release_ref_resolution_retries_a_transient_failure(self) -> None:
+        fetch_git_ref = mock.Mock(
+            side_effect=[urllib.error.URLError("temporary outage"), self.ref_payload]
+        )
+        write_output = mock.Mock()
+
+        with (
+            mock.patch.object(
+                wait_for_github_checks,
+                "parse_args",
+                return_value=main_args(skip_ci=True),
+            ),
+            mock.patch.object(
+                wait_for_github_checks, "github_token", return_value="token"
+            ),
+            mock.patch.object(wait_for_github_checks, "fetch_git_ref", fetch_git_ref),
+            mock.patch.object(
+                wait_for_github_checks,
+                "write_release_sha_output",
+                write_output,
+            ),
+        ):
+            result = wait_for_github_checks.main()
+
+        self.assertEqual(result, 0)
+        self.assertEqual(fetch_git_ref.call_count, 2)
+        write_output.assert_called_once_with(
+            ReleaseTarget(
+                tag="v1.2.3",
+                ref="refs/tags/v1.2.3",
+                commit_sha="commit-sha",
+                pushed_at=0,
+            )
+        )
+
+    def test_new_attempt_starting_during_success_check_is_polled(self) -> None:
+        attempt_1 = workflow_run(run_id=400, run_number=400, attempt=1)
+        attempt_2_queued = workflow_run(
+            run_id=400,
+            run_number=400,
+            attempt=2,
+            status="queued",
+            conclusion=None,
+        )
+        attempt_2_success = workflow_run(run_id=400, run_number=400, attempt=2)
+        fetch_attempt = mock.Mock(side_effect=[attempt_1, attempt_2_success])
+
+        with (
+            mock.patch.object(
+                wait_for_github_checks, "parse_args", return_value=main_args()
+            ),
+            mock.patch.object(
+                wait_for_github_checks, "github_token", return_value="token"
+            ),
+            mock.patch.object(
+                wait_for_github_checks,
+                "fetch_git_ref",
+                return_value=self.ref_payload,
+            ),
+            mock.patch.object(
+                wait_for_github_checks,
+                "fetch_workflow_runs",
+                side_effect=[[attempt_1], [attempt_2_success]],
+            ),
+            mock.patch.object(
+                wait_for_github_checks, "fetch_workflow_attempt", fetch_attempt
+            ),
+            mock.patch.object(
+                wait_for_github_checks,
+                "fetch_workflow_run",
+                side_effect=[attempt_2_queued, attempt_2_success],
+            ),
+            mock.patch.object(wait_for_github_checks, "write_release_sha_output"),
+        ):
+            result = wait_for_github_checks.main()
+
+        self.assertEqual(result, 0)
+        self.assertEqual(
+            [call.args[2] for call in fetch_attempt.call_args_list],
+            [1, 2],
+        )
+
+
+class ReleaseWorkflowTests(unittest.TestCase):
+    def test_manual_recovery_skip_remains_explicit(self) -> None:
+        workflow_path = SCRIPT_PATH.parents[1] / ".github" / "workflows" / "release.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("release_tag:", workflow)
+        self.assertIn("- name: Manual recovery - skip tag-push CI gate", workflow)
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", workflow)
+        self.assertIn("args+=(--skip-ci)", workflow)
+        self.assertIn('--workflow "ci.yml"', workflow)
+        self.assertIn('--tag "${RELEASE_TAG}"', workflow)
+        self.assertIn('--ref "${RELEASE_REF}"', workflow)
+        self.assertIn('--sha "${GITHUB_SHA}"', workflow)
+        self.assertIn('--pushed-at "${RELEASE_PUSHED_AT}"', workflow)
+        self.assertNotIn("${{ env.RELEASE_TAG }} explicitly skips", workflow)
+        self.assertNotIn('--tag "${{ env.RELEASE_TAG }}"', workflow)
+        self.assertNotIn('--ref "${{ env.RELEASE_REF }}"', workflow)
+
+    def test_release_checkouts_use_the_resolved_commit_sha(self) -> None:
+        workflow_path = SCRIPT_PATH.parents[1] / ".github" / "workflows" / "release.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+
+        checkout_count = workflow.count("- name: Checkout code")
+        immutable_checkout = "ref: ${{ needs.check-ci.outputs.release_sha }}"
+
+        self.assertIn(
+            "release_sha: ${{ steps.release-target.outputs.release_sha }}",
+            workflow,
+        )
+        self.assertEqual(workflow.count(immutable_checkout), checkout_count)
+        self.assertNotIn("ref: ${{ env.RELEASE_REF }}", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/wait_for_github_checks.py
+++ b/scripts/wait_for_github_checks.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Poll GitHub check runs until required checks succeed."""
+"""Wait for the exact CI workflow run and attempt for a release tag."""
 
 from __future__ import annotations
 
@@ -11,24 +11,47 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 API_VERSION = "2022-11-28"
 USER_AGENT = "ruviz-release-workflow/1.0 (https://github.com/Ameyanagi/ruviz)"
 
 
+@dataclass(frozen=True)
+class ReleaseTarget:
+    tag: str
+    ref: str
+    commit_sha: str
+    pushed_at: int
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Wait for one or more GitHub check runs to complete successfully.",
+        description="Wait for the exact GitHub Actions CI run for a release tag.",
     )
-    parser.add_argument("--repo", required=True, help="GitHub repository in owner/name form")
-    parser.add_argument("--sha", required=True, help="Commit SHA to inspect")
     parser.add_argument(
-        "--check",
-        action="append",
+        "--repo", required=True, help="GitHub repository in owner/name form"
+    )
+    parser.add_argument(
+        "--workflow",
         required=True,
-        dest="checks",
-        help="Exact check run name to require; may be passed multiple times",
+        help="CI workflow file name or workflow ID",
+    )
+    parser.add_argument("--tag", required=True, help="Release tag name")
+    parser.add_argument("--ref", required=True, help="Full release tag ref")
+    parser.add_argument("--sha", help="SHA from the release push event")
+    parser.add_argument(
+        "--pushed-at",
+        type=int,
+        help="Unix timestamp from the release push event",
+    )
+    parser.add_argument(
+        "--skip-ci",
+        action="store_true",
+        help="Resolve the release target without enforcing the tag-push CI gate",
     )
     parser.add_argument(
         "--timeout",
@@ -52,69 +75,293 @@ def github_token() -> str:
     return token
 
 
-def fetch_check_runs(repo: str, sha: str, token: str) -> list[dict[str, Any]]:
+def fetch_json(url: str, token: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": USER_AGENT,
+            "X-GitHub-Api-Version": API_VERSION,
+        },
+    )
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return json.load(response)
+
+
+def fetch_git_ref(repo: str, ref: str, token: str) -> dict[str, Any]:
+    ref_path = urllib.parse.quote(ref.removeprefix("refs/"), safe="/")
+    url = f"https://api.github.com/repos/{repo}/git/ref/{ref_path}"
+    return fetch_json(url, token)
+
+
+def fetch_annotated_tag(repo: str, sha: str, token: str) -> dict[str, Any]:
+    url = f"https://api.github.com/repos/{repo}/git/tags/{sha}"
+    return fetch_json(url, token)
+
+
+def resolve_release_target(
+    tag: str,
+    ref: str,
+    event_sha: str | None,
+    pushed_at: int | None,
+    ref_payload: dict[str, Any],
+    load_annotated_tag: Callable[[str], dict[str, Any]],
+) -> ReleaseTarget:
+    expected_ref = f"refs/tags/{tag}"
+    if ref != expected_ref:
+        raise ValueError(f"release ref {ref!r} does not match tag {tag!r}")
+    if ref_payload.get("ref") != ref:
+        raise ValueError(
+            f"GitHub returned {ref_payload.get('ref')!r} for release ref {ref!r}"
+        )
+
+    git_object = ref_payload.get("object")
+    if not isinstance(git_object, dict):
+        raise ValueError(f"release ref {ref!r} has no Git object")
+
+    tag_chain_shas: set[str] = set()
+    while git_object.get("type") == "tag":
+        tag_sha = git_object.get("sha")
+        if not isinstance(tag_sha, str) or not tag_sha:
+            raise ValueError(f"annotated tag for {ref!r} has no SHA")
+        if tag_sha in tag_chain_shas:
+            raise ValueError(f"annotated tag cycle detected for {ref!r}")
+        tag_chain_shas.add(tag_sha)
+
+        tag_payload = load_annotated_tag(tag_sha)
+        git_object = tag_payload.get("object")
+        if not isinstance(git_object, dict):
+            raise ValueError(f"annotated tag {tag_sha} has no target object")
+
+    if git_object.get("type") != "commit":
+        raise ValueError(
+            f"release ref {ref!r} resolves to unsupported Git object type "
+            f"{git_object.get('type')!r}"
+        )
+
+    commit_sha = git_object.get("sha")
+    if not isinstance(commit_sha, str) or not commit_sha:
+        raise ValueError(f"release ref {ref!r} resolves to a commit without a SHA")
+
+    if (
+        event_sha is not None
+        and event_sha != commit_sha
+        and event_sha not in tag_chain_shas
+    ):
+        raise ValueError(
+            f"release event SHA {event_sha} is not part of the Git object chain for {ref!r}"
+        )
+    if pushed_at is not None and pushed_at <= 0:
+        raise ValueError("release push timestamp must be a positive Unix timestamp")
+
+    return ReleaseTarget(
+        tag=tag,
+        ref=ref,
+        commit_sha=commit_sha,
+        pushed_at=pushed_at or 0,
+    )
+
+
+def fetch_workflow_runs(
+    repo: str,
+    workflow: str,
+    target: ReleaseTarget,
+    token: str,
+) -> list[dict[str, Any]]:
+    workflow_path = urllib.parse.quote(workflow, safe="")
     page = 1
     runs: list[dict[str, Any]] = []
 
     while True:
-        query = urllib.parse.urlencode({"per_page": 100, "page": page})
-        url = f"https://api.github.com/repos/{repo}/commits/{sha}/check-runs?{query}"
-        request = urllib.request.Request(
-            url,
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
-                "User-Agent": USER_AGENT,
-                "X-GitHub-Api-Version": API_VERSION,
-            },
+        query = urllib.parse.urlencode(
+            {
+                "branch": target.tag,
+                "event": "push",
+                "head_sha": target.commit_sha,
+                "per_page": 100,
+                "page": page,
+            }
         )
-        with urllib.request.urlopen(request) as response:
-            payload = json.load(response)
-
-        page_runs = payload.get("check_runs", [])
-        runs.extend(page_runs)
+        url = (
+            f"https://api.github.com/repos/{repo}/actions/workflows/"
+            f"{workflow_path}/runs?{query}"
+        )
+        payload = fetch_json(url, token)
+        page_runs = payload.get("workflow_runs", [])
+        if not isinstance(page_runs, list):
+            raise ValueError("GitHub workflow-runs response is missing workflow_runs")
+        runs.extend(run for run in page_runs if isinstance(run, dict))
         if len(page_runs) < 100:
             return runs
         page += 1
 
 
-def latest_completed_success(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
-    successes = [
-        run
-        for run in runs
-        if run.get("status") == "completed" and run.get("conclusion") == "success"
-    ]
-    if not successes:
+def fetch_workflow_attempt(
+    repo: str,
+    run_id: int,
+    attempt: int,
+    token: str,
+) -> dict[str, Any]:
+    url = (
+        f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/attempts/{attempt}"
+    )
+    return fetch_json(url, token)
+
+
+def fetch_workflow_run(repo: str, run_id: int, token: str) -> dict[str, Any]:
+    url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}"
+    return fetch_json(url, token)
+
+
+def run_created_at(run: dict[str, Any]) -> int | None:
+    created_at = run.get("created_at")
+    if not isinstance(created_at, str):
         return None
-    return max(successes, key=lambda run: run.get("completed_at") or "")
+    try:
+        parsed = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return None
+    return int(parsed.timestamp())
 
 
-def summarize_check(name: str, runs: list[dict[str, Any]]) -> tuple[str, str]:
-    matching = [run for run in runs if run.get("name") == name]
-    success = latest_completed_success(matching)
-    if success is not None:
-        completed_at = success.get("completed_at", "unknown time")
-        details_url = success.get("details_url", "")
-        summary = f"success at {completed_at}"
+def run_matches_target(run: dict[str, Any], target: ReleaseTarget) -> bool:
+    created_at = run_created_at(run)
+    return (
+        run.get("event") == "push"
+        and run.get("head_branch") == target.tag
+        and run.get("head_sha") == target.commit_sha
+        and created_at is not None
+        and created_at >= target.pushed_at
+    )
+
+
+def run_order(run: dict[str, Any]) -> tuple[int, int, int]:
+    return (
+        int(run.get("run_number") or 0),
+        int(run.get("run_attempt") or 0),
+        int(run.get("id") or 0),
+    )
+
+
+def select_workflow_run(
+    runs: list[dict[str, Any]],
+    target: ReleaseTarget,
+) -> dict[str, Any] | None:
+    matching = [run for run in runs if run_matches_target(run, target)]
+    if not matching:
+        return None
+    return max(matching, key=run_order)
+
+
+def selected_attempt(run: dict[str, Any]) -> tuple[int, int]:
+    run_id = run.get("id")
+    attempt = run.get("run_attempt")
+    if not isinstance(run_id, int) or not isinstance(attempt, int):
+        raise ValueError("selected workflow run has no numeric id or run_attempt")
+    return run_id, attempt
+
+
+def validate_workflow_attempt(
+    selected: dict[str, Any],
+    attempt: dict[str, Any],
+    target: ReleaseTarget,
+) -> None:
+    selected_identity = selected_attempt(selected)
+    attempt_identity = selected_attempt(attempt)
+    if attempt_identity != selected_identity:
+        raise ValueError(
+            f"GitHub returned workflow attempt {attempt_identity} for selected attempt "
+            f"{selected_identity}"
+        )
+    if not run_matches_target(attempt, target):
+        raise ValueError(
+            "selected workflow attempt no longer matches the release target"
+        )
+
+
+def attempt_is_current(
+    selected: dict[str, Any],
+    current: dict[str, Any],
+    target: ReleaseTarget,
+) -> bool:
+    selected_run_id, selected_attempt_number = selected_attempt(selected)
+    current_run_id, current_attempt_number = selected_attempt(current)
+    if current_run_id != selected_run_id:
+        raise ValueError(
+            f"GitHub returned current run {current_run_id} for selected run {selected_run_id}"
+        )
+    if not run_matches_target(current, target):
+        raise ValueError("current workflow run no longer matches the release target")
+    if current_attempt_number < selected_attempt_number:
+        raise ValueError(
+            f"current workflow attempt {current_attempt_number} is older than selected "
+            f"attempt {selected_attempt_number}"
+        )
+    return current_attempt_number == selected_attempt_number
+
+
+def summarize_workflow_run(run: dict[str, Any] | None) -> tuple[str, str]:
+    if run is None:
+        return "pending", "waiting for the release-tag CI workflow run to appear"
+
+    run_id, attempt = selected_attempt(run)
+    status = run.get("status") or "unknown"
+    conclusion = run.get("conclusion") or "none"
+    details_url = run.get("html_url") or ""
+    identity = f"run {run_id}, attempt {attempt}"
+
+    if status != "completed":
+        summary = f"{identity} is {status}"
         if details_url:
             summary += f" ({details_url})"
-        return "success", summary
-
-    pending = [run for run in matching if run.get("status") != "completed"]
-    if pending or not matching:
-        pending_statuses = sorted({run.get("status", "unknown") for run in pending})
-        if pending_statuses:
-            summary = f"pending ({', '.join(pending_statuses)})"
-        else:
-            summary = "waiting for check run to appear"
         return "pending", summary
 
-    conclusions = sorted({run.get("conclusion", "unknown") for run in matching})
-    details_url = next((run.get("details_url") for run in reversed(matching) if run.get("details_url")), "")
-    summary = f"completed without success ({', '.join(conclusions)})"
+    summary = f"{identity} completed with conclusion {conclusion}"
     if details_url:
         summary += f" ({details_url})"
+    if conclusion == "success":
+        return "success", summary
     return "failure", summary
+
+
+def print_http_error(exc: urllib.error.HTTPError) -> None:
+    message = exc.read().decode("utf-8", "replace").strip()
+    print(f"GitHub API error: {exc.code} {message}", file=sys.stderr)
+
+
+def is_retryable_http_error(exc: urllib.error.HTTPError) -> bool:
+    return exc.code == 429 or 500 <= exc.code < 600
+
+
+def retry_api_error(
+    exc: urllib.error.URLError,
+    *,
+    deadline: float,
+    interval: int,
+    context: str,
+) -> bool:
+    if time.monotonic() >= deadline:
+        print(
+            f"Timed out after transient GitHub API error while {context}: {exc}",
+            file=sys.stderr,
+        )
+        return False
+    print(
+        f"GitHub API unavailable while {context} ({exc}); retrying in {interval}s...",
+        file=sys.stderr,
+    )
+    time.sleep(interval)
+    return True
+
+
+def write_release_sha_output(target: ReleaseTarget) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a", encoding="utf-8") as output:
+            print(f"release_sha={target.commit_sha}", file=output)
 
 
 def main() -> int:
@@ -122,42 +369,130 @@ def main() -> int:
     token = github_token()
     deadline = time.monotonic() + args.timeout
 
+    if not args.skip_ci and (args.sha is None or args.pushed_at is None):
+        print(
+            "--sha and --pushed-at are required unless --skip-ci is used",
+            file=sys.stderr,
+        )
+        return 1
+
     while True:
         try:
-            runs = fetch_check_runs(args.repo, args.sha, token)
+            ref_payload = fetch_git_ref(args.repo, args.ref, token)
+            target = resolve_release_target(
+                args.tag,
+                args.ref,
+                args.sha,
+                args.pushed_at,
+                ref_payload,
+                lambda sha: fetch_annotated_tag(args.repo, sha, token),
+            )
+            break
         except urllib.error.HTTPError as exc:
-            message = exc.read().decode("utf-8", "replace").strip()
-            print(f"GitHub API error: {exc.code} {message}", file=sys.stderr)
+            if not is_retryable_http_error(exc):
+                print_http_error(exc)
+                return 1
+            if not retry_api_error(
+                exc,
+                deadline=deadline,
+                interval=args.interval,
+                context="resolving the release ref",
+            ):
+                return 1
+        except urllib.error.URLError as exc:
+            if not retry_api_error(
+                exc,
+                deadline=deadline,
+                interval=args.interval,
+                context="resolving the release ref",
+            ):
+                return 1
+        except ValueError as exc:
+            print(f"Invalid release target: {exc}", file=sys.stderr)
+            return 1
+
+    print(f"Release target: {target.ref} -> {target.commit_sha}")
+    write_release_sha_output(target)
+
+    if args.skip_ci:
+        print(
+            "Manual recovery explicitly skips the tag-push CI gate after resolving the "
+            "immutable release commit."
+        )
+        return 0
+
+    while True:
+        try:
+            runs = fetch_workflow_runs(args.repo, args.workflow, target, token)
+            selected = select_workflow_run(runs, target)
+            if selected is None:
+                attempt = None
+            else:
+                run_id, attempt_number = selected_attempt(selected)
+                attempt = fetch_workflow_attempt(
+                    args.repo,
+                    run_id,
+                    attempt_number,
+                    token,
+                )
+                validate_workflow_attempt(selected, attempt, target)
+                current = fetch_workflow_run(args.repo, run_id, token)
+                if not attempt_is_current(selected, current, target):
+                    print(
+                        f"CI workflow run {run_id} advanced beyond attempt "
+                        f"{attempt_number}; polling the current attempt."
+                    )
+                    if time.monotonic() >= deadline:
+                        print(
+                            f"Timed out after waiting {args.timeout}s for the "
+                            "release-tag CI workflow.",
+                            file=sys.stderr,
+                        )
+                        return 1
+                    time.sleep(args.interval)
+                    continue
+        except urllib.error.HTTPError as exc:
+            if not is_retryable_http_error(exc):
+                print_http_error(exc)
+                return 1
+            if retry_api_error(
+                exc,
+                deadline=deadline,
+                interval=args.interval,
+                context="polling the release-tag CI workflow",
+            ):
+                continue
             return 1
         except urllib.error.URLError as exc:
-            if time.monotonic() >= deadline:
-                print(f"Timed out after transient GitHub API error: {exc}", file=sys.stderr)
-                return 1
-            print(f"GitHub API unavailable ({exc}); retrying in {args.interval}s...", file=sys.stderr)
-            time.sleep(args.interval)
-            continue
-
-        states: dict[str, tuple[str, str]] = {
-            name: summarize_check(name, runs) for name in args.checks
-        }
-
-        print("Current check states:")
-        for name in args.checks:
-            status, summary = states[name]
-            print(f"- {name}: {status} - {summary}")
-
-        failures = {name: info for name, info in states.items() if info[0] == "failure"}
-        if failures:
-            print("Required checks failed.", file=sys.stderr)
+            if retry_api_error(
+                exc,
+                deadline=deadline,
+                interval=args.interval,
+                context="polling the release-tag CI workflow",
+            ):
+                continue
+            return 1
+        except ValueError as exc:
+            print(f"Invalid GitHub workflow response: {exc}", file=sys.stderr)
             return 1
 
-        if all(status == "success" for status, _ in states.values()):
-            print("All required checks succeeded.")
-            return 0
+        state, summary = summarize_workflow_run(attempt)
+        print(f"CI workflow: {state} - {summary}")
 
+        if state == "failure":
+            print(
+                "The release-tag CI workflow attempt did not succeed. Recover CI, then "
+                f"manually run the Release workflow with release_tag={target.tag}; manual "
+                "recovery explicitly skips the tag-push CI gate.",
+                file=sys.stderr,
+            )
+            return 1
+        if state == "success":
+            print("The exact release-tag CI workflow attempt succeeded.")
+            return 0
         if time.monotonic() >= deadline:
             print(
-                f"Timed out after waiting {args.timeout}s for required checks.",
+                f"Timed out after waiting {args.timeout}s for the release-tag CI workflow.",
                 file=sys.stderr,
             )
             return 1


### PR DESCRIPTION
## Summary

- bind release publication to the exact successful CI run for the release commit
- harden GitHub-check polling and failure reporting
- add unit coverage for check selection and terminal states

## Validation

- `uv run python -m unittest scripts/test_wait_for_github_checks.py`
- Ruff check and formatting
- actionlint on the changed workflows

Depends on #76.