### PR TITLE
Verify packaged GPUI consumers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,43 @@ jobs:
       - name: Run clippy
         run: cargo clippy -- -D warnings
 
+  packaged-crates:
+    name: Packaged Crates
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.0.0
+
+      - name: Cache cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-packaged-crates-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-packaged-crates-
+
+      - name: Install Linux desktop build dependencies
+        uses: ./.github/actions/install-linux-desktop-build-deps
+
+      - name: Test packaged-crate verifier
+        run: uv run python -m unittest scripts/test_verify_packaged_crates.py
+
+      - name: Verify packaged crates from an external consumer
+        run: uv run python scripts/verify_packaged_crates.py --mode ci
+
   test-fast:
     name: Test Fast Lane
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -475,6 +475,48 @@ jobs:
         if: steps.ruviz-version.outputs.published == 'true'
         run: echo "ruviz v${{ steps.ruviz-version.outputs.version }} is already published on crates.io"
 
+  verify-packaged-crates:
+    name: Verify packaged ruviz crates
+    runs-on: ubuntu-latest
+    needs: [check-ci, publish-ruviz]
+    if: ${{ !contains((github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag) || github.ref_name, '-') }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.check-ci.outputs.release_sha }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.0.0
+
+      - name: Cache cargo sources
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ${{ runner.os }}-cargo-release-packaged-crates-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-release-packaged-crates-
+
+      - name: Install GPUI Linux build dependencies
+        uses: ./.github/actions/install-linux-desktop-build-deps
+
+      - name: Verify packaged crates against crates.io
+        run: >-
+          uv run python scripts/verify_packaged_crates.py
+          --mode release
+          --expected-vcs-sha ${{ needs.check-ci.outputs.release_sha }}
+          --registry-attempts 60
+          --registry-delay 20
+
   publish-ruviz-web:
     name: Publish ruviz-web to crates.io
     runs-on: ubuntu-latest
@@ -536,7 +578,7 @@ jobs:
   publish-ruviz-gpui:
     name: Publish ruviz-gpui to crates.io
     runs-on: ubuntu-latest
-    needs: [check-ci, publish-ruviz]
+    needs: [check-ci, verify-packaged-crates]
     if: ${{ !contains((github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag) || github.ref_name, '-') }}
     steps:
       - name: Checkout code
@@ -564,28 +606,6 @@ jobs:
       - name: Install GPUI Linux build dependencies
         if: steps.gpui-version.outputs.published != 'true'
         uses: ./.github/actions/install-linux-desktop-build-deps
-
-      - name: Wait for ruviz-gpui packaging to resolve against crates.io
-        if: steps.gpui-version.outputs.published != 'true'
-        run: |
-          last_output=""
-
-          for attempt in $(seq 1 60); do
-            if output="$(cargo package --package ruviz-gpui --allow-dirty --no-verify 2>&1)"; then
-              exit 0
-            fi
-
-            last_output="${output}"
-            echo "Waiting for crates.io index to serve ruviz-gpui dependencies (attempt ${attempt}/60)..."
-            sleep 20
-          done
-
-          echo "Timed out waiting for ruviz-gpui packaging to resolve against crates.io"
-          if [ -n "${last_output}" ]; then
-            echo "Last cargo package error output:"
-            printf '%s\n' "${last_output}"
-          fi
-          exit 1
 
       - name: Publish ruviz-gpui to crates.io
         if: steps.gpui-version.outputs.published != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -792,8 +792,8 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [check-ci, build-release, publish-ruviz, publish-ruviz-web, publish-ruviz-gpui, publish-npm-web, publish-python]
