### PR TITLE
Share runtime fonts across backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8168,6 +8168,7 @@ dependencies = [
  "tiny-skia-path 0.12.0",
  "tokio",
  "trybuild",
+ "ttf-parser 0.25.1",
  "typst",
  "typst-kit",
  "typst-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ palette = "0.7"
 # Text rendering - unified on cosmic-text (pure Rust)
 cosmic-text = "0.16"  # Professional text layout, shaping, and font discovery
 swash = "0.2"  # Distinguish premultiplied color outlines from straight color bitmaps
+ttf-parser = "0.25"  # Validate registered font faces before mutating shared state
 unicode-width = "0.2"
 typst = { version = "0.13.1", optional = true }
 typst-svg = { version = "0.13.1", optional = true }

--- a/src/export/svg_to_pdf.rs
+++ b/src/export/svg_to_pdf.rs
@@ -4,7 +4,19 @@
 //! This provides publication-quality vector PDF output.
 
 use crate::core::{PlottingError, Result};
+#[cfg(feature = "pdf")]
+use crate::render::font_registry;
 use std::path::Path;
+
+#[cfg(feature = "pdf")]
+fn pdf_font_database() -> Result<svg2pdf::usvg::fontdb::Database> {
+    let mut database = svg2pdf::usvg::fontdb::Database::new();
+    #[cfg(not(target_arch = "wasm32"))]
+    database.load_system_fonts();
+    let registered_fonts = font_registry::snapshot()?;
+    font_registry::load_with_registered_precedence(&mut database, &registered_fonts);
+    Ok(database)
+}
 
 /// Convert SVG string to PDF bytes
 #[cfg(feature = "pdf")]
@@ -12,9 +24,9 @@ pub fn svg_to_pdf(svg_data: &str) -> Result<Vec<u8>> {
     // Use svg2pdf's re-exported usvg to ensure version compatibility
     use svg2pdf::usvg;
 
-    // Create font database with system fonts
-    let mut fontdb = usvg::fontdb::Database::new();
-    fontdb.load_system_fonts();
+    // Plain SVG stays portable-by-reference; registered bytes are supplied only
+    // to the PDF conversion database where glyph outlines can be embedded.
+    let fontdb = pdf_font_database()?;
 
     // Parse SVG with usvg
     let options = usvg::Options {
@@ -87,6 +99,26 @@ mod tests {
         let pdf_data = result.unwrap();
         // PDF files start with %PDF-
         assert!(pdf_data.starts_with(b"%PDF-"));
+    }
+
+    #[test]
+    #[cfg(feature = "pdf")]
+    fn registered_font_is_loaded_into_pdf_font_database() {
+        let Some(bytes) = crate::render::font_registry::renamed_test_font(b"PPdf") else {
+            return;
+        };
+        crate::render::register_font_bytes(bytes).unwrap();
+        let database = pdf_font_database().unwrap();
+        assert!(database.faces().any(|face| {
+            face.families
+                .iter()
+                .any(|(family, _)| family == "PPdf Sans")
+        }));
+
+        let svg = r#"<svg width="120" height="40" xmlns="http://www.w3.org/2000/svg">
+  <text x="2" y="28" font-family="PPdf Sans" font-size="20">P12 PDF</text>
+</svg>"#;
+        assert!(svg_to_pdf(svg).unwrap().starts_with(b"%PDF-"));
     }
 
     #[test]

--- a/src/render/cosmic_text_renderer.rs
+++ b/src/render/cosmic_text_renderer.rs
@@ -168,12 +168,9 @@ impl Default for CosmicTextRenderer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::render::register_font_bytes;
 
     #[test]
     fn legacy_renderer_preserves_destination_alpha() {
-        register_font_bytes(include_bytes!("../../assets/NotoSans-Regular.ttf").to_vec()).unwrap();
-
         let mut renderer = CosmicTextRenderer::new().unwrap();
         let color = Color::new_rgba(180, 90, 30, 96);
 

--- a/src/render/font_registry.rs
+++ b/src/render/font_registry.rs
@@ -1,0 +1,337 @@
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
+
+use cosmic_text::fontdb;
+
+use crate::core::{PlottingError, Result};
+
+#[derive(Clone, Debug)]
+pub(crate) struct RegisteredFace {
+    pub(crate) index: u32,
+    pub(crate) family: String,
+    pub(crate) post_script_name: String,
+    style: fontdb::Style,
+    weight: fontdb::Weight,
+    stretch: fontdb::Stretch,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SharedFontBytes(Arc<Vec<u8>>);
+
+impl SharedFontBytes {
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl AsRef<[u8]> for SharedFontBytes {
+    fn as_ref(&self) -> &[u8] {
+        self.as_slice()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RegisteredFont {
+    pub(crate) bytes: SharedFontBytes,
+    pub(crate) faces: Arc<[RegisteredFace]>,
+}
+
+impl RegisteredFont {
+    pub(crate) fn fontdb_source(&self) -> fontdb::Source {
+        fontdb::Source::Binary(Arc::new(self.bytes.clone()))
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RegistrySnapshot {
+    pub(crate) generation: u64,
+    pub(crate) fonts: Arc<[RegisteredFont]>,
+}
+
+#[derive(Debug, Default)]
+struct FontRegistry {
+    generation: u64,
+    fonts: Vec<RegisteredFont>,
+}
+
+#[derive(Debug)]
+pub(crate) enum Registration {
+    Duplicate,
+    Added(RegistrySnapshot),
+}
+
+static REGISTRY: OnceLock<Mutex<FontRegistry>> = OnceLock::new();
+
+fn registry() -> &'static Mutex<FontRegistry> {
+    REGISTRY.get_or_init(|| Mutex::new(FontRegistry::default()))
+}
+
+fn lock_registry() -> Result<MutexGuard<'static, FontRegistry>> {
+    registry().lock().map_err(|_| {
+        PlottingError::RenderError(
+            "Font registration aborted because the font registry lock is poisoned".to_string(),
+        )
+    })
+}
+
+pub(crate) fn validate(bytes: Vec<u8>) -> Result<RegisteredFont> {
+    let bytes = SharedFontBytes(Arc::new(bytes));
+    let face_count = ttf_parser::fonts_in_collection(bytes.as_slice()).unwrap_or(1);
+    if face_count == 0 {
+        return Err(invalid_font("font collection contains no faces"));
+    }
+
+    for index in 0..face_count {
+        ttf_parser::Face::parse(bytes.as_slice(), index)
+            .map_err(|err| invalid_font(format!("face {index} could not be parsed: {err}")))?;
+    }
+
+    let mut database = fontdb::Database::new();
+    let ids = database.load_font_source(fontdb::Source::Binary(Arc::new(bytes.clone())));
+    if ids.len() != face_count as usize {
+        return Err(invalid_font(
+            "one or more faces have no usable canonical metadata",
+        ));
+    }
+
+    let faces = ids
+        .iter()
+        .map(|id| {
+            let face = database.face(*id).ok_or_else(|| {
+                invalid_font("validated face metadata disappeared from the font database")
+            })?;
+            let family = face
+                .families
+                .first()
+                .map(|(family, _)| family.clone())
+                .ok_or_else(|| invalid_font(format!("face {} has no family name", face.index)))?;
+            Ok(RegisteredFace {
+                index: face.index,
+                family,
+                post_script_name: face.post_script_name.clone(),
+                style: face.style,
+                weight: face.weight,
+                stretch: face.stretch,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    Ok(RegisteredFont {
+        bytes,
+        faces: faces.into(),
+    })
+}
+
+fn invalid_font(reason: impl std::fmt::Display) -> PlottingError {
+    PlottingError::RenderError(format!("Invalid font data: {reason}"))
+}
+
+pub(crate) fn register(font: RegisteredFont) -> Result<Registration> {
+    let mut registry = lock_registry()?;
+    register_in(&mut registry, font)
+}
+
+fn register_in(registry: &mut FontRegistry, font: RegisteredFont) -> Result<Registration> {
+    if registry
+        .fonts
+        .iter()
+        .any(|existing| existing.bytes.as_slice() == font.bytes.as_slice())
+    {
+        return Ok(Registration::Duplicate);
+    }
+
+    registry.generation = registry.generation.checked_add(1).ok_or_else(|| {
+        PlottingError::RenderError("Font registry generation overflowed".to_string())
+    })?;
+    registry.fonts.push(font);
+    Ok(Registration::Added(RegistrySnapshot {
+        generation: registry.generation,
+        fonts: registry.fonts.clone().into(),
+    }))
+}
+
+pub(crate) fn snapshot() -> Result<RegistrySnapshot> {
+    let registry = lock_registry()?;
+    Ok(RegistrySnapshot {
+        generation: registry.generation,
+        fonts: registry.fonts.clone().into(),
+    })
+}
+
+/// Load registered faces into an existing database while giving exact
+/// family/style/weight/stretch ties precedence over preloaded system faces.
+pub(crate) fn load_with_registered_precedence(
+    database: &mut fontdb::Database,
+    snapshot: &RegistrySnapshot,
+) {
+    let superseded = database
+        .faces()
+        .filter(|candidate| {
+            snapshot.fonts.iter().any(|font| {
+                font.faces.iter().any(|registered| {
+                    candidate.style == registered.style
+                        && candidate.weight == registered.weight
+                        && candidate.stretch == registered.stretch
+                        && candidate
+                            .families
+                            .iter()
+                            .any(|(family, _)| family == &registered.family)
+                })
+            })
+        })
+        .map(|face| face.id)
+        .collect::<Vec<_>>();
+    for id in superseded {
+        database.remove_face(id);
+    }
+
+    for font in snapshot.fonts.iter() {
+        database.load_font_source(font.fontdb_source());
+    }
+}
+
+#[cfg(test)]
+fn deterministic_test_font() -> Option<Vec<u8>> {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("crates/ruviz-web/assets/NotoSans-Regular.ttf");
+    std::fs::read(path).ok()
+}
+
+#[cfg(test)]
+pub(crate) fn renamed_test_font(prefix: &[u8; 4]) -> Option<Vec<u8>> {
+    fn replace_all(bytes: &mut [u8], from: &[u8], to: &[u8]) {
+        debug_assert_eq!(from.len(), to.len());
+        let mut offset = 0;
+        while let Some(index) = bytes[offset..]
+            .windows(from.len())
+            .position(|window| window == from)
+        {
+            let start = offset + index;
+            bytes[start..start + to.len()].copy_from_slice(to);
+            offset = start + to.len();
+        }
+    }
+
+    let mut bytes = deterministic_test_font()?;
+    replace_all(&mut bytes, b"Noto", prefix);
+    let utf16_from: Vec<_> = "Noto".encode_utf16().flat_map(u16::to_be_bytes).collect();
+    let utf16_to: Vec<_> = std::str::from_utf8(prefix)
+        .ok()?
+        .encode_utf16()
+        .flat_map(u16::to_be_bytes)
+        .collect();
+    replace_all(&mut bytes, &utf16_from, &utf16_to);
+    Some(bytes)
+}
+
+#[cfg(all(test, feature = "typst-math"))]
+pub(crate) fn distinct_typographic_family_test_font() -> Option<Vec<u8>> {
+    fn read_u16(bytes: &[u8], offset: usize) -> Option<u16> {
+        Some(u16::from_be_bytes(
+            bytes.get(offset..offset + 2)?.try_into().ok()?,
+        ))
+    }
+
+    fn read_u32(bytes: &[u8], offset: usize) -> Option<u32> {
+        Some(u32::from_be_bytes(
+            bytes.get(offset..offset + 4)?.try_into().ok()?,
+        ))
+    }
+
+    let mut bytes = deterministic_test_font()?;
+    let table_count = usize::from(read_u16(&bytes, 4)?);
+    let name_offset = (0..table_count).find_map(|index| {
+        let record = 12 + index.checked_mul(16)?;
+        (bytes.get(record..record + 4)? == b"name")
+            .then(|| usize::try_from(read_u32(&bytes, record + 8)?).ok())
+            .flatten()
+    })?;
+    let name_count = usize::from(read_u16(&bytes, name_offset + 2)?);
+
+    for index in 0..name_count {
+        let record = name_offset + 6 + index.checked_mul(12)?;
+        let platform_id = read_u16(&bytes, record)?;
+        let name_id = read_u16(&bytes, record + 6)?;
+        if platform_id == 3 && name_id == ttf_parser::name_id::FULL_NAME {
+            bytes
+                .get_mut(record + 6..record + 8)?
+                .copy_from_slice(&ttf_parser::name_id::TYPOGRAPHIC_FAMILY.to_be_bytes());
+            return Some(bytes);
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_extracts_canonical_metadata_and_rejects_invalid_bytes() {
+        let Some(bytes) = deterministic_test_font() else {
+            return;
+        };
+        let font = validate(bytes).unwrap();
+        assert_eq!(font.faces.len(), 1);
+        assert_eq!(font.faces[0].family, "Noto Sans");
+        assert!(!font.faces[0].post_script_name.is_empty());
+
+        let err = validate(b"not a font".to_vec()).unwrap_err();
+        assert!(err.to_string().contains("Invalid font data"));
+    }
+
+    #[test]
+    fn duplicate_and_invalid_fonts_do_not_advance_local_generation() {
+        let Some(bytes) = renamed_test_font(b"PDup") else {
+            return;
+        };
+        let mut registry = FontRegistry::default();
+        let font = validate(bytes).unwrap();
+
+        assert!(matches!(
+            register_in(&mut registry, font.clone()).unwrap(),
+            Registration::Added(_)
+        ));
+        assert_eq!(registry.generation, 1);
+        assert_eq!(registry.fonts.len(), 1);
+
+        assert!(matches!(
+            register_in(&mut registry, font).unwrap(),
+            Registration::Duplicate
+        ));
+        assert_eq!(registry.generation, 1);
+        assert_eq!(registry.fonts.len(), 1);
+
+        assert!(validate(b"invalid font".to_vec()).is_err());
+        assert_eq!(registry.generation, 1);
+        assert_eq!(registry.fonts.len(), 1);
+    }
+
+    #[test]
+    fn registered_faces_replace_exact_preloaded_ties() {
+        let Some(bytes) = renamed_test_font(b"PPrx") else {
+            return;
+        };
+        let font = validate(bytes).unwrap();
+        let registered = font.faces[0].clone();
+        let mut database = fontdb::Database::new();
+        let preloaded = database.load_font_source(font.fontdb_source());
+        let preloaded_id = preloaded[0];
+        let snapshot = RegistrySnapshot {
+            generation: 1,
+            fonts: vec![font].into(),
+        };
+
+        load_with_registered_precedence(&mut database, &snapshot);
+        let selected = database.query(&fontdb::Query {
+            families: &[fontdb::Family::Name(&registered.family)],
+            weight: registered.weight,
+            stretch: registered.stretch,
+            style: registered.style,
+        });
+
+        assert!(database.face(preloaded_id).is_none());
+        assert!(selected.is_some());
+        assert_eq!(database.len(), 1);
+    }
+}

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -3,6 +3,7 @@
 pub mod backend;
 pub mod color;
 pub mod cosmic_text_renderer;
+pub(crate) mod font_registry;
 #[cfg(feature = "gpu")]
 pub mod gpu;
 #[cfg(feature = "parallel")]

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -30,6 +30,7 @@ use swash::scale::Source as SwashSource;
 use tiny_skia::{Pixmap, PixmapMut, PremultipliedColorU8};
 
 use crate::core::error::{PlottingError, Result};
+use crate::render::font_registry::{self, Registration};
 use crate::render::text_anchor::TextPlacementMetrics;
 use crate::render::{
     Color,
@@ -228,6 +229,14 @@ static FONT_SYSTEM: OnceLock<Mutex<FontSystem>> = OnceLock::new();
 /// Global SwashCache singleton - caches rasterized glyphs
 static SWASH_CACHE: OnceLock<Mutex<SwashCache>> = OnceLock::new();
 
+fn font_system_with_registered_fonts(snapshot: &font_registry::RegistrySnapshot) -> FontSystem {
+    let baseline = FontSystem::new();
+    let locale = baseline.locale().to_string();
+    let mut database = baseline.db().clone();
+    font_registry::load_with_registered_precedence(&mut database, snapshot);
+    FontSystem::new_with_locale_and_db(locale, database)
+}
+
 /// Get or initialize the global FontSystem
 ///
 /// The FontSystem is created lazily on first access and reused for all
@@ -236,7 +245,14 @@ static SWASH_CACHE: OnceLock<Mutex<SwashCache>> = OnceLock::new();
 pub fn get_font_system() -> &'static Mutex<FontSystem> {
     FONT_SYSTEM.get_or_init(|| {
         log::debug!("Initializing global FontSystem with system font discovery");
-        Mutex::new(FontSystem::new())
+        let font_system = match font_registry::snapshot() {
+            Ok(snapshot) => font_system_with_registered_fonts(&snapshot),
+            Err(err) => {
+                log::error!("Failed to seed FontSystem from font registry: {err}");
+                FontSystem::new()
+            }
+        };
+        Mutex::new(font_system)
     })
 }
 
@@ -289,8 +305,23 @@ pub fn initialize_text_system() {
 
 /// Register a font from raw bytes with the global text system.
 pub fn register_font_bytes(bytes: Vec<u8>) -> Result<()> {
+    // Preserve the historical successful no-op for malformed or unnamed data.
+    let font = match font_registry::validate(bytes) {
+        Ok(font) => font,
+        Err(err) => {
+            log::warn!("Ignoring font registration: {err}");
+            return Ok(());
+        }
+    };
+
+    // Text rendering always acquires these locks in this order. Holding both
+    // keeps the rebuilt FontSystem and its glyph cache generation consistent.
     let mut font_system = lock_font_system()?;
-    font_system.db_mut().load_font_data(bytes);
+    let mut swash_cache = lock_swash_cache()?;
+    if let Registration::Added(snapshot) = font_registry::register(font)? {
+        *font_system = font_system_with_registered_fonts(&snapshot);
+        *swash_cache = SwashCache::new();
+    }
     Ok(())
 }
 
@@ -1157,6 +1188,48 @@ mod tests {
     }
 
     #[test]
+    fn registered_family_is_available_to_cosmic_text_rendering() {
+        let Some(bytes) = crate::render::font_registry::renamed_test_font(b"PCos") else {
+            return;
+        };
+        let family = "PCos Sans";
+        register_font_bytes(bytes).unwrap();
+
+        let font_system = lock_font_system().unwrap();
+        assert!(font_system.db().faces().any(|face| {
+            face.families
+                .iter()
+                .any(|(registered, _)| registered == family)
+        }));
+        drop(font_system);
+
+        let renderer = TextRenderer::new();
+        let config = FontConfig::new(FontFamily::Name(family.to_string()), 24.0);
+        let mut pixmap = Pixmap::new(96, 64).unwrap();
+        renderer
+            .render_text(&mut pixmap, "P12", 8.0, 8.0, &config, Color::BLACK)
+            .unwrap();
+        assert!(pixmap.pixels().iter().any(|pixel| pixel.alpha() > 0));
+    }
+
+    #[test]
+    fn invalid_registration_remains_a_successful_no_op() {
+        // All successful registrations take this lock before committing to the
+        // registry, so these before/after observations are parallel-test safe.
+        let font_system = lock_font_system().unwrap();
+        let faces_before = font_system.db().len();
+        let generation_before = crate::render::font_registry::snapshot().unwrap().generation;
+
+        assert!(register_font_bytes(b"not a font".to_vec()).is_ok());
+
+        assert_eq!(font_system.db().len(), faces_before);
+        assert_eq!(
+            crate::render::font_registry::snapshot().unwrap().generation,
+            generation_before
+        );
+    }
+
+    #[test]
     fn poisoned_text_lock_returns_error() {
         let mutex = Mutex::new(0_u8);
         let _ = std::panic::catch_unwind(|| {
@@ -1327,10 +1400,8 @@ mod tests {
 
     #[test]
     fn rotated_text_is_pixel_exact_counterclockwise_parity() {
-        register_font_bytes(include_bytes!("../../assets/NotoSans-Regular.ttf").to_vec()).unwrap();
-
         let renderer = TextRenderer::new();
-        let config = FontConfig::new(FontFamily::Name("Noto Sans".to_string()), 32.0);
+        let config = FontConfig::new(FontFamily::SansSerif, 32.0);
         let color = Color::new_rgba(180, 90, 30, 128);
         let mut normal = Pixmap::new(128, 128).unwrap();
         let mut rotated = Pixmap::new(128, 128).unwrap();

--- a/src/render/typst_text.rs
+++ b/src/render/typst_text.rs
@@ -164,12 +164,12 @@ mod imp {
     use super::{TypstBackendKind, TypstRasterOutput, TypstSvgOutput};
     use crate::{
         core::{PlottingError, Result},
-        render::{Color, FontFamily},
+        render::{Color, FontFamily, font_registry},
     };
     use std::{
         collections::HashMap,
         path::PathBuf,
-        sync::{Mutex, MutexGuard, OnceLock},
+        sync::{Arc, Mutex, MutexGuard, OnceLock},
     };
     use tiny_skia::{IntSize, Pixmap};
     use typst::{
@@ -181,7 +181,7 @@ mod imp {
         text::{Font, FontBook},
         utils::LazyHash,
     };
-    use typst_kit::fonts::{FontSearcher, FontSlot};
+    use typst_kit::fonts::{FontSearcher, FontSlot as SearcherFontSlot};
 
     const MAX_CACHE_ENTRIES: usize = 256;
     const MAX_CACHE_BYTES: usize = 64 * 1024 * 1024;
@@ -190,6 +190,7 @@ mod imp {
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     struct CacheKey {
+        font_generation: u64,
         snippet: String,
         size_bits: u32,
         color: (u8, u8, u8, u8),
@@ -216,29 +217,46 @@ mod imp {
 
     #[derive(Debug, Default)]
     struct CacheState {
+        font_generation: u64,
         entries: HashMap<CacheKey, CachedValue>,
         total_bytes: usize,
     }
 
     #[derive(Debug)]
+    enum ContextFontSlot {
+        Searcher(SearcherFontSlot),
+        Registered(Font),
+    }
+
+    impl ContextFontSlot {
+        fn get(&self) -> Option<Font> {
+            match self {
+                Self::Searcher(slot) => slot.get(),
+                Self::Registered(font) => Some(font.clone()),
+            }
+        }
+    }
+
+    #[derive(Debug)]
     struct FontContext {
+        generation: u64,
         book: LazyHash<FontBook>,
-        fonts: Vec<FontSlot>,
+        fonts: Vec<ContextFontSlot>,
         sans_family: String,
         serif_family: String,
         mono_family: String,
     }
 
     #[derive(Debug)]
-    struct TypstWorld {
+    struct TypstWorld<'a> {
         library: &'static LazyHash<Library>,
-        book: &'static LazyHash<FontBook>,
-        fonts: &'static [FontSlot],
+        book: &'a LazyHash<FontBook>,
+        fonts: &'a [ContextFontSlot],
         main: FileId,
         source: Source,
     }
 
-    impl World for TypstWorld {
+    impl World for TypstWorld<'_> {
         fn library(&self) -> &LazyHash<Library> {
             self.library
         }
@@ -264,7 +282,7 @@ mod imp {
         }
 
         fn font(&self, index: usize) -> Option<Font> {
-            self.fonts.get(index).and_then(FontSlot::get)
+            self.fonts.get(index).and_then(ContextFontSlot::get)
         }
 
         fn today(&self, _offset: Option<i64>) -> Option<Datetime> {
@@ -277,61 +295,99 @@ mod imp {
         LIB.get_or_init(|| LazyHash::new(Library::default()))
     }
 
-    fn fonts() -> &'static FontContext {
-        static FONTS: OnceLock<FontContext> = OnceLock::new();
-        FONTS.get_or_init(|| {
-            let mut searcher = FontSearcher::new();
-            let found = searcher.search();
-            let sans_family = select_family(
-                &found.book,
-                &[
-                    "noto sans",
-                    "dejavu sans",
-                    "liberation sans",
-                    "arial",
-                    "helvetica",
-                    "new computer modern sans",
-                    "latin modern sans",
-                ],
-                "sans",
-                "New Computer Modern Sans",
-            );
-            let serif_family = select_family(
-                &found.book,
-                &[
-                    "new computer modern",
-                    "latin modern roman",
-                    "times new roman",
-                    "noto serif",
-                    "dejavu serif",
-                    "liberation serif",
-                    "georgia",
-                ],
-                "serif",
-                "New Computer Modern",
-            );
-            let mono_family = select_family(
-                &found.book,
-                &[
-                    "new computer modern mono",
-                    "latin modern mono",
-                    "noto sans mono",
-                    "dejavu sans mono",
-                    "liberation mono",
-                    "courier new",
-                    "monaco",
-                ],
-                "mono",
-                "New Computer Modern Mono",
-            );
-            FontContext {
-                book: LazyHash::new(found.book),
-                fonts: found.fonts,
-                sans_family,
-                serif_family,
-                mono_family,
+    fn font_context() -> Result<Arc<FontContext>> {
+        static FONTS: OnceLock<Mutex<Option<Arc<FontContext>>>> = OnceLock::new();
+
+        let snapshot = font_registry::snapshot()?;
+        let contexts = FONTS.get_or_init(|| Mutex::new(None));
+        let mut context = lock_cache_resource(contexts, "Typst font context")?;
+        if let Some(existing) = context.as_ref()
+            && existing.generation >= snapshot.generation
+        {
+            return Ok(existing.clone());
+        }
+
+        let rebuilt = Arc::new(build_font_context(snapshot));
+        *context = Some(rebuilt.clone());
+        Ok(rebuilt)
+    }
+
+    fn build_font_context(snapshot: font_registry::RegistrySnapshot) -> FontContext {
+        let mut searcher = FontSearcher::new();
+        #[cfg(target_arch = "wasm32")]
+        searcher.include_system_fonts(false);
+        let found = searcher.search();
+
+        let mut book = FontBook::new();
+        let mut fonts = Vec::new();
+        for registered in snapshot.fonts.iter() {
+            let bytes = Bytes::new(registered.bytes.clone());
+            for face in registered.faces.iter() {
+                if let Some(font) = Font::new(bytes.clone(), face.index) {
+                    let mut info = font.info().clone();
+                    info.family.clone_from(&face.family);
+                    book.push(info);
+                    fonts.push(ContextFontSlot::Registered(font));
+                }
             }
-        })
+        }
+        for (index, slot) in found.fonts.into_iter().enumerate() {
+            if let Some(info) = found.book.info(index) {
+                book.push(info.clone());
+                fonts.push(ContextFontSlot::Searcher(slot));
+            }
+        }
+
+        let sans_family = select_family(
+            &book,
+            &[
+                "noto sans",
+                "dejavu sans",
+                "liberation sans",
+                "arial",
+                "helvetica",
+                "new computer modern sans",
+                "latin modern sans",
+            ],
+            "sans",
+            "New Computer Modern Sans",
+        );
+        let serif_family = select_family(
+            &book,
+            &[
+                "new computer modern",
+                "latin modern roman",
+                "times new roman",
+                "noto serif",
+                "dejavu serif",
+                "liberation serif",
+                "georgia",
+            ],
+            "serif",
+            "New Computer Modern",
+        );
+        let mono_family = select_family(
+            &book,
+            &[
+                "new computer modern mono",
+                "latin modern mono",
+                "noto sans mono",
+                "dejavu sans mono",
+                "liberation mono",
+                "courier new",
+                "monaco",
+            ],
+            "mono",
+            "New Computer Modern Mono",
+        );
+        FontContext {
+            generation: snapshot.generation,
+            book: LazyHash::new(book),
+            fonts,
+            sans_family,
+            serif_family,
+            mono_family,
+        }
     }
 
     fn canonical_family_name<'a>(book: &'a FontBook, requested: &str) -> Option<&'a str> {
@@ -451,7 +507,7 @@ mod imp {
         rotation_deg: f32,
         backend: TypstBackendKind,
     ) -> CacheKey {
-        make_key_with_font_family(snippet, size_pt, color, rotation_deg, backend, "")
+        make_key_with_font_family(snippet, size_pt, color, rotation_deg, backend, "", 0)
     }
 
     fn make_key_with_font_family(
@@ -461,8 +517,10 @@ mod imp {
         rotation_deg: f32,
         backend: TypstBackendKind,
         font_family: &str,
+        font_generation: u64,
     ) -> CacheKey {
         CacheKey {
+            font_generation,
             snippet: snippet.to_string(),
             size_bits: size_pt.to_bits(),
             color: (color.r, color.g, color.b, color.a),
@@ -470,6 +528,18 @@ mod imp {
             backend,
             font_family: font_family.to_string(),
         }
+    }
+
+    fn synchronize_cache_generation(cache: &mut CacheState, generation: u64) -> bool {
+        if generation < cache.font_generation {
+            return false;
+        }
+        if generation > cache.font_generation {
+            cache.entries.clear();
+            cache.total_bytes = 0;
+            cache.font_generation = generation;
+        }
+        true
     }
 
     fn cached_value_bytes(value: &CachedValue) -> usize {
@@ -590,6 +660,7 @@ mod imp {
     }
 
     fn compile_single_page(
+        font_ctx: &FontContext,
         snippet: &str,
         size_pt: f32,
         color: Color,
@@ -597,7 +668,6 @@ mod imp {
         font_family: &str,
         operation: &str,
     ) -> Result<Page> {
-        let font_ctx = fonts();
         let source_text = build_document_source(snippet, size_pt, color, rotation_deg, font_family);
         let main = FileId::new_fake(VirtualPath::new("/main.typ"));
         let source = Source::new(main, source_text);
@@ -669,8 +739,8 @@ mod imp {
             });
         }
 
-        let font_ctx = fonts();
-        let resolved_font_family = resolve_typst_font_family(font_ctx, font_family);
+        let font_ctx = font_context()?;
+        let resolved_font_family = resolve_typst_font_family(&font_ctx, font_family);
         let key = make_key_with_font_family(
             snippet,
             size_pt,
@@ -678,17 +748,19 @@ mod imp {
             rotation_deg,
             TypstBackendKind::Raster,
             &resolved_font_family,
+            font_ctx.generation,
         );
 
         {
-            let cache = lock_cache()?;
-            if let Some(CachedValue::Raster {
-                pixels,
-                pixel_width,
-                pixel_height,
-                logical_width,
-                logical_height,
-            }) = cache.entries.get(&key)
+            let mut cache = lock_cache()?;
+            if synchronize_cache_generation(&mut cache, font_ctx.generation)
+                && let Some(CachedValue::Raster {
+                    pixels,
+                    pixel_width,
+                    pixel_height,
+                    logical_width,
+                    logical_height,
+                }) = cache.entries.get(&key)
             {
                 let size = IntSize::from_wh(*pixel_width, *pixel_height).ok_or_else(|| {
                     PlottingError::RenderError("Invalid cached typst raster size".to_string())
@@ -707,6 +779,7 @@ mod imp {
         }
 
         let page = compile_single_page(
+            &font_ctx,
             snippet,
             size_pt,
             color,
@@ -734,20 +807,22 @@ mod imp {
         let pixels = pixmap.data().to_vec();
         let pixel_bytes = pixels.len();
         let mut cache = lock_cache()?;
-        if pixel_bytes > MAX_CACHE_BYTES {
-            remove_cached_value(&mut cache, &key);
-        } else {
-            insert_cached_value(
-                &mut cache,
-                key,
-                CachedValue::Raster {
-                    pixels,
-                    pixel_width,
-                    pixel_height,
-                    logical_width,
-                    logical_height,
-                },
-            );
+        if synchronize_cache_generation(&mut cache, font_ctx.generation) {
+            if pixel_bytes > MAX_CACHE_BYTES {
+                remove_cached_value(&mut cache, &key);
+            } else {
+                insert_cached_value(
+                    &mut cache,
+                    key,
+                    CachedValue::Raster {
+                        pixels,
+                        pixel_width,
+                        pixel_height,
+                        logical_width,
+                        logical_height,
+                    },
+                );
+            }
         }
 
         Ok(TypstRasterOutput {
@@ -790,8 +865,8 @@ mod imp {
             });
         }
 
-        let font_ctx = fonts();
-        let resolved_font_family = resolve_typst_font_family(font_ctx, font_family);
+        let font_ctx = font_context()?;
+        let resolved_font_family = resolve_typst_font_family(&font_ctx, font_family);
         let key = make_key_with_font_family(
             snippet,
             size_pt,
@@ -799,10 +874,13 @@ mod imp {
             rotation_deg,
             TypstBackendKind::Svg,
             &resolved_font_family,
+            font_ctx.generation,
         );
         {
-            let cache = lock_cache()?;
-            if let Some(CachedValue::Svg { svg, width, height }) = cache.entries.get(&key) {
+            let mut cache = lock_cache()?;
+            if synchronize_cache_generation(&mut cache, font_ctx.generation)
+                && let Some(CachedValue::Svg { svg, width, height }) = cache.entries.get(&key)
+            {
                 return Ok(TypstSvgOutput {
                     svg: svg.clone(),
                     width: *width,
@@ -812,6 +890,7 @@ mod imp {
         }
 
         let page = compile_single_page(
+            &font_ctx,
             snippet,
             size_pt,
             color,
@@ -825,18 +904,20 @@ mod imp {
         let height = size.y.to_pt() as f32;
 
         let mut cache = lock_cache()?;
-        if raw_svg.len() > MAX_CACHE_BYTES {
-            remove_cached_value(&mut cache, &key);
-        } else {
-            insert_cached_value(
-                &mut cache,
-                key,
-                CachedValue::Svg {
-                    svg: raw_svg.clone(),
-                    width,
-                    height,
-                },
-            );
+        if synchronize_cache_generation(&mut cache, font_ctx.generation) {
+            if raw_svg.len() > MAX_CACHE_BYTES {
+                remove_cached_value(&mut cache, &key);
+            } else {
+                insert_cached_value(
+                    &mut cache,
+                    key,
+                    CachedValue::Svg {
+                        svg: raw_svg.clone(),
+                        width,
+                        height,
+                    },
+                );
+            }
         }
 
         Ok(TypstSvgOutput {
@@ -917,6 +998,167 @@ mod imp {
             assert!(err.to_string().contains("test cache lock is poisoned"));
         }
 
+        #[test]
+        fn registered_font_in_initial_snapshot_feeds_typst_raster_and_svg() {
+            let Some(bytes) = font_registry::renamed_test_font(b"PBef") else {
+                return;
+            };
+            let font =
+                font_registry::validate(bytes).expect("renamed deterministic font should validate");
+            let font_ctx = build_font_context(font_registry::RegistrySnapshot {
+                generation: 41,
+                fonts: vec![font].into(),
+            });
+            let family = FontFamily::Name("PBef Sans".to_string());
+            let resolved = resolve_typst_font_family(&font_ctx, &family);
+            assert_eq!(resolved, "PBef Sans");
+
+            let page = compile_single_page(
+                &font_ctx,
+                "Initial registry font",
+                14.0,
+                Color::BLACK,
+                0.0,
+                &resolved,
+                "initial registry test",
+            )
+            .unwrap();
+            assert!(!typst_svg::svg(&page).is_empty());
+            assert!(!typst_render::render(&page, 1.0).data().is_empty());
+        }
+
+        #[test]
+        fn registered_typst_face_uses_registry_canonical_family() {
+            let Some(bytes) = font_registry::distinct_typographic_family_test_font() else {
+                return;
+            };
+            let font = font_registry::validate(bytes).unwrap();
+            let canonical = font.faces[0].family.clone();
+            let typst_family = Font::new(Bytes::new(font.bytes.clone()), font.faces[0].index)
+                .unwrap()
+                .info()
+                .family
+                .clone();
+            assert_ne!(typst_family, canonical);
+
+            let font_ctx = build_font_context(font_registry::RegistrySnapshot {
+                generation: 42,
+                fonts: vec![font].into(),
+            });
+            let selected = font_ctx
+                .book
+                .select_family(&canonical.to_lowercase())
+                .next()
+                .expect("canonical registry family should select the registered face");
+
+            assert_eq!(font_ctx.book.info(selected).unwrap().family, canonical);
+            assert!(matches!(
+                font_ctx.fonts[selected],
+                ContextFontSlot::Registered(_)
+            ));
+            assert_eq!(
+                resolve_typst_font_family(
+                    &font_ctx,
+                    &FontFamily::Name(font_ctx.book.info(selected).unwrap().family.clone())
+                ),
+                canonical
+            );
+        }
+
+        #[test]
+        fn late_registration_rebuilds_typst_context_and_advances_cache_generation() {
+            let Some(bytes) = font_registry::renamed_test_font(b"PTyp") else {
+                return;
+            };
+            let requested = FontFamily::Name("PTyp Sans".to_string());
+            let before = font_context().unwrap();
+            assert_ne!(resolve_typst_font_family(&before, &requested), "PTyp Sans");
+
+            // Populate both backend caches at the old generation.
+            render_svg_with_font_family(
+                "Late font",
+                15.0,
+                Color::BLACK,
+                0.0,
+                &requested,
+                "late SVG baseline",
+            )
+            .unwrap();
+            render_raster_with_font_family(
+                "Late font",
+                15.0,
+                Color::BLACK,
+                0.0,
+                &requested,
+                "late raster baseline",
+            )
+            .unwrap();
+
+            crate::render::register_font_bytes(bytes).unwrap();
+            let after = font_context().unwrap();
+            assert!(after.generation > before.generation);
+            assert_eq!(resolve_typst_font_family(&after, &requested), "PTyp Sans");
+
+            let svg = render_svg_with_font_family(
+                "Late font",
+                15.0,
+                Color::BLACK,
+                0.0,
+                &requested,
+                "late SVG registered",
+            )
+            .unwrap();
+            let raster = render_raster_with_font_family(
+                "Late font",
+                15.0,
+                Color::BLACK,
+                0.0,
+                &requested,
+                "late raster registered",
+            )
+            .unwrap();
+            assert!(!svg.svg.is_empty());
+            assert!(raster.pixmap.data().iter().any(|alpha| *alpha != 0));
+
+            let cache = lock_cache().unwrap();
+            assert!(cache.font_generation >= after.generation);
+            assert!(
+                cache
+                    .entries
+                    .keys()
+                    .all(|key| key.font_generation == cache.font_generation)
+            );
+        }
+
+        #[test]
+        fn cache_generation_clears_old_entries_and_rejects_regression() {
+            let mut cache = CacheState::default();
+            assert!(synchronize_cache_generation(&mut cache, 7));
+            let key = make_key_with_font_family(
+                "generation",
+                12.0,
+                Color::BLACK,
+                0.0,
+                TypstBackendKind::Svg,
+                "P12",
+                7,
+            );
+            insert_cached_value(
+                &mut cache,
+                key,
+                CachedValue::Svg {
+                    svg: "old".to_string(),
+                    width: 1.0,
+                    height: 1.0,
+                },
+            );
+            assert!(synchronize_cache_generation(&mut cache, 8));
+            assert!(cache.entries.is_empty());
+            assert_eq!(cache.total_bytes, 0);
+            assert!(!synchronize_cache_generation(&mut cache, 7));
+            assert_eq!(cache.font_generation, 8);
+        }
+
         fn swap_ascii_case(value: &str) -> String {
             value
                 .chars()
@@ -932,7 +1174,7 @@ mod imp {
 
         #[test]
         fn named_family_resolution_is_case_insensitive_and_canonical() {
-            let font_ctx = fonts();
+            let font_ctx = font_context().unwrap();
             let canonical = font_ctx
                 .book
                 .families()
@@ -941,36 +1183,36 @@ mod imp {
                 .expect("Typst font search should find at least one family");
             let requested = swap_ascii_case(&canonical);
 
-            let resolved = resolve_typst_font_family(font_ctx, &FontFamily::Name(requested));
+            let resolved = resolve_typst_font_family(&font_ctx, &FontFamily::Name(requested));
 
             assert_eq!(resolved, canonical);
         }
 
         #[test]
         fn supported_generic_families_resolve_to_selected_canonical_families() {
-            let font_ctx = fonts();
+            let font_ctx = font_context().unwrap();
 
             assert_eq!(
-                resolve_typst_font_family(font_ctx, &FontFamily::Serif),
+                resolve_typst_font_family(&font_ctx, &FontFamily::Serif),
                 font_ctx.serif_family
             );
             assert_eq!(
-                resolve_typst_font_family(font_ctx, &FontFamily::SansSerif),
+                resolve_typst_font_family(&font_ctx, &FontFamily::SansSerif),
                 font_ctx.sans_family
             );
             assert_eq!(
-                resolve_typst_font_family(font_ctx, &FontFamily::Monospace),
+                resolve_typst_font_family(&font_ctx, &FontFamily::Monospace),
                 font_ctx.mono_family
             );
         }
 
         #[test]
         fn unsupported_typst_generic_families_use_sans_serif_fallback() {
-            let font_ctx = fonts();
+            let font_ctx = font_context().unwrap();
 
             for family in [FontFamily::Cursive, FontFamily::Fantasy] {
                 assert_eq!(
-                    resolve_typst_font_family(font_ctx, &family),
+                    resolve_typst_font_family(&font_ctx, &family),
                     font_ctx.sans_family
                 );
             }
@@ -1003,13 +1245,13 @@ mod imp {
 
         #[test]
         fn canonical_family_spelling_produces_the_same_cache_key_and_source() {
-            let font_ctx = fonts();
+            let font_ctx = font_context().unwrap();
             let canonical = font_ctx.sans_family.clone();
             let differently_cased = swap_ascii_case(&canonical);
             let resolved_canonical =
-                resolve_typst_font_family(font_ctx, &FontFamily::Name(canonical.clone()));
+                resolve_typst_font_family(&font_ctx, &FontFamily::Name(canonical.clone()));
             let resolved_differently_cased =
-                resolve_typst_font_family(font_ctx, &FontFamily::Name(differently_cased));
+                resolve_typst_font_family(&font_ctx, &FontFamily::Name(differently_cased));
 
             let canonical_key = make_key_with_font_family(
                 "#text(\"a\")",
@@ -1018,6 +1260,7 @@ mod imp {
                 0.0,
                 TypstBackendKind::Svg,
                 &resolved_canonical,
+                font_ctx.generation,
             );
             let differently_cased_key = make_key_with_font_family(
                 "#text(\"a\")",
@@ -1026,6 +1269,7 @@ mod imp {
                 0.0,
                 TypstBackendKind::Svg,
                 &resolved_differently_cased,
+                font_ctx.generation,
             );
             let other_family_key = make_key_with_font_family(
                 "#text(\"a\")",
@@ -1034,6 +1278,7 @@ mod imp {
                 0.0,
                 TypstBackendKind::Svg,
                 "Definitely Different Family",
+                font_ctx.generation,
             );
             let source = build_document_source(
                 "#text(\"a\")",
@@ -1065,18 +1310,18 @@ mod imp {
 
         #[test]
         fn missing_named_font_falls_back_by_family_hint() {
-            let font_ctx = fonts();
+            let font_ctx = font_context().unwrap();
 
             let serif = resolve_typst_font_family(
-                font_ctx,
+                &font_ctx,
                 &FontFamily::Name("Definitely Missing Serif".to_string()),
             );
             let sans = resolve_typst_font_family(
-                font_ctx,
+                &font_ctx,
                 &FontFamily::Name("Definitely Missing Sans-Serif".to_string()),
             );
             let mono = resolve_typst_font_family(
-                font_ctx,
+                &font_ctx,
                 &FontFamily::Name("Definitely Missing Mono".to_string()),
             );
 


### PR DESCRIPTION
## Summary

- share registered runtime fonts across raster, SVG, parallel, and Typst backends
- keep family selection and fallback behavior consistent
- add cross-backend font registry regression coverage

## Validation

- `cargo test`
- `cargo test --all-features`
- exact deterministic aggregate golden-image verification

Depends on #77.