-    if: ${{ always() && needs.build-release.result == 'success' && (needs.publish-ruviz.result == 'success' || needs.publish-ruviz.result == 'skipped') && (needs.publish-ruviz-web.result == 'success' || needs.publish-ruviz-web.result == 'skipped') && (needs.publish-ruviz-gpui.result == 'success' || needs.publish-ruviz-gpui.result == 'skipped') && (needs.publish-npm-web.result == 'success' || needs.publish-npm-web.result == 'skipped') && needs.publish-python.result == 'success' }}
+    needs: [check-ci, build-release, publish-ruviz, verify-packaged-crates, publish-ruviz-web, publish-ruviz-gpui, publish-npm-web, publish-python]
+    if: ${{ always() && needs.build-release.result == 'success' && (needs.publish-ruviz.result == 'success' || needs.publish-ruviz.result == 'skipped') && (needs.verify-packaged-crates.result == 'success' || (contains((github.event_name == 'workflow_dispatch' && github.event.inputs.release_tag) || github.ref_name, '-') && needs.verify-packaged-crates.result == 'skipped')) && (needs.publish-ruviz-web.result == 'success' || needs.publish-ruviz-web.result == 'skipped') && (needs.publish-ruviz-gpui.result == 'success' || needs.publish-ruviz-gpui.result == 'skipped') && (needs.publish-npm-web.result == 'success' || needs.publish-npm-web.result == 'skipped') && needs.publish-python.result == 'success' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/scripts/test_verify_packaged_crates.py
+++ b/scripts/test_verify_packaged_crates.py
@@ -1,0 +1,792 @@
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import io
+import re
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT_PATH = Path(__file__).with_name("verify_packaged_crates.py")
+SPEC = importlib.util.spec_from_file_location("verify_packaged_crates", SCRIPT_PATH)
+assert SPEC is not None
+assert SPEC.loader is not None
+verify_packaged_crates = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = verify_packaged_crates
+SPEC.loader.exec_module(verify_packaged_crates)
+
+LEGACY_CRATES_IO_SOURCE = verify_packaged_crates.LEGACY_CRATES_IO_SOURCE
+SPARSE_CRATES_IO_SOURCE = verify_packaged_crates.SPARSE_CRATES_IO_SOURCE
+ExtractedCrate = verify_packaged_crates.ExtractedCrate
+VerificationError = verify_packaged_crates.VerificationError
+WorkspaceContract = verify_packaged_crates.WorkspaceContract
+
+
+def add_archive_file(archive: tarfile.TarFile, name: str, contents: str) -> None:
+    payload = contents.encode("utf-8")
+    member = tarfile.TarInfo(name)
+    member.size = len(payload)
+    archive.addfile(member, io.BytesIO(payload))
+
+
+def parse_workflow_jobs(path: Path) -> dict[str, dict]:
+    """Parse the small job/step subset needed by these workflow assertions."""
+    jobs: dict[str, dict] = {}
+    current_job: dict | None = None
+    current_step: dict | None = None
+    multiline_key: str | None = None
+    multiline_indent = 0
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        stripped = raw_line.strip()
+        job_match = re.fullmatch(r"  ([A-Za-z0-9_-]+):", raw_line)
+        if job_match:
+            current_job = {"needs": [], "steps": []}
+            jobs[job_match.group(1)] = current_job
+            current_step = None
+            multiline_key = None
+            continue
+        if current_job is None:
+            continue
+        if multiline_key is not None:
+            if stripped and indent >= multiline_indent:
+                current_step[multiline_key] += " " + stripped
+                continue
+            multiline_key = None
+        if indent == 4 and stripped.startswith("needs:"):
+            value = stripped.removeprefix("needs:").strip()
+            if value.startswith("[") and value.endswith("]"):
+                current_job["needs"] = [
+                    item.strip() for item in value[1:-1].split(",") if item.strip()
+                ]
+            elif value:
+                current_job["needs"] = [value]
+            continue
+        if indent == 6 and stripped.startswith("- name:"):
+            current_step = {"name": stripped.split(":", 1)[1].strip()}
+            current_job["steps"].append(current_step)
+            continue
+        if (
+            current_step is not None
+            and indent == 10
+            and isinstance(current_step.get("with"), dict)
+            and ":" in stripped
+        ):
+            key, value = stripped.split(":", 1)
+            current_step["with"][key] = value.strip()
+            continue
+        if current_step is None or indent != 8 or ":" not in stripped:
+            continue
+        key, value = stripped.split(":", 1)
+        value = value.strip()
+        if key == "with" and not value:
+            current_step[key] = {}
+            continue
+        if value in {"|", ">-"}:
+            current_step[key] = ""
+            multiline_key = key
+            multiline_indent = 10
+        else:
+            current_step[key] = value
+
+    return jobs
+
+
+def step_named(job: dict, name: str) -> dict:
+    return next(step for step in job["steps"] if step.get("name") == name)
+
+
+class ArchiveSelectionTests(unittest.TestCase):
+    def test_selects_only_the_exact_name_and_version(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            exact = directory / "ruviz-1.2.3.crate"
+            exact.touch()
+            (directory / "ruviz-1.2.2.crate").touch()
+
+            selected = verify_packaged_crates.exact_archive_path(
+                directory, "ruviz", "1.2.3"
+            )
+
+            self.assertEqual(selected, exact.resolve())
+
+    def test_missing_exact_version_does_not_fall_back(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            (directory / "ruviz-1.2.2.crate").touch()
+
+            with self.assertRaisesRegex(VerificationError, "ruviz-1.2.3.crate"):
+                verify_packaged_crates.exact_archive_path(directory, "ruviz", "1.2.3")
+
+
+class ArchiveManifestTests(unittest.TestCase):
+    def test_archive_manifest_name_and_version_are_validated(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            archive_path = directory / "input.crate"
+            with tarfile.open(archive_path, "w:gz") as archive:
+                add_archive_file(
+                    archive,
+                    "ruviz-1.2.3/Cargo.toml",
+                    '[package]\nname = "different"\nversion = "1.2.3"\n',
+                )
+
+            with self.assertRaisesRegex(VerificationError, "expected ruviz 1.2.3"):
+                verify_packaged_crates.safe_extract_archive(
+                    archive_path, directory / "out", "ruviz", "1.2.3"
+                )
+
+    def test_expected_release_sha_is_checked_from_archive_metadata(self) -> None:
+        crate = ExtractedCrate(
+            "ruviz-gpui",
+            "1.2.3",
+            Path("archive.crate"),
+            Path("ruviz-gpui-1.2.3"),
+            {},
+            "a" * 40,
+            False,
+        )
+
+        verify_packaged_crates.require_archive_vcs_sha(crate, "a" * 40)
+        with self.assertRaisesRegex(VerificationError, "exact release SHA"):
+            verify_packaged_crates.require_archive_vcs_sha(crate, "b" * 40)
+
+    def test_missing_dirty_field_means_clean_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            archive_path = directory / "input.crate"
+            with tarfile.open(archive_path, "w:gz") as archive:
+                add_archive_file(
+                    archive,
+                    "ruviz-1.2.3/Cargo.toml",
+                    '[package]\nname = "ruviz"\nversion = "1.2.3"\n',
+                )
+                add_archive_file(
+                    archive,
+                    "ruviz-1.2.3/.cargo_vcs_info.json",
+                    '{"git":{"sha1":"' + "a" * 40 + '"}}',
+                )
+
+            crate = verify_packaged_crates.safe_extract_archive(
+                archive_path, directory / "out", "ruviz", "1.2.3"
+            )
+
+            self.assertIs(crate.vcs_dirty, False)
+            verify_packaged_crates.require_archive_vcs_sha(crate, "a" * 40)
+
+    def test_expected_release_sha_rejects_dirty_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            archive_path = directory / "input.crate"
+            with tarfile.open(archive_path, "w:gz") as archive:
+                add_archive_file(
+                    archive,
+                    "ruviz-1.2.3/Cargo.toml",
+                    '[package]\nname = "ruviz"\nversion = "1.2.3"\n',
+                )
+                add_archive_file(
+                    archive,
+                    "ruviz-1.2.3/.cargo_vcs_info.json",
+                    '{"git":{"sha1":"' + "a" * 40 + '","dirty":true}}',
+                )
+
+            crate = verify_packaged_crates.safe_extract_archive(
+                archive_path, directory / "out", "ruviz", "1.2.3"
+            )
+
+            self.assertIs(crate.vcs_dirty, True)
+            with self.assertRaisesRegex(VerificationError, "dirty=True"):
+                verify_packaged_crates.require_archive_vcs_sha(crate, "a" * 40)
+
+    def test_archive_cannot_escape_expected_package_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            archive_path = directory / "input.crate"
+            with tarfile.open(archive_path, "w:gz") as archive:
+                add_archive_file(archive, "../outside", "bad")
+
+            with self.assertRaisesRegex(VerificationError, "unexpected member"):
+                verify_packaged_crates.safe_extract_archive(
+                    archive_path, directory / "out", "ruviz", "1.2.3"
+                )
+
+    def test_archive_rejects_windows_escape_spellings(self) -> None:
+        members = (
+            r"ruviz-1.2.3/..\..\outside",
+            r"ruviz-1.2.3/\\server\share\escaped",
+            "ruviz-1.2.3/C:escaped",
+        )
+        for member in members:
+            with (
+                self.subTest(member=member),
+                tempfile.TemporaryDirectory() as temporary,
+            ):
+                directory = Path(temporary)
+                archive_path = directory / "input.crate"
+                with tarfile.open(archive_path, "w:gz") as archive:
+                    add_archive_file(archive, member, "bad")
+
+                with self.assertRaisesRegex(VerificationError, "unexpected member"):
+                    verify_packaged_crates.safe_extract_archive(
+                        archive_path, directory / "out", "ruviz", "1.2.3"
+                    )
+
+
+class RegistrySourceTests(unittest.TestCase):
+    def test_accepts_cargo_crates_io_source_spellings(self) -> None:
+        for source in (
+            LEGACY_CRATES_IO_SOURCE,
+            SPARSE_CRATES_IO_SOURCE,
+            "sparse+https://index.crates.io/",
+            "registry+https://index.crates.io/",
+        ):
+            with self.subTest(source=source):
+                self.assertTrue(verify_packaged_crates.is_crates_io_source(source))
+
+    def test_rejects_non_crates_io_registry(self) -> None:
+        self.assertFalse(
+            verify_packaged_crates.is_crates_io_source(
+                "registry+sparse+https://registry.example.invalid/"
+            )
+        )
+
+
+class WorkspaceContractTests(unittest.TestCase):
+    def test_discovers_target_specific_workspace_only_dev_dependencies(self) -> None:
+        contract = verify_packaged_crates.inspect_workspace(SCRIPT_PATH.parents[1])
+
+        self.assertEqual(
+            contract.workspace_only_dev_dependencies,
+            frozenset({"gpui_macos", "gpui_platform"}),
+        )
+
+
+class PackagingModeTests(unittest.TestCase):
+    def test_package_command_uses_exactly_one_lockfile_mode(self) -> None:
+        for locked, expected, rejected in (
+            (True, "--locked", "--exclude-lockfile"),
+            (False, "--exclude-lockfile", "--locked"),
+        ):
+            with (
+                self.subTest(locked=locked),
+                tempfile.TemporaryDirectory() as temporary,
+            ):
+                target = Path(temporary) / "target"
+                archive = target / "package/ruviz-1.2.3.crate"
+                archive.parent.mkdir(parents=True)
+                archive.touch()
+                success = mock.Mock(returncode=0, stdout="", stderr="")
+                with mock.patch.object(
+                    verify_packaged_crates, "run_command", return_value=success
+                ) as run:
+                    verify_packaged_crates.package_crate(
+                        workspace=Path(temporary),
+                        target_dir=target,
+                        name="ruviz",
+                        version="1.2.3",
+                        locked=locked,
+                    )
+
+                command = run.call_args.args[0]
+                self.assertIn(expected, command)
+                self.assertNotIn(rejected, command)
+
+    def test_locked_adapter_packaging_retries_registry_propagation(self) -> None:
+        error = mock.Mock(
+            returncode=101,
+            stdout="",
+            stderr=(
+                "error: failed to select a version for the requirement "
+                '`ruviz = "=1.2.3"`\nlocation searched: crates.io index'
+            ),
+        )
+        success = mock.Mock(returncode=0, stdout="", stderr="")
+        with tempfile.TemporaryDirectory() as temporary:
+            target = Path(temporary) / "target"
+            archive = target / "package/ruviz-gpui-1.2.3.crate"
+            archive.parent.mkdir(parents=True)
+            archive.touch()
+            with (
+                mock.patch.object(
+                    verify_packaged_crates,
+                    "run_command",
+                    side_effect=[error, success],
+                ) as run,
+                mock.patch.object(verify_packaged_crates.time, "sleep") as sleep,
+            ):
+                verify_packaged_crates.package_crate(
+                    workspace=Path(temporary),
+                    target_dir=target,
+                    name="ruviz-gpui",
+                    version="1.2.3",
+                    locked=True,
+                    registry_attempts=2,
+                    registry_delay=0.25,
+                    registry_package="ruviz",
+                    registry_version="1.2.3",
+                )
+
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(0.25)
+
+    def verify_package_calls(self, mode: str) -> list[object]:
+        contract = WorkspaceContract(
+            version="1.2.3",
+            gpui_version="0.2.2",
+            gpui_patch_git="https://github.com/zed-industries/zed",
+            gpui_patch_rev="abc123",
+            workspace_only_dev_dependencies=frozenset(),
+        )
+        ruviz = ExtractedCrate(
+            "ruviz", "1.2.3", Path("ruviz.crate"), Path("/tmp/ruviz"), {}, None
+        )
+        adapter = ExtractedCrate(
+            "ruviz-gpui",
+            "1.2.3",
+            Path("ruviz-gpui.crate"),
+            Path("/tmp/ruviz-gpui"),
+            {},
+            None,
+        )
+        args = argparse.Namespace(
+            workspace=Path("/tmp/ruviz-package-workspace"),
+            ruviz_archive=None,
+            ruviz_gpui_archive=None,
+            expected_vcs_sha=None,
+            mode=mode,
+            registry_attempts=60,
+            registry_delay=20.0,
+        )
+
+        def create_lockfile(consumer: Path, **_kwargs: object) -> None:
+            (consumer / "Cargo.lock").touch()
+
+        metadata_result = mock.Mock(stdout="{}")
+        with (
+            mock.patch.object(
+                verify_packaged_crates, "inspect_workspace", return_value=contract
+            ),
+            mock.patch.object(
+                verify_packaged_crates,
+                "package_crate",
+                side_effect=[Path("ruviz.crate"), Path("ruviz-gpui.crate")],
+            ) as package,
+            mock.patch.object(
+                verify_packaged_crates,
+                "safe_extract_archive",
+                side_effect=[ruviz, adapter],
+            ),
+            mock.patch.object(verify_packaged_crates, "validate_normalized_manifests"),
+            mock.patch.object(
+                verify_packaged_crates,
+                "generate_lockfile_with_registry_retries",
+                side_effect=create_lockfile,
+            ),
+            mock.patch.object(
+                verify_packaged_crates,
+                "run_command",
+                side_effect=[metadata_result, mock.Mock()],
+            ),
+            mock.patch.object(verify_packaged_crates, "validate_metadata"),
+        ):
+            verify_packaged_crates.verify(args)
+
+        return package.call_args_list
+
+    def test_ci_only_excludes_lockfile_for_unpublished_gpui_adapter(self) -> None:
+        core, adapter = self.verify_package_calls("ci")
+
+        self.assertIs(core.kwargs["locked"], True)
+        self.assertIs(adapter.kwargs["locked"], False)
+        self.assertEqual(adapter.kwargs["registry_attempts"], 1)
+
+    def test_release_packages_both_crates_locked_after_core_publish(self) -> None:
+        core, adapter = self.verify_package_calls("release")
+
+        self.assertIs(core.kwargs["locked"], True)
+        self.assertIs(adapter.kwargs["locked"], True)
+        self.assertEqual(adapter.kwargs["registry_attempts"], 60)
+        self.assertEqual(adapter.kwargs["registry_package"], "ruviz")
+        self.assertEqual(adapter.kwargs["registry_version"], "1.2.3")
+
+
+class MetadataSourceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        root = Path(self.temporary.name)
+        self.workspace = root / "workspace"
+        self.consumer = root / "consumer"
+        self.ruviz_root = root / "archives/ruviz-1.2.3"
+        self.gpui_root = root / "archives/ruviz-gpui-1.2.3"
+        for directory in (
+            self.workspace,
+            self.consumer,
+            self.ruviz_root,
+            self.gpui_root,
+        ):
+            directory.mkdir(parents=True)
+            (directory / "Cargo.toml").touch()
+        self.contract = WorkspaceContract(
+            version="1.2.3",
+            gpui_version="0.2.2",
+            gpui_patch_git="https://github.com/zed-industries/zed",
+            gpui_patch_rev="abc123",
+            workspace_only_dev_dependencies=frozenset({"gpui_macos", "gpui_platform"}),
+        )
+        self.ruviz = ExtractedCrate(
+            "ruviz", "1.2.3", root / "ruviz.crate", self.ruviz_root, {}, None
+        )
+        self.ruviz_gpui = ExtractedCrate(
+            "ruviz-gpui",
+            "1.2.3",
+            root / "ruviz-gpui.crate",
+            self.gpui_root,
+            {},
+            None,
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def metadata(
+        self, *, mode: str, gpui_source: str = LEGACY_CRATES_IO_SOURCE
+    ) -> dict:
+        core_source = None if mode == "ci" else LEGACY_CRATES_IO_SOURCE
+        core_manifest = (
+            self.ruviz_root / "Cargo.toml"
+            if mode == "ci"
+            else Path("/cargo/registry/ruviz-1.2.3/Cargo.toml")
+        )
+        ids = {
+            "consumer": "path+file:///tmp/consumer#ruviz-package-consumer@0.0.0",
+            "ruviz-gpui": "path+file:///tmp/ruviz-gpui#1.2.3",
+            "ruviz": f"{core_source or 'path+file:///tmp/ruviz'}#ruviz@1.2.3",
+            "gpui": f"{gpui_source}#gpui@0.2.2",
+        }
+        return {
+            "workspace_root": str(self.consumer),
+            "packages": [
+                {
+                    "name": "ruviz-package-consumer",
+                    "version": "0.0.0",
+                    "id": ids["consumer"],
+                    "manifest_path": str(self.consumer / "Cargo.toml"),
+                    "source": None,
+                },
+                {
+                    "name": "ruviz-gpui",
+                    "version": "1.2.3",
+                    "id": ids["ruviz-gpui"],
+                    "manifest_path": str(self.gpui_root / "Cargo.toml"),
+                    "source": None,
+                },
+                {
+                    "name": "ruviz",
+                    "version": "1.2.3",
+                    "id": ids["ruviz"],
+                    "manifest_path": str(core_manifest),
+                    "source": core_source,
+                },
+                {
+                    "name": "gpui",
+                    "version": "0.2.2",
+                    "id": ids["gpui"],
+                    "manifest_path": "/cargo/registry/gpui-0.2.2/Cargo.toml",
+                    "source": gpui_source,
+                },
+            ],
+            "resolve": {
+                "nodes": [
+                    {
+                        "id": ids["consumer"],
+                        "deps": [
+                            {
+                                "name": "ruviz",
+                                "pkg": ids["ruviz"],
+                                "dep_kinds": [{"kind": None, "target": None}],
+                            },
+                            {
+                                "name": "ruviz-gpui",
+                                "pkg": ids["ruviz-gpui"],
+                                "dep_kinds": [{"kind": None, "target": None}],
+                            },
+                        ],
+                    },
+                    {"id": ids["ruviz"], "deps": []},
+                    {
+                        "id": ids["ruviz-gpui"],
+                        "deps": [
+                            {
+                                "name": "gpui",
+                                "pkg": ids["gpui"],
+                                "dep_kinds": [{"kind": None, "target": None}],
+                            },
+                            {
+                                "name": "ruviz",
+                                "pkg": ids["ruviz"],
+                                "dep_kinds": [{"kind": None, "target": None}],
+                            },
+                        ],
+                    },
+                    {"id": ids["gpui"], "deps": []},
+                ]
+            },
+        }
+
+    def validate(self, metadata: dict, mode: str) -> None:
+        verify_packaged_crates.validate_metadata(
+            metadata,
+            mode=mode,
+            workspace=self.workspace,
+            consumer=self.consumer,
+            ruviz=self.ruviz,
+            ruviz_gpui=self.ruviz_gpui,
+            contract=self.contract,
+        )
+
+    def test_ci_accepts_local_ruviz_and_registry_gpui(self) -> None:
+        self.validate(self.metadata(mode="ci"), "ci")
+
+    def test_release_accepts_registry_ruviz_and_gpui(self) -> None:
+        self.validate(self.metadata(mode="release"), "release")
+
+    def test_release_accepts_sparse_crates_io_sources(self) -> None:
+        metadata = self.metadata(mode="release", gpui_source=SPARSE_CRATES_IO_SOURCE)
+        core = next(
+            package for package in metadata["packages"] if package["name"] == "ruviz"
+        )
+        core["source"] = SPARSE_CRATES_IO_SOURCE
+
+        self.validate(metadata, "release")
+
+    def test_gpui_git_source_is_rejected(self) -> None:
+        metadata = self.metadata(
+            mode="ci",
+            gpui_source="git+https://github.com/zed-industries/zed?rev=abc123",
+        )
+
+        with self.assertRaisesRegex(VerificationError, "GPUI git patch leaked"):
+            self.validate(metadata, "ci")
+
+    def test_gpui_other_registry_is_rejected(self) -> None:
+        metadata = self.metadata(
+            mode="ci",
+            gpui_source="registry+sparse+https://registry.example.invalid/",
+        )
+
+        with self.assertRaisesRegex(
+            VerificationError, "GPUI must resolve from crates.io"
+        ):
+            self.validate(metadata, "ci")
+
+    def test_release_ruviz_path_source_is_rejected(self) -> None:
+        metadata = self.metadata(mode="release")
+        core = next(
+            package for package in metadata["packages"] if package["name"] == "ruviz"
+        )
+        core["source"] = None
+        core["manifest_path"] = str(self.ruviz_root / "Cargo.toml")
+
+        with self.assertRaisesRegex(VerificationError, "unexpected path package ruviz"):
+            self.validate(metadata, "release")
+
+    def test_resolved_dev_dependency_is_rejected(self) -> None:
+        metadata = self.metadata(mode="ci")
+        adapter_id = next(
+            package["id"]
+            for package in metadata["packages"]
+            if package["name"] == "ruviz-gpui"
+        )
+        adapter_node = next(
+            node for node in metadata["resolve"]["nodes"] if node["id"] == adapter_id
+        )
+        adapter_node["deps"].append(
+            {
+                "name": "test-helper",
+                "pkg": "registry+example#test-helper@1.0.0",
+                "dep_kinds": [{"kind": "dev", "target": None}],
+            }
+        )
+
+        with self.assertRaisesRegex(VerificationError, "dev dependency"):
+            self.validate(metadata, "ci")
+
+    def test_workspace_only_dev_package_is_rejected(self) -> None:
+        metadata = self.metadata(mode="ci")
+        metadata["packages"].append(
+            {
+                "name": "gpui_platform",
+                "version": "0.1.0",
+                "id": "registry+example#gpui_platform@0.1.0",
+                "manifest_path": "/cargo/registry/gpui_platform/Cargo.toml",
+                "source": LEGACY_CRATES_IO_SOURCE,
+            }
+        )
+
+        with self.assertRaisesRegex(VerificationError, "workspace-only dev"):
+            self.validate(metadata, "ci")
+
+    def test_adapter_must_resolve_the_expected_core_edge(self) -> None:
+        metadata = self.metadata(mode="ci")
+        adapter_id = next(
+            package["id"]
+            for package in metadata["packages"]
+            if package["name"] == "ruviz-gpui"
+        )
+        adapter_node = next(
+            node for node in metadata["resolve"]["nodes"] if node["id"] == adapter_id
+        )
+        core_edge = next(
+            edge for edge in adapter_node["deps"] if edge["name"] == "ruviz"
+        )
+        core_edge["pkg"] = "registry+example#ruviz@1.2.3"
+
+        with self.assertRaisesRegex(VerificationError, "normal ruviz edge"):
+            self.validate(metadata, "ci")
+
+
+class NormalizedDependencyTests(unittest.TestCase):
+    def extracted(self, manifest: dict) -> ExtractedCrate:
+        return ExtractedCrate(
+            "ruviz-gpui",
+            "1.2.3",
+            Path("/tmp/ruviz-gpui.crate"),
+            Path("/tmp/ruviz-gpui-1.2.3"),
+            manifest,
+            None,
+        )
+
+    def test_workspace_only_target_dev_dependency_is_rejected(self) -> None:
+        crate = self.extracted(
+            {
+                "target": {
+                    'cfg(target_os = "linux")': {
+                        "dev-dependencies": {
+                            "gpui_platform": {
+                                "git": "https://github.com/zed-industries/zed",
+                                "rev": "abc123",
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+        with self.assertRaisesRegex(VerificationError, "workspace-only dependency"):
+            verify_packaged_crates.validate_active_dependency_sources(crate)
+
+    def test_path_dependency_is_rejected_in_any_dependency_table(self) -> None:
+        crate = self.extracted(
+            {"dev-dependencies": {"helper": {"path": "../../helper"}}}
+        )
+
+        with self.assertRaisesRegex(VerificationError, "non-crates.io source"):
+            verify_packaged_crates.validate_active_dependency_sources(crate)
+
+
+class RegistryRetryTests(unittest.TestCase):
+    def test_exact_version_index_lag_is_retryable(self) -> None:
+        error = """error: failed to select a version for the requirement `ruviz = \"=1.2.3\"`
+candidate versions found which didn't match: 1.2.2
+location searched: crates.io index
+"""
+        self.assertTrue(
+            verify_packaged_crates.is_registry_propagation_error(
+                error, "ruviz", "1.2.3"
+            )
+        )
+
+    def test_manifest_error_is_not_retryable(self) -> None:
+        error = "error: failed to parse manifest at `/tmp/consumer/Cargo.toml`"
+        self.assertFalse(
+            verify_packaged_crates.is_registry_propagation_error(
+                error, "ruviz", "1.2.3"
+            )
+        )
+
+    def test_deterministic_failure_stops_after_one_attempt(self) -> None:
+        failure = mock.Mock(returncode=101, stderr="failed to parse manifest")
+        with mock.patch.object(
+            verify_packaged_crates, "run_command", return_value=failure
+        ) as run:
+            with self.assertRaisesRegex(VerificationError, "not retrying"):
+                verify_packaged_crates.generate_lockfile_with_registry_retries(
+                    Path("/tmp/consumer"),
+                    env={},
+                    attempts=60,
+                    delay=0,
+                    registry_package="ruviz",
+                    registry_version="1.2.3",
+                )
+
+        run.assert_called_once()
+
+
+class WorkflowIntegrationTests(unittest.TestCase):
+    def test_ci_has_one_packaged_crate_gate(self) -> None:
+        jobs = parse_workflow_jobs(SCRIPT_PATH.parents[1] / ".github/workflows/ci.yml")
+        packaged = jobs["packaged-crates"]
+
+        self.assertEqual(packaged["needs"], ["fmt", "clippy"])
+        self.assertEqual(
+            step_named(packaged, "Test packaged-crate verifier")["run"],
+            "uv run python -m unittest scripts/test_verify_packaged_crates.py",
+        )
+        self.assertEqual(
+            step_named(packaged, "Verify packaged crates from an external consumer")[
+                "run"
+            ],
+            "uv run python scripts/verify_packaged_crates.py --mode ci",
+        )
+        self.assertTrue(
+            {"test-fast", "test-feature-contract", "test-visual-heavy"}.issubset(jobs),
+            "P01 feature lanes must remain present",
+        )
+
+    def test_release_gate_uses_resolved_sha_and_blocks_gpui_publish(self) -> None:
+        jobs = parse_workflow_jobs(
+            SCRIPT_PATH.parents[1] / ".github/workflows/release.yml"
+        )
+        verify_job = jobs["verify-packaged-crates"]
+        gpui_job = jobs["publish-ruviz-gpui"]
+
+        self.assertEqual(verify_job["needs"], ["check-ci", "publish-ruviz"])
+        checkout = step_named(verify_job, "Checkout code")
+        self.assertEqual(
+            checkout["with"]["ref"], "${{ needs.check-ci.outputs.release_sha }}"
+        )
+        verify_run = step_named(verify_job, "Verify packaged crates against crates.io")[
+            "run"
+        ]
+        self.assertIn("uv run python scripts/verify_packaged_crates.py", verify_run)
+        self.assertIn("--mode release", verify_run)
+        self.assertIn(
+            "--expected-vcs-sha ${{ needs.check-ci.outputs.release_sha }}", verify_run
+        )
+        self.assertEqual(gpui_job["needs"], ["check-ci", "verify-packaged-crates"])
+
+        publish_steps = [
+            (job_name, step)
+            for job_name, job in jobs.items()
+            for step in job["steps"]
+            if "cargo publish --package ruviz-gpui" in step.get("run", "")
+        ]
+        self.assertEqual(
+            [(name, step["name"]) for name, step in publish_steps],
+            [("publish-ruviz-gpui", "Publish ruviz-gpui to crates.io")],
+        )
+        self.assertEqual(
+            step_named(gpui_job, "Skip ruviz-gpui publish")["if"],
+            "steps.gpui-version.outputs.published == 'true'",
+            "idempotent recovery must still pass through the verification job",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_verify_packaged_crates.py
+++ b/scripts/test_verify_packaged_crates.py
@@ -68,6 +68,9 @@ def parse_workflow_jobs(path: Path) -> dict[str, dict]:
             elif value:
                 current_job["needs"] = [value]
             continue
+        if indent == 4 and stripped.startswith("if:"):
+            current_job["if"] = stripped.removeprefix("if:").strip()
+            continue
         if indent == 6 and stripped.startswith("- name:"):
             current_step = {"name": stripped.split(":", 1)[1].strip()}
             current_job["steps"].append(current_step)
@@ -424,6 +427,7 @@ class MetadataSourceTests(unittest.TestCase):
         self.consumer = root / "consumer"
         self.ruviz_root = root / "archives/ruviz-1.2.3"
         self.gpui_root = root / "archives/ruviz-gpui-1.2.3"
+        self.registry_root = root / "registry/ruviz-1.2.3"
         for directory in (
             self.workspace,
             self.consumer,
@@ -539,7 +543,9 @@ class MetadataSourceTests(unittest.TestCase):
             },
         }
 
-    def validate(self, metadata: dict, mode: str) -> None:
+    def validate(
+        self, metadata: dict, mode: str, expected_vcs_sha: str | None = None
+    ) -> None:
         verify_packaged_crates.validate_metadata(
             metadata,
             mode=mode,
@@ -548,6 +554,7 @@ class MetadataSourceTests(unittest.TestCase):
             ruviz=self.ruviz,
             ruviz_gpui=self.ruviz_gpui,
             contract=self.contract,
+            expected_vcs_sha=expected_vcs_sha,
         )
 
     def test_ci_accepts_local_ruviz_and_registry_gpui(self) -> None:
@@ -555,6 +562,64 @@ class MetadataSourceTests(unittest.TestCase):
 
     def test_release_accepts_registry_ruviz_and_gpui(self) -> None:
         self.validate(self.metadata(mode="release"), "release")
+
+    def test_release_registry_ruviz_matches_expected_sha(self) -> None:
+        metadata = self.metadata(mode="release")
+        core = next(
+            package for package in metadata["packages"] if package["name"] == "ruviz"
+        )
+        registry_root = self.registry_root
+        registry_root.mkdir(parents=True)
+        (registry_root / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+        (registry_root / ".cargo_vcs_info.json").write_text(
+            '{"git":{"sha1":"' + "a" * 40 + '"}}', encoding="utf-8"
+        )
+        core["manifest_path"] = str(registry_root / "Cargo.toml")
+
+        self.validate(metadata, "release", "a" * 40)
+
+    def test_release_registry_ruviz_rejects_mismatched_sha(self) -> None:
+        metadata = self.metadata(mode="release")
+        core = next(
+            package for package in metadata["packages"] if package["name"] == "ruviz"
+        )
+        registry_root = self.registry_root
+        registry_root.mkdir(parents=True)
+        (registry_root / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+        (registry_root / ".cargo_vcs_info.json").write_text(
+            '{"git":{"sha1":"' + "b" * 40 + '"}}', encoding="utf-8"
+        )
+        core["manifest_path"] = str(registry_root / "Cargo.toml")
+
+        with self.assertRaisesRegex(VerificationError, "exact release SHA"):
+            self.validate(metadata, "release", "a" * 40)
+
+    def test_release_registry_ruviz_requires_vcs_metadata(self) -> None:
+        metadata = self.metadata(mode="release")
+        core = next(
+            package for package in metadata["packages"] if package["name"] == "ruviz"
+        )
+        registry_root = self.registry_root
+        registry_root.mkdir(parents=True)
+        (registry_root / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+        core["manifest_path"] = str(registry_root / "Cargo.toml")
+
+        with self.assertRaisesRegex(VerificationError, "exact release SHA"):
+            self.validate(metadata, "release", "a" * 40)
+
+    def test_release_registry_ruviz_rejects_malformed_vcs_metadata(self) -> None:
+        metadata = self.metadata(mode="release")
+        core = next(
+            package for package in metadata["packages"] if package["name"] == "ruviz"
+        )
+        registry_root = self.registry_root
+        registry_root.mkdir(parents=True)
+        (registry_root / "Cargo.toml").write_text("[package]\n", encoding="utf-8")
+        (registry_root / ".cargo_vcs_info.json").write_text("{", encoding="utf-8")
+        core["manifest_path"] = str(registry_root / "Cargo.toml")
+
+        with self.assertRaisesRegex(VerificationError, "invalid .cargo_vcs_info"):
+            self.validate(metadata, "release", "a" * 40)
 
     def test_release_accepts_sparse_crates_io_sources(self) -> None:
         metadata = self.metadata(mode="release", gpui_source=SPARSE_CRATES_IO_SOURCE)
@@ -755,6 +820,7 @@ class WorkflowIntegrationTests(unittest.TestCase):
         )
         verify_job = jobs["verify-packaged-crates"]
         gpui_job = jobs["publish-ruviz-gpui"]
+        release_job = jobs["create-github-release"]
 
         self.assertEqual(verify_job["needs"], ["check-ci", "publish-ruviz"])
         checkout = step_named(verify_job, "Checkout code")
@@ -770,6 +836,16 @@ class WorkflowIntegrationTests(unittest.TestCase):
             "--expected-vcs-sha ${{ needs.check-ci.outputs.release_sha }}", verify_run
         )
         self.assertEqual(gpui_job["needs"], ["check-ci", "verify-packaged-crates"])
+        self.assertIn("verify-packaged-crates", release_job["needs"])
+        self.assertIn(
+            "needs.verify-packaged-crates.result == 'success'",
+            release_job["if"],
+        )
+        self.assertIn(
+            "needs.verify-packaged-crates.result == 'skipped'",
+            release_job["if"],
+        )
+        self.assertIn("contains(", release_job["if"])
 
         publish_steps = [
             (job_name, step)

--- a/scripts/verify_packaged_crates.py
+++ b/scripts/verify_packaged_crates.py
@@ -383,37 +383,35 @@ def safe_extract_archive(
             f"normalized {name} manifest unexpectedly retains workspace-only tables"
         )
 
-    vcs_sha: str | None = None
-    vcs_dirty: bool | None = None
+    vcs_sha, vcs_dirty = read_vcs_metadata(root, f"archive {archive_path}")
+
+    return ExtractedCrate(
+        name, version, archive_path, root, manifest, vcs_sha, vcs_dirty
+    )
+
+
+def read_vcs_metadata(root: Path, artifact: str) -> tuple[str | None, bool | None]:
     vcs_info_path = root / ".cargo_vcs_info.json"
     if vcs_info_path.is_file():
         try:
             vcs_info = json.loads(vcs_info_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError) as exc:
             raise VerificationError(
-                f"archive {archive_path} has invalid .cargo_vcs_info.json: {exc}"
+                f"{artifact} has invalid .cargo_vcs_info.json: {exc}"
             ) from exc
         if not isinstance(vcs_info, dict):
-            raise VerificationError(f"archive {archive_path} has invalid VCS metadata")
+            raise VerificationError(f"{artifact} has invalid VCS metadata")
         git_info = vcs_info.get("git", {})
         if not isinstance(git_info, dict):
-            raise VerificationError(
-                f"archive {archive_path} has invalid git VCS metadata"
-            )
+            raise VerificationError(f"{artifact} has invalid git VCS metadata")
         candidate = git_info.get("sha1")
         if candidate is not None and not isinstance(candidate, str):
-            raise VerificationError(f"archive {archive_path} has a non-string VCS SHA")
+            raise VerificationError(f"{artifact} has a non-string VCS SHA")
         dirty = git_info.get("dirty", False)
         if not isinstance(dirty, bool):
-            raise VerificationError(
-                f"archive {archive_path} has a non-boolean VCS dirty flag"
-            )
-        vcs_sha = candidate
-        vcs_dirty = dirty
-
-    return ExtractedCrate(
-        name, version, archive_path, root, manifest, vcs_sha, vcs_dirty
-    )
+            raise VerificationError(f"{artifact} has a non-boolean VCS dirty flag")
+        return candidate, dirty
+    return None, None
 
 
 def require_archive_vcs_sha(crate: ExtractedCrate, expected_sha: str) -> None:
@@ -426,6 +424,25 @@ def require_archive_vcs_sha(crate: ExtractedCrate, expected_sha: str) -> None:
         raise VerificationError(
             f"{crate.name} archive VCS metadata reports dirty={crate.vcs_dirty!r}; "
             "expected a clean exact-release archive"
+        )
+
+
+def require_registry_vcs_sha(package: dict[str, Any], expected_sha: str) -> None:
+    manifest_path = package.get("manifest_path")
+    if not isinstance(manifest_path, str):
+        raise VerificationError("registry ruviz package has no manifest path")
+    vcs_sha, vcs_dirty = read_vcs_metadata(
+        Path(manifest_path).resolve().parent, "registry ruviz artifact"
+    )
+    if vcs_sha != expected_sha:
+        raise VerificationError(
+            f"registry ruviz artifact was produced from VCS SHA {vcs_sha!r}; "
+            f"expected exact release SHA {expected_sha}"
+        )
+    if vcs_dirty is not False:
+        raise VerificationError(
+            "registry ruviz artifact VCS metadata reports "
+            f"dirty={vcs_dirty!r}; expected a clean exact-release artifact"
         )
 
 
@@ -531,6 +548,7 @@ def validate_metadata(
     ruviz: ExtractedCrate,
     ruviz_gpui: ExtractedCrate,
     contract: WorkspaceContract,
+    expected_vcs_sha: str | None = None,
 ) -> None:
     if Path(metadata.get("workspace_root", "")).resolve() != consumer.resolve():
         raise VerificationError(
@@ -614,6 +632,8 @@ def validate_metadata(
         raise VerificationError(
             f"release ruviz must resolve from crates.io, got {core.get('source')!r}"
         )
+    elif expected_vcs_sha is not None:
+        require_registry_vcs_sha(core, expected_vcs_sha)
 
     gpui = one_package("gpui", contract.gpui_version)
     if not is_crates_io_source(gpui.get("source")):
@@ -849,6 +869,7 @@ def verify(args: argparse.Namespace) -> None:
             ruviz=ruviz,
             ruviz_gpui=ruviz_gpui,
             contract=contract,
+            expected_vcs_sha=args.expected_vcs_sha,
         )
         run_command(["cargo", "check", "--locked"], cwd=consumer, env=cargo_env)
 

--- a/scripts/verify_packaged_crates.py
+++ b/scripts/verify_packaged_crates.py
@@ -1,0 +1,906 @@
+#!/usr/bin/env python3
+"""Verify packaged ruviz crates from a fresh external Cargo consumer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath, PureWindowsPath
+from typing import Any
+
+
+LEGACY_CRATES_IO_SOURCE = "registry+https://github.com/rust-lang/crates.io-index"
+SPARSE_CRATES_IO_SOURCE = "registry+sparse+https://index.crates.io/"
+SUPPORTED_GPUI_TARGETS = {
+    'cfg(target_os = "linux")',
+    'cfg(target_os = "macos")',
+    'cfg(target_os = "windows")',
+}
+WORKSPACE_ONLY_DEV_DEPENDENCIES = {"gpui_macos", "gpui_platform"}
+
+
+class VerificationError(RuntimeError):
+    """A packaged-crate invariant was not satisfied."""
+
+
+@dataclass(frozen=True)
+class WorkspaceContract:
+    version: str
+    gpui_version: str
+    gpui_patch_git: str
+    gpui_patch_rev: str
+    workspace_only_dev_dependencies: frozenset[str]
+
+
+@dataclass(frozen=True)
+class ExtractedCrate:
+    name: str
+    version: str
+    archive: Path
+    root: Path
+    manifest: dict[str, Any]
+    vcs_sha: str | None
+    vcs_dirty: bool | None = None
+
+
+def load_toml(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def is_crates_io_source(source: Any) -> bool:
+    """Accept Cargo's canonical git and sparse spellings for crates.io."""
+    if not isinstance(source, str):
+        return False
+    return source.rstrip("/") in {
+        LEGACY_CRATES_IO_SOURCE.rstrip("/"),
+        SPARSE_CRATES_IO_SOURCE.rstrip("/"),
+        "sparse+https://index.crates.io",
+        "registry+https://index.crates.io",
+    }
+
+
+def dependency_table(manifest: dict[str, Any], table: str, name: str) -> Any:
+    return manifest.get(table, {}).get(name)
+
+
+def require_registry_dependency(dependency: Any, *, name: str, version: str) -> None:
+    if not isinstance(dependency, dict):
+        raise VerificationError(f"{name} must be a detailed dependency table")
+    if dependency.get("version") != version:
+        raise VerificationError(
+            f"{name} must require version {version}, got {dependency.get('version')!r}"
+        )
+    forbidden = sorted(key for key in ("git", "path", "registry") if key in dependency)
+    if forbidden:
+        raise VerificationError(
+            f"{name} must resolve from crates.io; found {', '.join(forbidden)}"
+        )
+
+
+def iter_dependency_tables(
+    manifest: dict[str, Any],
+) -> list[tuple[str, dict[str, Any]]]:
+    tables: list[tuple[str, dict[str, Any]]] = []
+    for table_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+        table = manifest.get(table_name, {})
+        if isinstance(table, dict):
+            tables.append((table_name, table))
+
+    for target, target_manifest in manifest.get("target", {}).items():
+        if not isinstance(target_manifest, dict):
+            continue
+        for table_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+            table = target_manifest.get(table_name, {})
+            if isinstance(table, dict):
+                tables.append((f"target.{target}.{table_name}", table))
+    return tables
+
+
+def validate_active_dependency_sources(
+    crate: ExtractedCrate,
+    workspace_only_dev_dependencies: frozenset[str] = frozenset(
+        WORKSPACE_ONLY_DEV_DEPENDENCIES
+    ),
+) -> None:
+    for table_name, dependencies in iter_dependency_tables(crate.manifest):
+        for name, dependency in dependencies.items():
+            if name in workspace_only_dev_dependencies:
+                raise VerificationError(
+                    f"normalized {crate.name} manifest leaked workspace-only "
+                    f"dependency {name} in {table_name}"
+                )
+            if not isinstance(dependency, dict):
+                continue
+            forbidden = sorted(
+                key for key in ("git", "path", "registry") if key in dependency
+            )
+            if forbidden:
+                raise VerificationError(
+                    f"normalized {crate.name} dependency {name} in {table_name} "
+                    f"retains non-crates.io source keys: {', '.join(forbidden)}"
+                )
+
+
+def inspect_workspace(workspace: Path) -> WorkspaceContract:
+    root_manifest = load_toml(workspace / "Cargo.toml")
+    gpui_manifest = load_toml(workspace / "crates/ruviz-gpui/Cargo.toml")
+
+    members = root_manifest.get("workspace", {}).get("members", [])
+    if "crates/ruviz-gpui" not in members:
+        raise VerificationError("ruviz-gpui is not a workspace member")
+
+    root_package = root_manifest.get("package", {})
+    gpui_package = gpui_manifest.get("package", {})
+    if root_package.get("name") != "ruviz":
+        raise VerificationError("the root package must be named ruviz")
+    if gpui_package.get("name") != "ruviz-gpui":
+        raise VerificationError("the GPUI package must be named ruviz-gpui")
+
+    version = root_package.get("version")
+    if not isinstance(version, str) or gpui_package.get("version") != version:
+        raise VerificationError("ruviz and ruviz-gpui versions must match")
+
+    local_ruviz = dependency_table(gpui_manifest, "dependencies", "ruviz")
+    if not isinstance(local_ruviz, dict):
+        raise VerificationError("ruviz-gpui must declare ruviz with version and path")
+    if local_ruviz.get("version") != version or local_ruviz.get("path") != "../..":
+        raise VerificationError(
+            "ruviz-gpui must use the matching ruviz version and workspace path"
+        )
+
+    patch = root_manifest.get("patch", {}).get("crates-io", {}).get("gpui")
+    if not isinstance(patch, dict) or not patch.get("git") or not patch.get("rev"):
+        raise VerificationError(
+            "the workspace GPUI override must be a pinned git patch"
+        )
+
+    gpui_versions: set[str] = set()
+    gpui_targets: set[str] = set()
+    for target, target_manifest in gpui_manifest.get("target", {}).items():
+        dependency = target_manifest.get("dependencies", {}).get("gpui", {})
+        if dependency:
+            gpui_targets.add(target)
+            if isinstance(dependency, str):
+                gpui_versions.add(dependency)
+            elif isinstance(dependency, dict) and isinstance(
+                dependency.get("version"), str
+            ):
+                if any(key in dependency for key in ("git", "path", "registry")):
+                    raise VerificationError(
+                        f"ruviz-gpui target {target} must declare GPUI from crates.io"
+                    )
+                gpui_versions.add(dependency["version"])
+            else:
+                raise VerificationError(f"invalid GPUI dependency for target {target}")
+
+    if gpui_targets != SUPPORTED_GPUI_TARGETS or len(gpui_versions) != 1:
+        raise VerificationError(
+            "ruviz-gpui must use one GPUI version on Linux, macOS, and Windows"
+        )
+
+    workspace_only_dev_dependencies = {
+        name
+        for table_name, dependencies in iter_dependency_tables(gpui_manifest)
+        if table_name.endswith("dev-dependencies")
+        for name, dependency in dependencies.items()
+        if isinstance(dependency, dict)
+        and any(key in dependency for key in ("git", "path"))
+    }
+    return WorkspaceContract(
+        version=version,
+        gpui_version=gpui_versions.pop(),
+        gpui_patch_git=str(patch["git"]),
+        gpui_patch_rev=str(patch["rev"]),
+        workspace_only_dev_dependencies=frozenset(workspace_only_dev_dependencies),
+    )
+
+
+def exact_archive_path(directory: Path, name: str, version: str) -> Path:
+    expected = directory / f"{name}-{version}.crate"
+    if not expected.is_file():
+        available = ", ".join(path.name for path in sorted(directory.glob("*.crate")))
+        detail = f"; found: {available}" if available else ""
+        raise VerificationError(f"expected archive {expected}{detail}")
+    return expected.resolve()
+
+
+def resolve_archive_argument(path: Path, name: str, version: str) -> Path:
+    path = path.expanduser().resolve()
+    if path.is_dir():
+        return exact_archive_path(path, name, version)
+    if not path.is_file():
+        raise VerificationError(f"archive does not exist: {path}")
+    return path
+
+
+def run_command(
+    command: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str] | None = None,
+    capture: bool = False,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    print(f"+ {' '.join(command)}", flush=True)
+    result = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+    )
+    if check and result.returncode != 0:
+        detail = ""
+        if capture and result.stderr:
+            detail = f"\n{result.stderr.strip()}"
+        raise VerificationError(
+            f"command failed with exit code {result.returncode}: "
+            f"{' '.join(command)}{detail}"
+        )
+    return result
+
+
+def package_crate(
+    *,
+    workspace: Path,
+    target_dir: Path,
+    name: str,
+    version: str,
+    locked: bool,
+    registry_attempts: int = 1,
+    registry_delay: float = 0,
+    registry_package: str | None = None,
+    registry_version: str | None = None,
+) -> Path:
+    command = [
+        "cargo",
+        "package",
+        "--package",
+        name,
+        "--allow-dirty",
+        "--no-verify",
+        "--locked" if locked else "--exclude-lockfile",
+        "--target-dir",
+        str(target_dir),
+    ]
+    last_error = ""
+    for attempt in range(1, registry_attempts + 1):
+        result = run_command(command, cwd=workspace, capture=True, check=False)
+        if result.returncode == 0:
+            return exact_archive_path(target_dir / "package", name, version)
+
+        last_error = "\n".join(
+            output.strip()
+            for output in (result.stdout, result.stderr)
+            if output.strip()
+        )
+        retryable = (
+            registry_package is not None
+            and registry_version is not None
+            and is_registry_propagation_error(
+                last_error, registry_package, registry_version
+            )
+        )
+        if not retryable:
+            raise VerificationError(
+                f"cargo package for {name} failed with a deterministic or "
+                f"non-propagation error; not retrying:\n{last_error}"
+            )
+        if attempt < registry_attempts:
+            print(
+                f"crates.io has not indexed {registry_package} {registry_version} "
+                f"for packaging (attempt {attempt}/{registry_attempts}); "
+                f"retrying in {registry_delay:g}s",
+                flush=True,
+            )
+            time.sleep(registry_delay)
+
+    raise VerificationError(
+        f"crates.io did not expose {registry_package} {registry_version} for "
+        f"packaging after {registry_attempts} attempt(s):\n{last_error}"
+    )
+
+
+def safe_extract_archive(
+    archive_path: Path, destination: Path, name: str, version: str
+) -> ExtractedCrate:
+    expected_root = f"{name}-{version}"
+    destination.mkdir(parents=True, exist_ok=True)
+    extraction_root = (destination / expected_root).resolve()
+    seen: set[PurePosixPath] = set()
+
+    try:
+        archive = tarfile.open(archive_path, mode="r:gz")
+    except (OSError, tarfile.TarError) as exc:
+        raise VerificationError(f"cannot read archive {archive_path}: {exc}") from exc
+
+    with archive:
+        for member in archive.getmembers():
+            relative = PurePosixPath(member.name)
+            windows_parts = [PureWindowsPath(part) for part in relative.parts]
+            if (
+                "\\" in member.name
+                or relative.is_absolute()
+                or ".." in relative.parts
+                or not relative.parts
+                or relative.parts[0] != expected_root
+                or any(part.drive or part.root for part in windows_parts)
+            ):
+                raise VerificationError(
+                    f"archive {archive_path} has unsafe or unexpected member {member.name!r}"
+                )
+            if relative in seen:
+                raise VerificationError(
+                    f"archive {archive_path} contains duplicate member {member.name!r}"
+                )
+            seen.add(relative)
+            output = destination.joinpath(*relative.parts).resolve()
+            if not is_within(output, extraction_root):
+                raise VerificationError(
+                    f"archive {archive_path} member escapes extraction root: "
+                    f"{member.name!r}"
+                )
+            if member.isdir():
+                output.mkdir(parents=True, exist_ok=True)
+            elif member.isfile():
+                output.parent.mkdir(parents=True, exist_ok=True)
+                source = archive.extractfile(member)
+                if source is None:
+                    raise VerificationError(f"cannot extract {member.name!r}")
+                with source, output.open("wb") as target:
+                    shutil.copyfileobj(source, target)
+            else:
+                raise VerificationError(
+                    f"archive {archive_path} contains unsupported member {member.name!r}"
+                )
+
+    root = extraction_root
+    manifest_path = root / "Cargo.toml"
+    if not manifest_path.is_file():
+        raise VerificationError(f"archive {archive_path} has no normalized Cargo.toml")
+    manifest = load_toml(manifest_path)
+    package = manifest.get("package", {})
+    if package.get("name") != name or package.get("version") != version:
+        raise VerificationError(
+            f"archive manifest identifies {package.get('name')} {package.get('version')}, "
+            f"expected {name} {version}"
+        )
+    if "workspace" in manifest or "patch" in manifest:
+        raise VerificationError(
+            f"normalized {name} manifest unexpectedly retains workspace-only tables"
+        )
+
+    vcs_sha: str | None = None
+    vcs_dirty: bool | None = None
+    vcs_info_path = root / ".cargo_vcs_info.json"
+    if vcs_info_path.is_file():
+        try:
+            vcs_info = json.loads(vcs_info_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise VerificationError(
+                f"archive {archive_path} has invalid .cargo_vcs_info.json: {exc}"
+            ) from exc
+        if not isinstance(vcs_info, dict):
+            raise VerificationError(f"archive {archive_path} has invalid VCS metadata")
+        git_info = vcs_info.get("git", {})
+        if not isinstance(git_info, dict):
+            raise VerificationError(
+                f"archive {archive_path} has invalid git VCS metadata"
+            )
+        candidate = git_info.get("sha1")
+        if candidate is not None and not isinstance(candidate, str):
+            raise VerificationError(f"archive {archive_path} has a non-string VCS SHA")
+        dirty = git_info.get("dirty", False)
+        if not isinstance(dirty, bool):
+            raise VerificationError(
+                f"archive {archive_path} has a non-boolean VCS dirty flag"
+            )
+        vcs_sha = candidate
+        vcs_dirty = dirty
+
+    return ExtractedCrate(
+        name, version, archive_path, root, manifest, vcs_sha, vcs_dirty
+    )
+
+
+def require_archive_vcs_sha(crate: ExtractedCrate, expected_sha: str) -> None:
+    if crate.vcs_sha != expected_sha:
+        raise VerificationError(
+            f"{crate.name} archive was produced from VCS SHA {crate.vcs_sha!r}; "
+            f"expected exact release SHA {expected_sha}"
+        )
+    if crate.vcs_dirty is not False:
+        raise VerificationError(
+            f"{crate.name} archive VCS metadata reports dirty={crate.vcs_dirty!r}; "
+            "expected a clean exact-release archive"
+        )
+
+
+def validate_normalized_manifests(
+    ruviz: ExtractedCrate,
+    ruviz_gpui: ExtractedCrate,
+    contract: WorkspaceContract,
+) -> None:
+    validate_active_dependency_sources(ruviz, contract.workspace_only_dev_dependencies)
+    validate_active_dependency_sources(
+        ruviz_gpui, contract.workspace_only_dev_dependencies
+    )
+
+    dependency = dependency_table(ruviz_gpui.manifest, "dependencies", "ruviz")
+    require_registry_dependency(dependency, name="ruviz", version=contract.version)
+
+    gpui_targets: set[str] = set()
+    for target, target_manifest in ruviz_gpui.manifest.get("target", {}).items():
+        gpui = target_manifest.get("dependencies", {}).get("gpui")
+        if gpui is not None:
+            gpui_targets.add(target)
+            require_registry_dependency(
+                gpui, name=f"gpui ({target})", version=contract.gpui_version
+            )
+    if gpui_targets != SUPPORTED_GPUI_TARGETS:
+        raise VerificationError(
+            "normalized ruviz-gpui manifest is missing a supported-target GPUI dependency"
+        )
+
+    if ruviz.manifest.get("package", {}).get("version") != contract.version:
+        raise VerificationError("normalized ruviz manifest version changed")
+
+
+def toml_string(value: str | Path) -> str:
+    return json.dumps(str(value))
+
+
+def write_consumer(
+    directory: Path,
+    *,
+    mode: str,
+    ruviz: ExtractedCrate,
+    ruviz_gpui: ExtractedCrate,
+) -> None:
+    dependencies = [
+        f'ruviz = {{ version = "={ruviz.version}" }}',
+        (
+            "ruviz-gpui = { path = "
+            f"{toml_string(ruviz_gpui.root)}, default-features = false }}"
+        ),
+    ]
+    patch = ""
+    if mode == "ci":
+        patch = f"\n[patch.crates-io]\nruviz = {{ path = {toml_string(ruviz.root)} }}\n"
+
+    manifest = (
+        "[package]\n"
+        'name = "ruviz-package-consumer"\n'
+        'version = "0.0.0"\n'
+        'edition = "2024"\n'
+        "\n[dependencies]\n" + "\n".join(dependencies) + "\n" + patch
+    )
+    source = """use ruviz::prelude::*;
+use ruviz_gpui::{
+    gpui::{Context, Entity},
+    plot_builder, PresentationMode, RuvizPlot,
+};
+
+fn embed<V: 'static>(cx: &mut Context<V>) -> Entity<RuvizPlot> {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 4.0])
+        .title("packaged consumer")
+        .into();
+    plot_builder(plot)
+        .interactive()
+        .presentation(PresentationMode::Image)
+        .build(cx)
+}
+
+fn main() {
+    let _ = embed::<RuvizPlot>;
+}
+"""
+    (directory / "src").mkdir(parents=True)
+    (directory / "Cargo.toml").write_text(manifest, encoding="utf-8")
+    (directory / "src/main.rs").write_text(source, encoding="utf-8")
+
+
+def is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.resolve().relative_to(parent.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def validate_metadata(
+    metadata: dict[str, Any],
+    *,
+    mode: str,
+    workspace: Path,
+    consumer: Path,
+    ruviz: ExtractedCrate,
+    ruviz_gpui: ExtractedCrate,
+    contract: WorkspaceContract,
+) -> None:
+    if Path(metadata.get("workspace_root", "")).resolve() != consumer.resolve():
+        raise VerificationError(
+            "Cargo metadata did not use the fresh external consumer"
+        )
+
+    packages = metadata.get("packages")
+    if not isinstance(packages, list):
+        raise VerificationError("Cargo metadata has no package list")
+    expected_local = {
+        "ruviz-package-consumer": consumer.resolve(),
+        "ruviz-gpui": ruviz_gpui.root.resolve(),
+    }
+    if mode == "ci":
+        expected_local["ruviz"] = ruviz.root.resolve()
+
+    for package in packages:
+        if not isinstance(package, dict) or not isinstance(
+            package.get("manifest_path"), str
+        ):
+            raise VerificationError("Cargo metadata contains an invalid package")
+        manifest_path = Path(package["manifest_path"]).resolve()
+        if is_within(manifest_path, workspace):
+            raise VerificationError(
+                f"workspace source leaked into consumer: {manifest_path}"
+            )
+        source = package.get("source")
+        if source is None:
+            expected_root = expected_local.get(package.get("name"))
+            if expected_root is None or not is_within(manifest_path, expected_root):
+                raise VerificationError(
+                    f"unexpected path package {package.get('name')} at {manifest_path}"
+                )
+        elif not isinstance(source, str):
+            raise VerificationError(
+                f"Cargo metadata has an invalid source for {package.get('name')}: "
+                f"{source!r}"
+            )
+        elif source.startswith("git+") and (
+            contract.gpui_patch_git in source or contract.gpui_patch_rev in source
+        ):
+            raise VerificationError(f"workspace GPUI git patch leaked: {source}")
+        elif source.startswith("git+"):
+            raise VerificationError(
+                f"unexpected git dependency leaked into consumer: {source}"
+            )
+
+        if package.get("name") in contract.workspace_only_dev_dependencies:
+            raise VerificationError(
+                f"workspace-only dev dependency resolved in consumer: "
+                f"{package.get('name')}"
+            )
+
+    def one_package(name: str, version: str) -> dict[str, Any]:
+        matches = [
+            package
+            for package in packages
+            if package.get("name") == name and package.get("version") == version
+        ]
+        if len(matches) != 1:
+            raise VerificationError(
+                f"expected exactly one {name} {version}, found {len(matches)}"
+            )
+        return matches[0]
+
+    adapter = one_package("ruviz-gpui", contract.version)
+    if adapter.get("source") is not None or not is_within(
+        Path(adapter["manifest_path"]), ruviz_gpui.root
+    ):
+        raise VerificationError("ruviz-gpui did not resolve from its unpacked archive")
+
+    core = one_package("ruviz", contract.version)
+    if mode == "ci":
+        if core.get("source") is not None or not is_within(
+            Path(core["manifest_path"]), ruviz.root
+        ):
+            raise VerificationError(
+                "CI ruviz did not resolve from its unpacked archive"
+            )
+    elif not is_crates_io_source(core.get("source")):
+        raise VerificationError(
+            f"release ruviz must resolve from crates.io, got {core.get('source')!r}"
+        )
+
+    gpui = one_package("gpui", contract.gpui_version)
+    if not is_crates_io_source(gpui.get("source")):
+        raise VerificationError(
+            f"GPUI must resolve from crates.io, got {gpui.get('source')!r}"
+        )
+
+    resolve = metadata.get("resolve")
+    if not isinstance(resolve, dict) or not isinstance(resolve.get("nodes"), list):
+        raise VerificationError("Cargo metadata has no usable resolve graph")
+    nodes_by_id = {
+        node.get("id"): node
+        for node in resolve["nodes"]
+        if isinstance(node, dict) and isinstance(node.get("id"), str)
+    }
+
+    def node_for(package: dict[str, Any]) -> dict[str, Any]:
+        node = nodes_by_id.get(package.get("id"))
+        if not isinstance(node, dict) or not isinstance(node.get("deps"), list):
+            raise VerificationError(
+                f"Cargo resolve graph has no usable node for {package['name']}"
+            )
+        return node
+
+    def require_normal_edge(
+        package: dict[str, Any], dependency_name: str, expected_id: str
+    ) -> None:
+        node = node_for(package)
+        edges = []
+        for dependency in node["deps"]:
+            if not isinstance(dependency, dict):
+                continue
+            kinds = dependency.get("dep_kinds")
+            if not isinstance(kinds, list):
+                continue
+            if (
+                isinstance(dependency.get("name"), str)
+                and dependency["name"].replace("_", "-") == dependency_name
+                and dependency.get("pkg") == expected_id
+                and any(
+                    isinstance(kind, dict) and kind.get("kind") is None
+                    for kind in kinds
+                )
+            ):
+                edges.append(dependency)
+        if len(edges) != 1:
+            raise VerificationError(
+                f"{package['name']} does not resolve one normal {dependency_name} "
+                "edge to the expected package"
+            )
+
+    consumer_package = one_package("ruviz-package-consumer", "0.0.0")
+    require_normal_edge(consumer_package, "ruviz", core["id"])
+    require_normal_edge(consumer_package, "ruviz-gpui", adapter["id"])
+    require_normal_edge(adapter, "ruviz", core["id"])
+    require_normal_edge(adapter, "gpui", gpui["id"])
+
+    for package in (core, adapter):
+        node = node_for(package)
+        for dependency in node["deps"]:
+            if not isinstance(dependency, dict):
+                raise VerificationError(
+                    f"Cargo resolve graph has an invalid edge for {package['name']}"
+                )
+            kinds = dependency.get("dep_kinds")
+            if not isinstance(kinds, list):
+                raise VerificationError(
+                    f"Cargo resolve edge has no dependency kinds for {package['name']}"
+                )
+            if any(
+                isinstance(kind, dict) and kind.get("kind") == "dev" for kind in kinds
+            ):
+                raise VerificationError(
+                    f"dev dependency {dependency.get('name')!r} from "
+                    f"{package['name']} leaked into the consumer resolve graph"
+                )
+
+
+def is_registry_propagation_error(stderr: str, name: str, version: str) -> bool:
+    """Identify the exact-version-not-yet-indexed Cargo failures worth retrying."""
+    lowered = stderr.lower()
+    if "crates.io index" not in lowered or name.lower() not in lowered:
+        return False
+    missing_exact_version = (
+        "failed to select a version for the requirement" in lowered
+        or f"no matching package named `{name.lower()}` found" in lowered
+    )
+    return missing_exact_version and version.lower() in lowered
+
+
+def generate_lockfile_with_registry_retries(
+    consumer: Path,
+    *,
+    env: dict[str, str],
+    attempts: int,
+    delay: float,
+    registry_package: str,
+    registry_version: str,
+) -> None:
+    command = ["cargo", "generate-lockfile"]
+    last_error = ""
+    for attempt in range(1, attempts + 1):
+        result = run_command(command, cwd=consumer, env=env, capture=True, check=False)
+        if result.returncode == 0:
+            return
+        last_error = result.stderr.strip()
+        retryable = is_registry_propagation_error(
+            last_error, registry_package, registry_version
+        )
+        if not retryable:
+            raise VerificationError(
+                "cargo generate-lockfile failed with a deterministic or non-propagation "
+                f"error; not retrying:\n{last_error}"
+            )
+        if attempt < attempts:
+            print(
+                f"crates.io has not indexed {registry_package} {registry_version} "
+                f"(attempt {attempt}/{attempts}); "
+                f"retrying in {delay:g}s",
+                flush=True,
+            )
+            time.sleep(delay)
+    raise VerificationError(
+        f"crates.io did not expose {registry_package} {registry_version} after "
+        f"{attempts} attempt(s):\n{last_error}"
+    )
+
+
+def verify(args: argparse.Namespace) -> None:
+    workspace = args.workspace.expanduser().resolve()
+    contract = inspect_workspace(workspace)
+
+    system_temp = Path(tempfile.gettempdir()).resolve()
+    if is_within(system_temp, workspace):
+        raise VerificationError(
+            f"system temporary directory is inside workspace: {system_temp}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="ruviz-package-verifier-") as temporary:
+        temp = Path(temporary).resolve()
+        if is_within(temp, workspace):
+            raise VerificationError(
+                "verifier temporary directory must be outside workspace"
+            )
+
+        package_target = temp / "package-target"
+        extracted = temp / "archives"
+
+        if args.ruviz_archive is None:
+            ruviz_archive = package_crate(
+                workspace=workspace,
+                target_dir=package_target / "ruviz",
+                name="ruviz",
+                version=contract.version,
+                locked=True,
+            )
+        else:
+            ruviz_archive = resolve_archive_argument(
+                args.ruviz_archive, "ruviz", contract.version
+            )
+        ruviz = safe_extract_archive(
+            ruviz_archive, extracted, "ruviz", contract.version
+        )
+
+        if args.ruviz_gpui_archive is None:
+            gpui_archive = package_crate(
+                workspace=workspace,
+                target_dir=package_target / "ruviz-gpui",
+                name="ruviz-gpui",
+                version=contract.version,
+                locked=args.mode == "release",
+                registry_attempts=(
+                    args.registry_attempts if args.mode == "release" else 1
+                ),
+                registry_delay=args.registry_delay,
+                registry_package="ruviz" if args.mode == "release" else None,
+                registry_version=(contract.version if args.mode == "release" else None),
+            )
+        else:
+            gpui_archive = resolve_archive_argument(
+                args.ruviz_gpui_archive, "ruviz-gpui", contract.version
+            )
+        ruviz_gpui = safe_extract_archive(
+            gpui_archive, extracted, "ruviz-gpui", contract.version
+        )
+        validate_normalized_manifests(ruviz, ruviz_gpui, contract)
+        if args.expected_vcs_sha is not None:
+            require_archive_vcs_sha(ruviz, args.expected_vcs_sha)
+            require_archive_vcs_sha(ruviz_gpui, args.expected_vcs_sha)
+
+        consumer = temp / "consumer"
+        consumer.mkdir()
+        write_consumer(
+            consumer,
+            mode=args.mode,
+            ruviz=ruviz,
+            ruviz_gpui=ruviz_gpui,
+        )
+
+        cargo_env = os.environ.copy()
+        cargo_env["CARGO_TARGET_DIR"] = str(temp / "consumer-target")
+        registry_package = "ruviz" if args.mode == "release" else "gpui"
+        registry_version = (
+            contract.version if args.mode == "release" else contract.gpui_version
+        )
+        generate_lockfile_with_registry_retries(
+            consumer,
+            env=cargo_env,
+            attempts=args.registry_attempts,
+            delay=args.registry_delay,
+            registry_package=registry_package,
+            registry_version=registry_version,
+        )
+        if not (consumer / "Cargo.lock").is_file():
+            raise VerificationError("cargo generate-lockfile did not create Cargo.lock")
+        metadata_result = run_command(
+            ["cargo", "metadata", "--format-version", "1", "--locked"],
+            cwd=consumer,
+            env=cargo_env,
+            capture=True,
+        )
+        try:
+            metadata = json.loads(metadata_result.stdout)
+        except json.JSONDecodeError as exc:
+            raise VerificationError(
+                f"cargo metadata returned invalid JSON: {exc}"
+            ) from exc
+        validate_metadata(
+            metadata,
+            mode=args.mode,
+            workspace=workspace,
+            consumer=consumer,
+            ruviz=ruviz,
+            ruviz_gpui=ruviz_gpui,
+            contract=contract,
+        )
+        run_command(["cargo", "check", "--locked"], cwd=consumer, env=cargo_env)
+
+        print(
+            f"Verified ruviz {contract.version} and ruviz-gpui {contract.version} "
+            f"in {args.mode} mode: GPUI {contract.gpui_version} is registry-sourced."
+        )
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--mode", choices=("ci", "release"), required=True)
+    parser.add_argument(
+        "--workspace", type=Path, default=Path(__file__).resolve().parents[1]
+    )
+    parser.add_argument(
+        "--ruviz-archive",
+        type=Path,
+        help="ruviz .crate file or directory containing the exact versioned archive",
+    )
+    parser.add_argument(
+        "--ruviz-gpui-archive",
+        type=Path,
+        help="ruviz-gpui .crate file or directory containing the exact archive",
+    )
+    parser.add_argument(
+        "--expected-vcs-sha",
+        help="require both local archives to carry this exact cargo VCS SHA",
+    )
+    parser.add_argument("--registry-attempts", type=int, default=1)
+    parser.add_argument("--registry-delay", type=float, default=20.0)
+    args = parser.parse_args(argv)
+    if args.registry_attempts < 1:
+        parser.error("--registry-attempts must be at least 1")
+    if args.registry_delay < 0:
+        parser.error("--registry-delay cannot be negative")
+    if (
+        args.expected_vcs_sha is not None
+        and re.fullmatch(r"[0-9a-f]{40}", args.expected_vcs_sha) is None
+    ):
+        parser.error("--expected-vcs-sha must be a full lowercase 40-character SHA")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        verify(parse_args(argv))
+    except (OSError, subprocess.SubprocessError, VerificationError, ValueError) as exc:
+        print(f"packaged-crate verification failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- verify packaged `ruviz` and `ruviz-gpui` crates as external consumers
- reject workspace patch leakage and unsafe archive extraction
- gate release workflows on the packaged-crate contract

## Validation

- packaged-crate verifier unit tests
- external consumer builds for `ruviz` and `ruviz-gpui`
- Rustfmt and all-target/all-feature Clippy
