### PR TITLE
Make interaction scale-aware

### DIFF
--- a/crates/ruviz-gpui/src/lib.rs
+++ b/crates/ruviz-gpui/src/lib.rs
@@ -893,15 +893,14 @@ mod platform_impl {
             &self,
             cursor_position_px: ViewportPoint,
         ) -> Result<()> {
-            let snapshot = self.session.viewport_snapshot()?;
-            let cursor_data_position = cursor_data_position(
-                snapshot.visible_bounds,
-                snapshot.plot_area,
-                cursor_position_px,
-            )
-            .ok_or_else(|| {
-                PlottingError::InvalidInput("cursor is outside the plotted data area".to_string())
-            })?;
+            let cursor_data_position = self
+                .session
+                .screen_to_data(cursor_position_px)?
+                .ok_or_else(|| {
+                    PlottingError::InvalidInput(
+                        "cursor is outside the plotted data area".to_string(),
+                    )
+                })?;
             self.copy_text_to_clipboard(&format!(
                 "x={:.6}, y={:.6}",
                 cursor_data_position.x, cursor_data_position.y
@@ -1195,7 +1194,7 @@ mod platform_impl {
     mod tests {
         use super::*;
         use gpui::{Modifiers, MouseButton, TestAppContext};
-        use ruviz::{data::Observable, prelude::Plot};
+        use ruviz::{axes::AxisScale, data::Observable, prelude::Plot};
 
         #[test]
         fn test_rgba_to_bgra_conversion() {
@@ -1572,21 +1571,37 @@ mod platform_impl {
         }
 
         #[test]
-        fn test_cursor_data_position_maps_plot_area() {
-            let visible = ViewportRect::from_points(
-                ViewportPoint::new(0.0, 0.0),
-                ViewportPoint::new(10.0, 20.0),
+        fn test_cursor_data_position_uses_core_scaled_conversion() {
+            let plot: Plot = Plot::new()
+                .line(&[1.0, 100.0], &[-100.0, 100.0])
+                .xscale(AxisScale::Log)
+                .yscale(AxisScale::symlog(1.0))
+                .xlim(1.0, 100.0)
+                .ylim(-100.0, 100.0)
+                .into();
+            let session = plot.prepare_interactive();
+            session
+                .render_to_surface(SurfaceTarget {
+                    size_px: (320, 240),
+                    scale_factor: 1.0,
+                    time_seconds: 0.0,
+                })
+                .expect("cursor conversion frame should render");
+            let plot_area = session
+                .viewport_snapshot()
+                .expect("displayed viewport should be available")
+                .plot_area;
+            let cursor = ViewportPoint::new(
+                (plot_area.min.x + plot_area.max.x) * 0.5,
+                (plot_area.min.y + plot_area.max.y) * 0.5,
             );
-            let plot_area = ViewportRect::from_points(
-                ViewportPoint::new(100.0, 50.0),
-                ViewportPoint::new(300.0, 250.0),
-            );
-            let cursor = ViewportPoint::new(200.0, 150.0);
 
-            let data = cursor_data_position(visible, plot_area, cursor)
+            let data = session
+                .screen_to_data(cursor)
+                .expect("cursor conversion should succeed")
                 .expect("cursor inside plot area should map to data coordinates");
-            assert!((data.x - 5.0).abs() < 1e-6);
-            assert!((data.y - 10.0).abs() < 1e-6);
+            assert!((data.x - 10.0).abs() < 1e-6);
+            assert!(data.y.abs() < 1e-6);
         }
 
         #[test]

--- a/crates/ruviz-gpui/src/platform_impl/interaction.rs
+++ b/crates/ruviz-gpui/src/platform_impl/interaction.rs
@@ -88,28 +88,6 @@ pub(super) fn distance_px(a: ViewportPoint, b: ViewportPoint) -> f64 {
     (dx * dx + dy * dy).sqrt()
 }
 
-pub(super) fn cursor_data_position(
-    visible_bounds: ViewportRect,
-    plot_area: ViewportRect,
-    cursor_position_px: ViewportPoint,
-) -> Option<ViewportPoint> {
-    let plot_width = plot_area.width();
-    let plot_height = plot_area.height();
-    if plot_width <= f64::EPSILON || plot_height <= f64::EPSILON {
-        return None;
-    }
-    if !plot_area.contains(cursor_position_px) {
-        return None;
-    }
-
-    let normalized_x = (cursor_position_px.x - plot_area.min.x) / plot_width;
-    let normalized_y = (cursor_position_px.y - plot_area.min.y) / plot_height;
-    Some(ViewportPoint::new(
-        visible_bounds.min.x + visible_bounds.width() * normalized_x,
-        visible_bounds.max.y - visible_bounds.height() * normalized_y,
-    ))
-}
-
 impl RuvizPlot {
     pub(super) fn reset_pointer_state(&mut self) {
         self.interaction_state.reset_pointer_state();
@@ -148,13 +126,7 @@ impl RuvizPlot {
         &self,
         cursor_position_px: ViewportPoint,
     ) -> Result<Vec<ContextMenuEntry>> {
-        let snapshot = self.session.viewport_snapshot()?;
-        let cursor_available = cursor_data_position(
-            snapshot.visible_bounds,
-            snapshot.plot_area,
-            cursor_position_px,
-        )
-        .is_some();
+        let cursor_available = self.session.screen_to_data(cursor_position_px)?.is_some();
         let mut entries = Vec::new();
 
         let push_entry = |entries: &mut Vec<ContextMenuEntry>,

--- a/crates/ruviz-gpui/src/platform_impl/presentation.rs
+++ b/crates/ruviz-gpui/src/platform_impl/presentation.rs
@@ -360,11 +360,7 @@ impl RuvizPlot {
         cursor_position_px: ViewportPoint,
     ) -> Result<Option<GpuiContextMenuActionContext>> {
         let snapshot = self.session.viewport_snapshot()?;
-        let cursor_data_position = cursor_data_position(
-            snapshot.visible_bounds,
-            snapshot.plot_area,
-            cursor_position_px,
-        );
+        let cursor_data_position = self.session.screen_to_data(cursor_position_px)?;
         let image = self.capture_visible_view_image(window)?;
         Ok(Some(GpuiContextMenuActionContext {
             action_id,

--- a/crates/ruviz-web/src/lib.rs
+++ b/crates/ruviz-web/src/lib.rs
@@ -691,6 +691,16 @@ mod wasm {
             self.update_plot(|plot| plot.size_px(width, height));
         }
 
+        /// Sets the x-axis limits. Inverted bounds keep a descending axis.
+        pub fn xlim(&mut self, min: f64, max: f64) {
+            self.update_plot(|plot| plot.xlim(min, max));
+        }
+
+        /// Sets the y-axis limits. Inverted bounds keep a descending axis.
+        pub fn ylim(&mut self, min: f64, max: f64) {
+            self.update_plot(|plot| plot.ylim(min, max));
+        }
+
         pub fn ticks(&mut self, enabled: bool) {
             self.update_plot(|plot| plot.ticks(enabled));
         }
@@ -894,6 +904,15 @@ mod wasm {
             self.drag = None;
             self.mark_frame_dirty();
             Ok(())
+        }
+
+        /// Maps a backing-surface pixel to displayed data coordinates.
+        fn data_at(&self, x: f64, y: f64) -> Result<(f64, f64), JsValue> {
+            let point = self
+                .session()?
+                .screen_to_data_clamped(ViewportPoint::new(x, y))
+                .map_err(js_err)?;
+            Ok((point.x, point.y))
         }
 
         fn pointer_down(&mut self, x: f64, y: f64, button: i16) -> Result<(), JsValue> {
@@ -1190,6 +1209,11 @@ mod wasm {
         pub fn reset_view(&mut self) -> Result<(), JsValue> {
             self.browser.reset_view()?;
             self.render()
+        }
+
+        /// Returns the data x-coordinate under a backing-surface pixel.
+        pub fn data_x_at(&self, x: f64, y: f64) -> Result<f64, JsValue> {
+            Ok(self.browser.data_at(x, y)?.0)
         }
 
         pub fn render(&mut self) -> Result<(), JsValue> {

--- a/src/axes/mod.rs
+++ b/src/axes/mod.rs
@@ -11,6 +11,7 @@ pub mod ticks;
 
 pub use inset::{ConnectorStyle, InsetAxes};
 pub use polar::PolarAxes;
+pub(crate) use scale::expand_degenerate_range;
 pub use scale::{AxisScale, LinearScale, LogScale, Scale, SymLogScale};
 pub use secondary::{AxisType, DualAxes, SecondaryAxis};
 pub use tick_layout::TickLayout;

--- a/src/axes/scale.rs
+++ b/src/axes/scale.rs
@@ -203,6 +203,25 @@ pub(crate) fn linear_range_is_degenerate(range: f64) -> bool {
     range.abs() < f64::EPSILON
 }
 
+pub(crate) fn expand_degenerate_range(min: f64, max: f64, scale: &AxisScale) -> (f64, f64) {
+    match scale {
+        AxisScale::Log if min == max && min.is_finite() && min > 0.0 => {
+            let lower = min / 10.0;
+            let upper = min * 10.0;
+            if lower > 0.0 && lower < min {
+                (lower, if upper.is_finite() { upper } else { min })
+            } else if upper.is_finite() && upper > min {
+                (min, upper)
+            } else {
+                (min, max)
+            }
+        }
+        AxisScale::Log => (min, max),
+        _ if min == max || linear_range_is_degenerate(max - min) => (min - 1.0, max + 1.0),
+        _ => (min, max),
+    }
+}
+
 #[inline]
 pub(crate) fn linear_normalized_position_with_range(
     value: f64,
@@ -373,7 +392,10 @@ impl AxisScale {
     pub fn create_scale(&self, min: f64, max: f64) -> Box<dyn Scale> {
         match self {
             AxisScale::Linear => Box::new(LinearScale::new(min, max)),
-            AxisScale::Log => Box::new(LogScale::new(min.max(f64::EPSILON), max.max(f64::EPSILON))),
+            AxisScale::Log => {
+                let (min, max) = log_normalization_bounds(min, max);
+                Box::new(LogScale::new(min, max))
+            }
             AxisScale::SymLog { linthresh } => Box::new(SymLogScale::new(min, max, *linthresh)),
         }
     }
@@ -520,6 +542,30 @@ mod tests {
 
         let symlog = AxisScale::symlog(1.0).create_scale(-100.0, 100.0);
         assert!((symlog.transform(0.0) - 0.5).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_axis_scale_create_log_scale_preserves_positive_sub_epsilon_bounds() {
+        let min = f64::EPSILON / 16.0;
+        let max = f64::EPSILON / 2.0;
+        let scale = AxisScale::Log.create_scale(min, max);
+
+        assert_eq!(scale.range(), (min, max));
+        assert_eq!(scale.transform(min), 0.0);
+        assert_eq!(scale.transform(max), 1.0);
+        assert!((scale.inverse(0.5) - (min * max).sqrt()).abs() <= min * 1e-12);
+    }
+
+    #[test]
+    fn test_expand_equal_log_range_stays_positive_for_tiny_value() {
+        for value in [1.0, f64::EPSILON / 1024.0, f64::from_bits(1)] {
+            let (min, max) = expand_degenerate_range(value, value, &AxisScale::Log);
+
+            assert!(min > 0.0, "lower bound must stay positive for {value}");
+            assert!(min < value || max > value);
+            assert!(min < max, "expanded bounds must have extent for {value}");
+            assert!(max.is_finite());
+        }
     }
 
     #[test]

--- a/src/axes/tick_layout.rs
+++ b/src/axes/tick_layout.rs
@@ -52,7 +52,7 @@ impl TickLayout {
         let pixel_positions: Vec<f32> = data_positions
             .iter()
             .map(|&data_pos| {
-                if (data_max - data_min).abs() < f64::EPSILON {
+                if scale_range_is_degenerate(data_min, data_max, scale) {
                     pixel_min
                 } else {
                     let normalized = scale.normalized_position(data_pos, data_min, data_max);
@@ -92,7 +92,7 @@ impl TickLayout {
         let pixel_positions: Vec<f32> = data_positions
             .iter()
             .map(|&data_pos| {
-                if (data_max - data_min).abs() < f64::EPSILON {
+                if scale_range_is_degenerate(data_min, data_max, scale) {
                     pixel_bottom
                 } else {
                     // Invert: higher data values -> lower pixel values
@@ -213,6 +213,19 @@ impl TickLayout {
     }
 }
 
+fn scale_range_is_degenerate(data_min: f64, data_max: f64, scale: &AxisScale) -> bool {
+    match scale {
+        AxisScale::Log => {
+            data_min <= 0.0
+                || data_max <= 0.0
+                || !data_min.is_finite()
+                || !data_max.is_finite()
+                || data_min == data_max
+        }
+        _ => (data_max - data_min).abs() < f64::EPSILON,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -246,6 +259,23 @@ mod tests {
         assert!((layout.pixel_positions[1] - 200.0).abs() < 0.1);
         assert!((layout.pixel_positions[2] - 100.0).abs() < 0.1);
         assert!((layout.pixel_positions[3] - 0.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn test_log_tick_layout_spreads_sub_epsilon_ticks() {
+        let min = f64::EPSILON / 1024.0;
+        let max = f64::EPSILON / 16.0;
+        let layout = TickLayout::compute(min, max, 0.0, 300.0, &AxisScale::Log, 8);
+
+        assert!(layout.pixel_positions.len() >= 2);
+        assert!(
+            layout
+                .pixel_positions
+                .windows(2)
+                .all(|pair| pair[0] < pair[1]),
+            "expected distinct log-space positions: {:?}",
+            layout.pixel_positions
+        );
     }
 
     #[test]

--- a/src/axes/ticks.rs
+++ b/src/axes/ticks.rs
@@ -82,14 +82,16 @@ pub fn generate_ticks_for_scale(
 /// # Returns
 /// Vector of tick positions at powers of 10 (1, 10, 100, 1000, ...)
 pub fn generate_log_ticks(min: f64, max: f64, target_count: usize) -> Vec<f64> {
-    if target_count == 0 || (max - min).abs() < f64::EPSILON {
-        return vec![min.max(f64::EPSILON), max.max(f64::EPSILON)];
-    }
-
     let (min, max) = if min <= max { (min, max) } else { (max, min) };
 
-    if min <= 0.0 || max <= 0.0 {
-        return vec![min.max(f64::EPSILON), max.max(f64::EPSILON)];
+    if min <= 0.0 || max <= 0.0 || !min.is_finite() || !max.is_finite() {
+        let mut fallback = vec![min, max];
+        fallback.retain(|tick| tick.is_finite() && *tick > 0.0);
+        fallback.dedup_by(|left, right| left == right);
+        return fallback;
+    }
+    if target_count == 0 || min == max {
+        return vec![min, max];
     }
 
     let log_min = min.log10().floor() as i32;
@@ -133,8 +135,11 @@ pub fn generate_log_ticks(min: f64, max: f64, target_count: usize) -> Vec<f64> {
         }
     }
 
-    ticks.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    ticks.dedup_by(|a, b| (*a - *b).abs() < f64::EPSILON);
+    if ticks.len() < 2 {
+        ticks.extend([min, max]);
+    }
+    ticks.sort_by(f64::total_cmp);
+    ticks.dedup_by(|left, right| left == right);
     ticks
 }
 
@@ -195,8 +200,12 @@ pub fn generate_symlog_ticks(min: f64, max: f64, linthresh: f64, target_count: u
     }
 
     ticks.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    ticks.dedup_by(|a, b| (*a - *b).abs() < f64::EPSILON);
+    ticks.dedup_by(|a, b| relative_ticks_overlap(*a, *b));
     ticks
+}
+
+fn relative_ticks_overlap(left: f64, right: f64) -> bool {
+    left == right || (left - right).abs() <= left.abs().max(right.abs()) * f64::EPSILON * 8.0
 }
 
 /// Generate minor ticks for logarithmic scales
@@ -353,6 +362,29 @@ mod tests {
         let ticks = generate_log_ticks(-10.0, 100.0, 5);
         // Should return a fallback
         assert!(!ticks.is_empty());
+    }
+
+    #[test]
+    fn test_log_ticks_preserve_sub_epsilon_range() {
+        let min = f64::EPSILON / 1024.0;
+        let max = f64::EPSILON / 16.0;
+        let ticks = generate_log_ticks(min, max, 8);
+
+        assert!(
+            ticks.len() >= 2,
+            "expected distinct sub-epsilon ticks: {ticks:?}"
+        );
+        assert!(ticks.iter().all(|tick| *tick >= min && *tick <= max));
+        assert!(ticks.windows(2).all(|pair| pair[0] < pair[1]));
+    }
+
+    #[test]
+    fn test_log_ticks_fall_back_to_narrow_sub_epsilon_endpoints() {
+        let min = f64::EPSILON / 1024.0;
+        let max = min * 1.5;
+        let ticks = generate_log_ticks(min, max, 8);
+
+        assert_eq!(ticks, vec![min, max]);
     }
 
     #[test]

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -3,13 +3,13 @@ use super::{
     ResolvedData, ResolvedFrame, ResolvedSeries, SeriesType,
 };
 use crate::{
+    axes::{AxisScale, expand_degenerate_range},
     core::{
-        LayoutCalculator, LayoutConfig, MarginConfig, PlotLayout, PlottingError, REFERENCE_DPI,
-        Result,
+        CoordinateTransform, LayoutCalculator, LayoutConfig, MarginConfig, PlotLayout,
+        PlottingError, REFERENCE_DPI, Result,
     },
     render::{
-        Color, FontConfig, FontFamily, LineStyle, MarkerStyle, TextRenderer,
-        skia::{SkiaRenderer, map_data_to_pixels},
+        Color, FontConfig, FontFamily, LineStyle, MarkerStyle, TextRenderer, skia::SkiaRenderer,
     },
 };
 use std::{
@@ -78,6 +78,7 @@ pub struct InteractiveViewportSnapshot {
 const MIN_ZOOM_LEVEL: f64 = 0.1;
 const MAX_ZOOM_LEVEL: f64 = 100.0;
 const VIEWPORT_EPSILON: f64 = 1e-9;
+const HIT_TEST_TOLERANCE_LOGICAL_PX: f64 = 8.0;
 
 #[cfg(not(target_arch = "wasm32"))]
 type FrameTimer = Instant;
@@ -364,23 +365,11 @@ impl DataBounds {
         self.y_max - self.y_min
     }
 
-    fn width_abs(&self) -> f64 {
-        self.width().abs()
-    }
-
-    fn height_abs(&self) -> f64 {
-        self.height().abs()
-    }
-
     fn center(&self) -> ViewportPoint {
         ViewportPoint::new(
             (self.x_min + self.x_max) * 0.5,
             (self.y_min + self.y_max) * 0.5,
         )
-    }
-
-    fn from_points(a: ViewportPoint, b: ViewportPoint) -> Self {
-        Self::from_limits(a.x.min(b.x), a.x.max(b.x), a.y.min(b.y), a.y.max(b.y))
     }
 
     fn from_screen_corners(top_left: ViewportPoint, bottom_right: ViewportPoint) -> Self {
@@ -389,24 +378,6 @@ impl DataBounds {
 
     fn from_viewport_rect(bounds: ViewportRect) -> Self {
         Self::from_limits(bounds.min.x, bounds.max.x, bounds.min.y, bounds.max.y)
-    }
-
-    fn with_center_size(center: ViewportPoint, width: f64, height: f64) -> Self {
-        Self::from_limits(
-            center.x - width * 0.5,
-            center.x + width * 0.5,
-            center.y - height * 0.5,
-            center.y + height * 0.5,
-        )
-    }
-
-    fn translated(self, dx: f64, dy: f64) -> Self {
-        Self::from_limits(
-            self.x_min + dx,
-            self.x_max + dx,
-            self.y_min + dy,
-            self.y_max + dy,
-        )
     }
 }
 
@@ -571,6 +542,7 @@ struct InteractiveFrameCache {
 #[derive(Clone, Debug, PartialEq)]
 struct OverlayFrameKey {
     size_px: (u32, u32),
+    plot_area: Option<ViewportRect>,
     hovered: Option<HitResult>,
     selected: Vec<HitResult>,
     brushed_region: Option<ViewportRect>,
@@ -589,12 +561,140 @@ struct GeometrySnapshot {
     plot_area: tiny_skia::Rect,
     x_bounds: (f64, f64),
     y_bounds: (f64, f64),
+    x_scale: AxisScale,
+    y_scale: AxisScale,
+    transform: CoordinateTransform,
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+impl GeometrySnapshot {
+    fn with_bounds(&self, bounds: DataBounds) -> Self {
+        let mut geometry = self.clone();
+        geometry.x_bounds = (bounds.x_min, bounds.x_max);
+        geometry.y_bounds = (bounds.y_min, bounds.y_max);
+        geometry.transform.data_x = bounds.x_min..bounds.x_max;
+        geometry.transform.data_y = bounds.y_min..bounds.y_max;
+        geometry
+    }
+
+    fn logical_pixels_to_pixels(&self, logical_pixels: f64) -> f64 {
+        logical_pixels * f64::from(f32::from_bits(self.key.scale_bits))
+    }
+
+    fn contains_screen(&self, point: ViewportPoint) -> bool {
+        point.x.is_finite()
+            && point.y.is_finite()
+            && point.x >= self.plot_area.left() as f64
+            && point.x <= self.plot_area.right() as f64
+            && point.y >= self.plot_area.top() as f64
+            && point.y <= self.plot_area.bottom() as f64
+    }
+
+    fn contains_data(&self, point: ViewportPoint) -> bool {
+        point.x.is_finite()
+            && point.y.is_finite()
+            && value_in_bounds(point.x, self.x_bounds)
+            && value_in_bounds(point.y, self.y_bounds)
+    }
+
+    fn screen_to_data(&self, point: ViewportPoint) -> ViewportPoint {
+        let (x, y) = self.transform.screen_to_data_scaled(
+            point.x as f32,
+            point.y as f32,
+            &self.x_scale,
+            &self.y_scale,
+        );
+        ViewportPoint::new(x, y)
+    }
+
+    fn data_to_screen(&self, point: ViewportPoint) -> ViewportPoint {
+        let (x, y) =
+            self.transform
+                .data_to_screen_scaled(point.x, point.y, &self.x_scale, &self.y_scale);
+        ViewportPoint::new(x as f64, y as f64)
+    }
+
+    fn clamp_screen(&self, point: ViewportPoint) -> ViewportPoint {
+        ViewportPoint::new(
+            point
+                .x
+                .clamp(self.plot_area.left() as f64, self.plot_area.right() as f64),
+            point
+                .y
+                .clamp(self.plot_area.top() as f64, self.plot_area.bottom() as f64),
+        )
+    }
+
+    fn clamp_data(&self, point: ViewportPoint) -> ViewportPoint {
+        ViewportPoint::new(
+            clamp_to_bounds(point.x, self.x_bounds),
+            clamp_to_bounds(point.y, self.y_bounds),
+        )
+    }
+
+    fn screen_normalized(&self, point: ViewportPoint) -> (f64, f64) {
+        let data = self.screen_to_data(self.clamp_screen(point));
+        (
+            self.x_scale
+                .normalized_position(data.x, self.x_bounds.0, self.x_bounds.1)
+                .clamp(0.0, 1.0),
+            self.y_scale
+                .normalized_position(data.y, self.y_bounds.0, self.y_bounds.1)
+                .clamp(0.0, 1.0),
+        )
+    }
+
+    fn zoomed_bounds(
+        &self,
+        factor: f64,
+        anchor_px: ViewportPoint,
+        base_bounds: DataBounds,
+    ) -> DataBounds {
+        let (anchor_x, anchor_y) = self.screen_normalized(anchor_px);
+        let x = zoom_axis_bounds(
+            self.x_bounds,
+            (base_bounds.x_min, base_bounds.x_max),
+            &self.x_scale,
+            factor,
+            anchor_x,
+        );
+        let y = zoom_axis_bounds(
+            self.y_bounds,
+            (base_bounds.y_min, base_bounds.y_max),
+            &self.y_scale,
+            factor,
+            anchor_y,
+        );
+        DataBounds::from_limits(x.0, x.1, y.0, y.1)
+    }
+
+    fn panned_bounds(&self, delta_px: ViewportPoint) -> DataBounds {
+        let delta_x = delta_px.x / f64::from(self.plot_area.width()).max(1.0);
+        let delta_y = delta_px.y / f64::from(self.plot_area.height()).max(1.0);
+        DataBounds::from_limits(
+            self.x_scale
+                .inverse_normalized_position(-delta_x, self.x_bounds.0, self.x_bounds.1),
+            self.x_scale.inverse_normalized_position(
+                1.0 - delta_x,
+                self.x_bounds.0,
+                self.x_bounds.1,
+            ),
+            self.y_scale
+                .inverse_normalized_position(delta_y, self.y_bounds.0, self.y_bounds.1),
+            self.y_scale.inverse_normalized_position(
+                1.0 + delta_y,
+                self.y_bounds.0,
+                self.y_bounds.1,
+            ),
+        )
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
 struct AxisConstraints {
     x_limits: Option<(f64, f64)>,
     y_limits: Option<(f64, f64)>,
+    x_scale: AxisScale,
+    y_scale: AxisScale,
 }
 
 impl AxisConstraints {
@@ -602,6 +702,8 @@ impl AxisConstraints {
         Self {
             x_limits: plot.layout.x_limits,
             y_limits: plot.layout.y_limits,
+            x_scale: plot.layout.x_scale.clone(),
+            y_scale: plot.layout.y_scale.clone(),
         }
     }
 
@@ -613,14 +715,8 @@ impl AxisConstraints {
             .y_limits
             .unwrap_or((data_bounds.y_min, data_bounds.y_max));
 
-        if (x_max - x_min).abs() < f64::EPSILON {
-            x_min -= 1.0;
-            x_max += 1.0;
-        }
-        if (y_max - y_min).abs() < f64::EPSILON {
-            y_min -= 1.0;
-            y_max += 1.0;
-        }
+        (x_min, x_max) = expand_degenerate_range(x_min, x_max, &self.x_scale);
+        (y_min, y_max) = expand_degenerate_range(y_min, y_max, &self.y_scale);
 
         DataBounds::from_limits(x_min, x_max, y_min, y_max)
     }
@@ -703,7 +799,11 @@ impl InteractivePlotSession {
             visible_bounds: initial_bounds,
             ..SessionState::default()
         };
-        sync_legacy_viewport_fields(&mut state);
+        sync_legacy_viewport_fields(
+            &mut state,
+            &prepared.plot().layout.x_scale,
+            &prepared.plot().layout.y_scale,
+        );
 
         Self {
             inner: Arc::new(InteractivePlotSessionInner {
@@ -861,7 +961,7 @@ impl InteractivePlotSession {
             PlotInputEvent::Zoom { factor, center_px } => {
                 let state_snapshot = state.clone();
                 drop(state);
-                let current_geometry = match self.geometry_snapshot() {
+                let current_geometry = match self.interaction_geometry() {
                     Ok(geometry) => geometry,
                     Err(_) => return,
                 };
@@ -870,27 +970,11 @@ impl InteractivePlotSession {
                     return;
                 }
 
-                let anchor_before = screen_to_data(
-                    state_snapshot.visible_bounds,
-                    current_geometry.plot_area,
-                    center_px,
-                );
-                let (normalized_x, normalized_y) =
-                    screen_to_normalized(current_geometry.plot_area, center_px);
-                let width = clamp_visible_width(
-                    state_snapshot.visible_bounds.width() / factor,
-                    state_snapshot.base_bounds,
-                );
-                let height = clamp_visible_height(
-                    state_snapshot.visible_bounds.height() / factor,
-                    state_snapshot.base_bounds,
-                );
-                let next_visible = DataBounds::from_limits(
-                    anchor_before.x - width * normalized_x,
-                    anchor_before.x + width * (1.0 - normalized_x),
-                    anchor_before.y - height * (1.0 - normalized_y),
-                    anchor_before.y + height * normalized_y,
-                );
+                let next_visible =
+                    current_geometry.zoomed_bounds(factor, center_px, state_snapshot.base_bounds);
+                if !bounds_have_extent(next_visible) {
+                    return;
+                }
 
                 if bounds_close(state_snapshot.visible_bounds, next_visible) {
                     return;
@@ -901,13 +985,17 @@ impl InteractivePlotSession {
                     .state
                     .lock()
                     .expect("InteractivePlotSession state lock poisoned");
-                set_visible_bounds(&mut state, next_visible);
+                set_visible_bounds(
+                    &mut state,
+                    next_visible,
+                    &current_geometry.x_scale,
+                    &current_geometry.y_scale,
+                );
                 drop(state);
                 self.mark_dirty(DirtyDomain::Data);
                 self.mark_dirty(DirtyDomain::Overlay);
             }
             PlotInputEvent::ZoomRect { region_px } => {
-                let state_snapshot = state.clone();
                 let had_brush =
                     state.brush_anchor.take().is_some() || state.brushed_region.take().is_some();
                 drop(state);
@@ -919,24 +1007,16 @@ impl InteractivePlotSession {
                     return;
                 }
 
-                let current_geometry = match self.geometry_snapshot() {
+                let current_geometry = match self.interaction_geometry() {
                     Ok(geometry) => geometry,
                     Err(_) => return,
                 };
-                let data_min = screen_to_data(
-                    state_snapshot.visible_bounds,
-                    current_geometry.plot_area,
-                    region_px.min,
-                );
-                let data_max = screen_to_data(
-                    state_snapshot.visible_bounds,
-                    current_geometry.plot_area,
-                    region_px.max,
-                );
+                let data_min =
+                    current_geometry.screen_to_data(current_geometry.clamp_screen(region_px.min));
+                let data_max =
+                    current_geometry.screen_to_data(current_geometry.clamp_screen(region_px.max));
                 let next_visible = DataBounds::from_screen_corners(data_min, data_max);
-                if next_visible.width_abs() <= VIEWPORT_EPSILON
-                    || next_visible.height_abs() <= VIEWPORT_EPSILON
-                {
+                if !bounds_have_extent(next_visible) {
                     if had_brush {
                         self.mark_dirty(DirtyDomain::Overlay);
                     }
@@ -951,7 +1031,12 @@ impl InteractivePlotSession {
                 let viewport_changed = !bounds_close(state.visible_bounds, next_visible);
                 state.brush_anchor = None;
                 state.brushed_region = None;
-                set_visible_bounds(&mut state, next_visible);
+                set_visible_bounds(
+                    &mut state,
+                    next_visible,
+                    &current_geometry.x_scale,
+                    &current_geometry.y_scale,
+                );
                 drop(state);
                 if viewport_changed {
                     self.mark_dirty(DirtyDomain::Data);
@@ -959,32 +1044,29 @@ impl InteractivePlotSession {
                 self.mark_dirty(DirtyDomain::Overlay);
             }
             PlotInputEvent::Pan { delta_px } => {
-                let state_snapshot = state.clone();
                 drop(state);
-                let current_geometry = match self.geometry_snapshot() {
+                let current_geometry = match self.interaction_geometry() {
                     Ok(geometry) => geometry,
                     Err(_) => return,
                 };
-                let width = signed_span_with_min_magnitude(
-                    state_snapshot.visible_bounds.width(),
-                    f64::EPSILON,
-                );
-                let height = signed_span_with_min_magnitude(
-                    state_snapshot.visible_bounds.height(),
-                    f64::EPSILON,
-                );
-                let size_x = f64::from(current_geometry.plot_area.width()).max(1.0);
-                let size_y = f64::from(current_geometry.plot_area.height()).max(1.0);
-                let next_visible = state_snapshot.visible_bounds.translated(
-                    -(delta_px.x / size_x) * width,
-                    (delta_px.y / size_y) * height,
-                );
+                if !delta_px.x.is_finite() || !delta_px.y.is_finite() {
+                    return;
+                }
+                let next_visible = current_geometry.panned_bounds(delta_px);
+                if !bounds_have_extent(next_visible) {
+                    return;
+                }
                 let mut state = self
                     .inner
                     .state
                     .lock()
                     .expect("InteractivePlotSession state lock poisoned");
-                set_visible_bounds(&mut state, next_visible);
+                set_visible_bounds(
+                    &mut state,
+                    next_visible,
+                    &current_geometry.x_scale,
+                    &current_geometry.y_scale,
+                );
                 drop(state);
                 self.mark_dirty(DirtyDomain::Data);
                 self.mark_dirty(DirtyDomain::Overlay);
@@ -1030,7 +1112,11 @@ impl InteractivePlotSession {
                 state.brush_anchor = None;
                 state.brushed_region = None;
                 state.visible_bounds = state.base_bounds;
-                sync_legacy_viewport_fields(&mut state);
+                sync_legacy_viewport_fields(
+                    &mut state,
+                    &self.inner.prepared.plot().layout.x_scale,
+                    &self.inner.prepared.plot().layout.y_scale,
+                );
                 drop(state);
                 self.mark_dirty(DirtyDomain::Data);
                 self.mark_dirty(DirtyDomain::Overlay);
@@ -1111,7 +1197,11 @@ impl InteractivePlotSession {
         else {
             return HitResult::None;
         };
+        if !geometry.contains_screen(position_px) {
+            return HitResult::None;
+        }
         let plot = self.inner.prepared.plot();
+        let hit_tolerance_px = geometry.logical_pixels_to_pixels(HIT_TEST_TOLERANCE_LOGICAL_PX);
         let mut best_hit = HitResult::None;
         let mut best_distance = f64::INFINITY;
 
@@ -1128,28 +1218,21 @@ impl InteractivePlotSession {
                         if !x_val.is_finite() || !y_val.is_finite() {
                             continue;
                         }
-                        let (screen_x, screen_y) = map_data_to_pixels(
-                            x_val,
-                            y_val,
-                            geometry.x_bounds.0,
-                            geometry.x_bounds.1,
-                            geometry.y_bounds.0,
-                            geometry.y_bounds.1,
-                            geometry.plot_area,
-                        );
-                        let dx = position_px.x - screen_x as f64;
-                        let dy = position_px.y - screen_y as f64;
+                        let data_position = ViewportPoint::new(x_val, y_val);
+                        if !geometry.contains_data(data_position) {
+                            continue;
+                        }
+                        let screen_position = geometry.data_to_screen(data_position);
+                        let dx = position_px.x - screen_position.x;
+                        let dy = position_px.y - screen_position.y;
                         let distance = (dx * dx + dy * dy).sqrt();
-                        if distance <= 8.0 && distance < best_distance {
+                        if distance <= hit_tolerance_px && distance < best_distance {
                             best_distance = distance;
                             best_hit = HitResult::SeriesPoint {
                                 series_index,
                                 point_index,
-                                screen_position: ViewportPoint::new(
-                                    screen_x as f64,
-                                    screen_y as f64,
-                                ),
-                                data_position: ViewportPoint::new(x_val, y_val),
+                                screen_position,
+                                data_position,
                                 distance_px: distance,
                             };
                         }
@@ -1164,16 +1247,7 @@ impl InteractivePlotSession {
                     {
                         continue;
                     }
-                    let data_position = screen_to_data(
-                        DataBounds::from_limits(
-                            geometry.x_bounds.0,
-                            geometry.x_bounds.1,
-                            geometry.y_bounds.0,
-                            geometry.y_bounds.1,
-                        ),
-                        rect,
-                        position_px,
-                    );
+                    let data_position = geometry.screen_to_data(position_px);
                     if data_position.x < data.x_extent.0
                         || data_position.x > data.x_extent.1
                         || data_position.y < data.y_extent.0
@@ -1199,32 +1273,16 @@ impl InteractivePlotSession {
                         continue;
                     }
                     let ((x1, x2), (y1, y2)) = data.cell_data_bounds(row, col);
-                    let (sx1, sy1) = map_data_to_pixels(
-                        x1,
-                        y2,
-                        geometry.x_bounds.0,
-                        geometry.x_bounds.1,
-                        geometry.y_bounds.0,
-                        geometry.y_bounds.1,
-                        rect,
-                    );
-                    let (sx2, sy2) = map_data_to_pixels(
-                        x2,
-                        y1,
-                        geometry.x_bounds.0,
-                        geometry.x_bounds.1,
-                        geometry.y_bounds.0,
-                        geometry.y_bounds.1,
-                        rect,
-                    );
+                    let first = geometry.data_to_screen(ViewportPoint::new(x1, y2));
+                    let second = geometry.data_to_screen(ViewportPoint::new(x2, y1));
                     best_hit = HitResult::HeatmapCell {
                         series_index,
                         row,
                         col,
                         value,
                         screen_rect: ViewportRect {
-                            min: ViewportPoint::new(sx1.min(sx2) as f64, sy1.min(sy2) as f64),
-                            max: ViewportPoint::new(sx1.max(sx2) as f64, sy1.max(sy2) as f64),
+                            min: ViewportPoint::new(first.x.min(second.x), first.y.min(second.y)),
+                            max: ViewportPoint::new(first.x.max(second.x), first.y.max(second.y)),
                         },
                     };
                 }
@@ -1233,6 +1291,60 @@ impl InteractivePlotSession {
         }
 
         best_hit
+    }
+
+    /// Converts a displayed-frame screen position to data coordinates.
+    ///
+    /// Returns `Ok(None)` for non-finite positions or positions outside the
+    /// displayed plot area. An error is returned until a base frame has been
+    /// rendered and its geometry is available.
+    pub fn screen_to_data(&self, position_px: ViewportPoint) -> Result<Option<ViewportPoint>> {
+        let geometry = self.displayed_geometry()?;
+        if !geometry.contains_screen(position_px) {
+            return Ok(None);
+        }
+        let data = geometry.screen_to_data(position_px);
+        Ok((data.x.is_finite() && data.y.is_finite()).then_some(data))
+    }
+
+    /// Converts a screen position to data coordinates after clamping it to the
+    /// displayed plot area.
+    ///
+    /// An error is returned for non-finite input or until displayed geometry is
+    /// available.
+    pub fn screen_to_data_clamped(&self, position_px: ViewportPoint) -> Result<ViewportPoint> {
+        require_finite_point(position_px, "screen position")?;
+        let geometry = self.displayed_geometry()?;
+        let data = geometry.screen_to_data(geometry.clamp_screen(position_px));
+        require_finite_point(data, "converted data position")?;
+        Ok(data)
+    }
+
+    /// Converts a data position to screen coordinates for the displayed frame.
+    ///
+    /// Returns `Ok(None)` for non-finite positions or positions outside the
+    /// displayed data bounds. An error is returned until displayed geometry is
+    /// available.
+    pub fn data_to_screen(&self, data_position: ViewportPoint) -> Result<Option<ViewportPoint>> {
+        let geometry = self.displayed_geometry()?;
+        if !geometry.contains_data(data_position) {
+            return Ok(None);
+        }
+        let screen = geometry.data_to_screen(data_position);
+        Ok((screen.x.is_finite() && screen.y.is_finite()).then_some(screen))
+    }
+
+    /// Converts a data position to screen coordinates after clamping it to the
+    /// displayed data bounds.
+    ///
+    /// An error is returned for non-finite input or until displayed geometry is
+    /// available.
+    pub fn data_to_screen_clamped(&self, data_position: ViewportPoint) -> Result<ViewportPoint> {
+        require_finite_point(data_position, "data position")?;
+        let geometry = self.displayed_geometry()?;
+        let screen = geometry.data_to_screen(geometry.clamp_data(data_position));
+        require_finite_point(screen, "converted screen position")?;
+        Ok(screen)
     }
 
     pub fn render_to_image(&self, target: ImageTarget) -> Result<InteractiveFrame> {
@@ -1263,19 +1375,33 @@ impl InteractivePlotSession {
 
     /// Returns the current interactive viewport state.
     pub fn viewport_snapshot(&self) -> Result<InteractiveViewportSnapshot> {
-        let geometry = self.geometry_snapshot()?;
+        let geometry = self
+            .displayed_geometry()
+            .or_else(|_| self.geometry_snapshot())?;
         let state = self
             .inner
             .state
             .lock()
             .expect("InteractivePlotSession state lock poisoned")
             .clone();
+        let displayed_bounds = DataBounds::from_limits(
+            geometry.x_bounds.0,
+            geometry.x_bounds.1,
+            geometry.y_bounds.0,
+            geometry.y_bounds.1,
+        );
+        let (zoom_level, pan_offset) = legacy_viewport_metrics(
+            state.base_bounds,
+            displayed_bounds,
+            &geometry.x_scale,
+            &geometry.y_scale,
+        );
 
         Ok(InteractiveViewportSnapshot {
-            zoom_level: state.zoom_level,
-            pan_offset: state.pan_offset,
+            zoom_level,
+            pan_offset,
             base_bounds: data_bounds_to_viewport_rect(state.base_bounds),
-            visible_bounds: data_bounds_to_viewport_rect(state.visible_bounds),
+            visible_bounds: data_bounds_to_viewport_rect(displayed_bounds),
             plot_area: plot_area_to_viewport_rect(geometry.plot_area),
             selected_count: state.selected.len(),
         })
@@ -1284,8 +1410,21 @@ impl InteractivePlotSession {
     /// Restores the visible bounds for the interactive viewport.
     pub fn restore_visible_bounds(&self, bounds: ViewportRect) -> bool {
         let next_visible = DataBounds::from_viewport_rect(bounds);
-        if next_visible.width_abs() <= VIEWPORT_EPSILON
-            || next_visible.height_abs() <= VIEWPORT_EPSILON
+        if !bounds_have_extent(next_visible) {
+            return false;
+        }
+
+        let plot = self.inner.prepared.plot();
+        if plot
+            .layout
+            .x_scale
+            .validate_range(next_visible.x_min, next_visible.x_max)
+            .is_err()
+            || plot
+                .layout
+                .y_scale
+                .validate_range(next_visible.y_min, next_visible.y_max)
+                .is_err()
         {
             return false;
         }
@@ -1295,11 +1434,22 @@ impl InteractivePlotSession {
             .state
             .lock()
             .expect("InteractivePlotSession state lock poisoned");
+        let next_visible = normalize_visible_bounds(
+            next_visible,
+            state.base_bounds,
+            &plot.layout.x_scale,
+            &plot.layout.y_scale,
+        );
         if bounds_close(state.visible_bounds, next_visible) {
             return false;
         }
 
-        set_visible_bounds(&mut state, next_visible);
+        set_visible_bounds(
+            &mut state,
+            next_visible,
+            &plot.layout.x_scale,
+            &plot.layout.y_scale,
+        );
         drop(state);
         self.mark_dirty(DirtyDomain::Data);
         self.mark_dirty(DirtyDomain::Overlay);
@@ -1322,128 +1472,159 @@ impl InteractivePlotSession {
         self.resize(size_px, scale_factor);
         self.apply_input(PlotInputEvent::SetTime { time_seconds });
 
-        let reactive_epoch = self.inner.reactive_epoch.load(Ordering::Acquire);
-        let mut mark_data_dirty = false;
-        {
-            let mut state = self
-                .inner
-                .state
-                .lock()
-                .expect("InteractivePlotSession state lock poisoned");
-            if state.last_reactive_epoch != reactive_epoch {
-                state.last_reactive_epoch = reactive_epoch;
-                mark_data_dirty = true;
+        let state_before_render = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned")
+            .clone();
+        let render_result = (|| -> Result<InteractiveFrame> {
+            let reactive_epoch = self.inner.reactive_epoch.load(Ordering::Acquire);
+            let mut mark_data_dirty = false;
+            {
+                let mut state = self
+                    .inner
+                    .state
+                    .lock()
+                    .expect("InteractivePlotSession state lock poisoned");
+                if state.last_reactive_epoch != reactive_epoch {
+                    state.last_reactive_epoch = reactive_epoch;
+                    mark_data_dirty = true;
+                }
             }
-        }
-        if mark_data_dirty {
-            self.mark_dirty(DirtyDomain::Data);
-            self.mark_dirty(DirtyDomain::Overlay);
-        }
-
-        let dirty_before_render = self.dirty_domains();
-        let dirty_epoch_before_render = self.inner.dirty_epoch.load(Ordering::Acquire);
-        let source_plot = self.inner.prepared.plot();
-        let resolved_frame = dirty_before_render
-            .needs_base_render()
-            .then(|| source_plot.resolve_frame(time_seconds))
-            .transpose()?;
-
-        if dirty_before_render.layout || dirty_before_render.data || dirty_before_render.temporal {
-            let constraints = AxisConstraints::from_plot(source_plot);
-            let mut state = self
-                .inner
-                .state
-                .lock()
-                .expect("InteractivePlotSession state lock poisoned");
-            let previous_base = state.base_bounds;
-            let previous_visible = state.visible_bounds;
-            let next_data_bounds = resolved_frame
-                .as_ref()
-                .and_then(|frame| compute_data_bounds_from_frame(source_plot, frame).ok())
-                .unwrap_or(state.data_bounds);
-            state.data_bounds = next_data_bounds;
-            state.base_bounds = constraints.apply(next_data_bounds);
-            if bounds_close(previous_visible, previous_base) {
-                state.visible_bounds = state.base_bounds;
-            } else {
-                state.visible_bounds =
-                    normalize_visible_bounds(previous_visible, state.base_bounds);
+            if mark_data_dirty {
+                self.mark_dirty(DirtyDomain::Data);
+                self.mark_dirty(DirtyDomain::Overlay);
             }
-            sync_legacy_viewport_fields(&mut state);
-        }
 
-        let base_key = {
-            let state = self
-                .inner
-                .state
-                .lock()
-                .expect("InteractivePlotSession state lock poisoned")
-                .clone();
-            build_frame_key(self.inner.prepared.plot(), &state)
-        };
+            let dirty_before_render = self.dirty_domains();
+            let dirty_epoch_before_render = self.inner.dirty_epoch.load(Ordering::Acquire);
+            let source_plot = self.inner.prepared.plot();
+            let resolved_frame = dirty_before_render
+                .needs_base_render()
+                .then(|| source_plot.resolve_frame(time_seconds))
+                .transpose()?;
 
-        let geometry = self.ensure_geometry(&base_key, resolved_frame.as_ref())?;
-        self.refresh_overlay_state(&geometry, dirty_before_render, resolved_frame.as_ref())?;
-        let frame_size_px = {
-            self.inner
-                .state
-                .lock()
-                .expect("InteractivePlotSession state lock poisoned")
-                .size_px
-        };
-        let base_result = self.ensure_base_image(
-            &base_key,
-            &geometry,
-            dirty_before_render,
-            resolved_frame.as_ref(),
-        )?;
-        let overlay_result = self.ensure_overlay_image(frame_size_px, dirty_before_render)?;
-        let composed = if target == RenderTargetKind::Image {
-            if let Some(overlay_image) = overlay_result.image.as_ref() {
-                Arc::new(compose_images(&base_result.image, overlay_image))
+            if dirty_before_render.layout
+                || dirty_before_render.data
+                || dirty_before_render.temporal
+            {
+                let constraints = AxisConstraints::from_plot(source_plot);
+                let mut state = self
+                    .inner
+                    .state
+                    .lock()
+                    .expect("InteractivePlotSession state lock poisoned");
+                let previous_base = state.base_bounds;
+                let previous_visible = state.visible_bounds;
+                let next_data_bounds = resolved_frame
+                    .as_ref()
+                    .and_then(|frame| compute_data_bounds_from_frame(source_plot, frame).ok())
+                    .unwrap_or(state.data_bounds);
+                state.data_bounds = next_data_bounds;
+                state.base_bounds = constraints.apply(next_data_bounds);
+                if bounds_close(previous_visible, previous_base) {
+                    state.visible_bounds = state.base_bounds;
+                } else {
+                    state.visible_bounds = normalize_visible_bounds(
+                        previous_visible,
+                        state.base_bounds,
+                        &source_plot.layout.x_scale,
+                        &source_plot.layout.y_scale,
+                    );
+                }
+                sync_legacy_viewport_fields(
+                    &mut state,
+                    &source_plot.layout.x_scale,
+                    &source_plot.layout.y_scale,
+                );
+            }
+
+            let base_key = {
+                let state = self
+                    .inner
+                    .state
+                    .lock()
+                    .expect("InteractivePlotSession state lock poisoned")
+                    .clone();
+                build_frame_key(self.inner.prepared.plot(), &state)
+            };
+
+            let geometry = self.ensure_geometry(&base_key, resolved_frame.as_ref())?;
+            let frame_size_px = {
+                self.inner
+                    .state
+                    .lock()
+                    .expect("InteractivePlotSession state lock poisoned")
+                    .size_px
+            };
+            let base_result = self.ensure_base_image(
+                &base_key,
+                &geometry,
+                dirty_before_render,
+                resolved_frame.as_ref(),
+            )?;
+            self.refresh_overlay_state(dirty_before_render)?;
+            let overlay_result = self.ensure_overlay_image(frame_size_px, dirty_before_render)?;
+            let composed = if target == RenderTargetKind::Image {
+                if let Some(overlay_image) = overlay_result.image.as_ref() {
+                    Arc::new(compose_images(&base_result.image, overlay_image))
+                } else {
+                    Arc::clone(&base_result.image)
+                }
             } else {
                 Arc::clone(&base_result.image)
-            }
-        } else {
-            Arc::clone(&base_result.image)
-        };
+            };
 
-        if base_result.updated {
-            if let Some(frame) = resolved_frame.as_ref() {
-                frame.acknowledge_rendered(source_plot);
+            if base_result.updated {
+                if let Some(frame) = resolved_frame.as_ref() {
+                    frame.acknowledge_rendered(source_plot);
+                }
             }
-        }
-        self.clear_dirty_after_render(dirty_epoch_before_render);
+            self.clear_dirty_after_render(dirty_epoch_before_render);
 
-        let surface_capability = if target == RenderTargetKind::Surface {
-            if base_result.used_incremental_data
-                || plot_supports_surface_fast_path(self.inner.prepared.plot())
-            {
-                SurfaceCapability::FastPath
+            let surface_capability = if target == RenderTargetKind::Surface {
+                if base_result.used_incremental_data
+                    || plot_supports_surface_fast_path(self.inner.prepared.plot())
+                {
+                    SurfaceCapability::FastPath
+                } else {
+                    SurfaceCapability::FallbackImage
+                }
             } else {
-                SurfaceCapability::FallbackImage
-            }
-        } else {
-            SurfaceCapability::Unsupported
-        };
-        let stats =
-            self.record_frame_stats(elapsed_frame_time(frame_start), target, surface_capability);
+                SurfaceCapability::Unsupported
+            };
+            let stats = self.record_frame_stats(
+                elapsed_frame_time(frame_start),
+                target,
+                surface_capability,
+            );
 
-        Ok(InteractiveFrame {
-            image: composed,
-            layers: LayerImages {
-                base: base_result.image,
-                overlay: overlay_result.image,
-            },
-            layer_state: LayerRenderState {
-                base_dirty: base_result.updated,
-                overlay_dirty: overlay_result.updated,
-                used_incremental_data: base_result.used_incremental_data,
-            },
-            stats,
-            target,
-            surface_capability,
-        })
+            Ok(InteractiveFrame {
+                image: composed,
+                layers: LayerImages {
+                    base: base_result.image,
+                    overlay: overlay_result.image,
+                },
+                layer_state: LayerRenderState {
+                    base_dirty: base_result.updated,
+                    overlay_dirty: overlay_result.updated,
+                    used_incremental_data: base_result.used_incremental_data,
+                },
+                stats,
+                target,
+                surface_capability,
+            })
+        })();
+
+        if render_result.is_err() {
+            *self
+                .inner
+                .state
+                .lock()
+                .expect("InteractivePlotSession state lock poisoned") = state_before_render;
+        }
+        render_result
     }
 
     fn ensure_geometry(
@@ -1584,6 +1765,10 @@ impl InteractivePlotSession {
             .clone();
         let overlay_key = OverlayFrameKey {
             size_px,
+            plot_area: state
+                .base_cache
+                .as_ref()
+                .map(|cache| plot_area_to_viewport_rect(cache.geometry.plot_area)),
             hovered: state.hovered.clone(),
             selected: state.selected.clone(),
             brushed_region: state.brushed_region,
@@ -1637,11 +1822,27 @@ impl InteractivePlotSession {
         }
 
         let mut pixels = vec![0u8; (size_px.0 * size_px.1 * 4) as usize];
+        let hit_clip = state
+            .base_cache
+            .as_ref()
+            .map(|cache| plot_area_to_viewport_rect(cache.geometry.plot_area));
         if let Some(hit) = state.hovered.as_ref() {
-            draw_hit(&mut pixels, size_px, hit, Color::new_rgba(255, 165, 0, 180));
+            draw_hit(
+                &mut pixels,
+                size_px,
+                hit,
+                Color::new_rgba(255, 165, 0, 180),
+                hit_clip,
+            );
         }
         for hit in &state.selected {
-            draw_hit(&mut pixels, size_px, hit, Color::new_rgba(255, 0, 0, 180));
+            draw_hit(
+                &mut pixels,
+                size_px,
+                hit,
+                Color::new_rgba(255, 0, 0, 180),
+                hit_clip,
+            );
         }
         if let Some(region) = state.brushed_region {
             draw_brush_rect(
@@ -1672,12 +1873,7 @@ impl InteractivePlotSession {
         })
     }
 
-    fn refresh_overlay_state(
-        &self,
-        geometry: &GeometrySnapshot,
-        dirty_before_render: DirtyDomains,
-        frame: Option<&ResolvedFrame<'_>>,
-    ) -> Result<()> {
+    fn refresh_overlay_state(&self, dirty_before_render: DirtyDomains) -> Result<()> {
         if !dirty_before_render.layout && !dirty_before_render.data && !dirty_before_render.temporal
         {
             return Ok(());
@@ -1697,16 +1893,20 @@ impl InteractivePlotSession {
             return Ok(());
         }
 
+        let (geometry, displayed_data) = state_snapshot
+            .base_cache
+            .as_ref()
+            .map(|cache| (cache.geometry.clone(), cache.displayed_data.clone()))
+            .ok_or_else(displayed_geometry_unavailable)?;
         let source_plot = self.inner.prepared.plot();
-        let frame = frame.expect("data/layout refresh must resolve a frame");
         let refreshed_hovered = state_snapshot
             .hovered
             .as_ref()
-            .and_then(|hit| refresh_hit_result(hit, source_plot, &frame.series, geometry));
+            .and_then(|hit| refresh_hit_result(hit, source_plot, &displayed_data, &geometry));
         let refreshed_selected = state_snapshot
             .selected
             .iter()
-            .filter_map(|hit| refresh_hit_result(hit, source_plot, &frame.series, geometry))
+            .filter_map(|hit| refresh_hit_result(hit, source_plot, &displayed_data, &geometry))
             .collect::<Vec<_>>();
         let (refreshed_tooltip, refreshed_tooltip_source) =
             if state_snapshot.tooltip_source == Some(TooltipSource::Hover) {
@@ -1742,6 +1942,30 @@ impl InteractivePlotSession {
             .clone();
         let key = build_frame_key(self.inner.prepared.plot(), &state);
         self.ensure_geometry(&key, None)
+    }
+
+    fn displayed_geometry(&self) -> Result<GeometrySnapshot> {
+        self.inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned")
+            .base_cache
+            .as_ref()
+            .map(|cache| cache.geometry.clone())
+            .ok_or_else(displayed_geometry_unavailable)
+    }
+
+    fn interaction_geometry(&self) -> Result<GeometrySnapshot> {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned");
+        state
+            .base_cache
+            .as_ref()
+            .map(|cache| cache.geometry.with_bounds(state.visible_bounds))
+            .ok_or_else(displayed_geometry_unavailable)
     }
 
     fn mark_dirty(&self, domain: DirtyDomain) {
@@ -1895,22 +2119,42 @@ impl InteractivePlotSession {
             .lock()
             .expect("InteractivePlotSession state lock poisoned");
         let zoom_level = zoom_level.clamp(MIN_ZOOM_LEVEL, MAX_ZOOM_LEVEL);
-        let width = clamp_visible_width(state.base_bounds.width() / zoom_level, state.base_bounds);
-        let height =
-            clamp_visible_height(state.base_bounds.height() / zoom_level, state.base_bounds);
-        let center = ViewportPoint::new(
-            state.base_bounds.center().x + pan_x,
-            state.base_bounds.center().y + pan_y,
+        let plot = self.inner.prepared.plot();
+        let normalized_half_span = 0.5 / zoom_level;
+        let next_visible = DataBounds::from_limits(
+            plot.layout.x_scale.inverse_normalized_position(
+                0.5 - normalized_half_span,
+                state.base_bounds.x_min,
+                state.base_bounds.x_max,
+            ) + pan_x,
+            plot.layout.x_scale.inverse_normalized_position(
+                0.5 + normalized_half_span,
+                state.base_bounds.x_min,
+                state.base_bounds.x_max,
+            ) + pan_x,
+            plot.layout.y_scale.inverse_normalized_position(
+                0.5 - normalized_half_span,
+                state.base_bounds.y_min,
+                state.base_bounds.y_max,
+            ) + pan_y,
+            plot.layout.y_scale.inverse_normalized_position(
+                0.5 + normalized_half_span,
+                state.base_bounds.y_min,
+                state.base_bounds.y_max,
+            ) + pan_y,
         );
-        let next_visible = DataBounds::with_center_size(center, width, height);
         if (state.zoom_level - zoom_level).abs() < f64::EPSILON
             && (state.pan_offset.x - pan_x).abs() < f64::EPSILON
             && (state.pan_offset.y - pan_y).abs() < f64::EPSILON
         {
             return;
         }
-        state.visible_bounds = next_visible;
-        sync_legacy_viewport_fields(&mut state);
+        set_visible_bounds(
+            &mut state,
+            next_visible,
+            &plot.layout.x_scale,
+            &plot.layout.y_scale,
+        );
         drop(state);
         self.mark_dirty(DirtyDomain::Data);
         self.mark_dirty(DirtyDomain::Overlay);
@@ -1952,14 +2196,8 @@ fn compute_data_bounds_from_frame(plot: &Plot, frame: &ResolvedFrame<'_>) -> Res
     let (mut x_min, mut x_max, mut y_min, mut y_max) =
         plot.calculate_data_bounds_from_resolved(&frame.series)?;
 
-    if (x_max - x_min).abs() < f64::EPSILON {
-        x_min -= 1.0;
-        x_max += 1.0;
-    }
-    if (y_max - y_min).abs() < f64::EPSILON {
-        y_min -= 1.0;
-        y_max += 1.0;
-    }
+    (x_min, x_max) = expand_degenerate_range(x_min, x_max, &plot.layout.x_scale);
+    (y_min, y_max) = expand_degenerate_range(y_min, y_max, &plot.layout.y_scale);
 
     Ok(DataBounds::from_limits(x_min, x_max, y_min, y_max))
 }
@@ -1978,49 +2216,112 @@ fn visible_bounds(state: &SessionState) -> DataBounds {
 }
 
 fn bounds_close(a: DataBounds, b: DataBounds) -> bool {
-    (a.x_min - b.x_min).abs() <= VIEWPORT_EPSILON
-        && (a.x_max - b.x_max).abs() <= VIEWPORT_EPSILON
-        && (a.y_min - b.y_min).abs() <= VIEWPORT_EPSILON
-        && (a.y_max - b.y_max).abs() <= VIEWPORT_EPSILON
+    axis_bounds_close((a.x_min, a.x_max), (b.x_min, b.x_max))
+        && axis_bounds_close((a.y_min, a.y_max), (b.y_min, b.y_max))
 }
 
-fn clamp_visible_width(width: f64, base_bounds: DataBounds) -> f64 {
-    let direction = direction_for_span(width, base_bounds.width());
-    let base_width = base_bounds.width_abs().max(VIEWPORT_EPSILON);
-    width
+fn axis_bounds_close(a: (f64, f64), b: (f64, f64)) -> bool {
+    let tolerance = (a.1 - a.0).abs().max((b.1 - b.0).abs()) * 1e-12;
+    (a.0 == b.0 || (a.0 - b.0).abs() <= tolerance) && (a.1 == b.1 || (a.1 - b.1).abs() <= tolerance)
+}
+
+fn bounds_have_extent(bounds: DataBounds) -> bool {
+    bounds.x_min.is_finite()
+        && bounds.x_max.is_finite()
+        && bounds.y_min.is_finite()
+        && bounds.y_max.is_finite()
+        && bounds.x_min != bounds.x_max
+        && bounds.y_min != bounds.y_max
+}
+
+fn normalize_axis_bounds(
+    bounds: (f64, f64),
+    base_bounds: (f64, f64),
+    scale: &AxisScale,
+) -> (f64, f64) {
+    let start = scale.normalized_position(bounds.0, base_bounds.0, base_bounds.1);
+    let end = scale.normalized_position(bounds.1, base_bounds.0, base_bounds.1);
+    let center = (start + end) * 0.5;
+    let direction = direction_for_span(end - start, 1.0);
+    let span = (end - start)
         .abs()
-        .clamp(base_width / MAX_ZOOM_LEVEL, base_width / MIN_ZOOM_LEVEL)
-        * direction
+        .clamp(1.0 / MAX_ZOOM_LEVEL, 1.0 / MIN_ZOOM_LEVEL)
+        * direction;
+    (
+        scale.inverse_normalized_position(center - span * 0.5, base_bounds.0, base_bounds.1),
+        scale.inverse_normalized_position(center + span * 0.5, base_bounds.0, base_bounds.1),
+    )
 }
 
-fn clamp_visible_height(height: f64, base_bounds: DataBounds) -> f64 {
-    let direction = direction_for_span(height, base_bounds.height());
-    let base_height = base_bounds.height_abs().max(VIEWPORT_EPSILON);
-    height
-        .abs()
-        .clamp(base_height / MAX_ZOOM_LEVEL, base_height / MIN_ZOOM_LEVEL)
-        * direction
+fn zoom_axis_bounds(
+    bounds: (f64, f64),
+    base_bounds: (f64, f64),
+    scale: &AxisScale,
+    factor: f64,
+    anchor: f64,
+) -> (f64, f64) {
+    let start = scale.normalized_position(bounds.0, base_bounds.0, base_bounds.1);
+    let end = scale.normalized_position(bounds.1, base_bounds.0, base_bounds.1);
+    let current_span = end - start;
+    let direction = direction_for_span(current_span, 1.0);
+    let next_span =
+        (current_span.abs() / factor).clamp(1.0 / MAX_ZOOM_LEVEL, 1.0 / MIN_ZOOM_LEVEL) * direction;
+    let anchor_position = start + anchor * current_span;
+    (
+        scale.inverse_normalized_position(
+            anchor_position - anchor * next_span,
+            base_bounds.0,
+            base_bounds.1,
+        ),
+        scale.inverse_normalized_position(
+            anchor_position + (1.0 - anchor) * next_span,
+            base_bounds.0,
+            base_bounds.1,
+        ),
+    )
 }
 
-fn normalize_visible_bounds(bounds: DataBounds, base_bounds: DataBounds) -> DataBounds {
-    let center = bounds.center();
-    let width = clamp_visible_width(
-        signed_span_with_min_magnitude(bounds.width(), VIEWPORT_EPSILON),
-        base_bounds,
+fn normalize_visible_bounds(
+    bounds: DataBounds,
+    base_bounds: DataBounds,
+    x_scale: &AxisScale,
+    y_scale: &AxisScale,
+) -> DataBounds {
+    let x = normalize_axis_bounds(
+        (bounds.x_min, bounds.x_max),
+        (base_bounds.x_min, base_bounds.x_max),
+        x_scale,
     );
-    let height = clamp_visible_height(
-        signed_span_with_min_magnitude(bounds.height(), VIEWPORT_EPSILON),
-        base_bounds,
+    let y = normalize_axis_bounds(
+        (bounds.y_min, bounds.y_max),
+        (base_bounds.y_min, base_bounds.y_max),
+        y_scale,
     );
-    DataBounds::with_center_size(center, width, height)
+    DataBounds::from_limits(x.0, x.1, y.0, y.1)
 }
 
 fn legacy_viewport_metrics(
     base_bounds: DataBounds,
     visible_bounds: DataBounds,
+    x_scale: &AxisScale,
+    y_scale: &AxisScale,
 ) -> (f64, ViewportPoint) {
-    let zoom_x = base_bounds.width_abs() / visible_bounds.width_abs().max(VIEWPORT_EPSILON);
-    let zoom_y = base_bounds.height_abs() / visible_bounds.height_abs().max(VIEWPORT_EPSILON);
+    let x_span =
+        x_scale.normalized_position(visible_bounds.x_max, base_bounds.x_min, base_bounds.x_max)
+            - x_scale.normalized_position(
+                visible_bounds.x_min,
+                base_bounds.x_min,
+                base_bounds.x_max,
+            );
+    let y_span =
+        y_scale.normalized_position(visible_bounds.y_max, base_bounds.y_min, base_bounds.y_max)
+            - y_scale.normalized_position(
+                visible_bounds.y_min,
+                base_bounds.y_min,
+                base_bounds.y_max,
+            );
+    let zoom_x = x_span.abs().max(VIEWPORT_EPSILON).recip();
+    let zoom_y = y_span.abs().max(VIEWPORT_EPSILON).recip();
     let zoom_level = (zoom_x * zoom_y)
         .abs()
         .sqrt()
@@ -2034,15 +2335,21 @@ fn legacy_viewport_metrics(
     )
 }
 
-fn sync_legacy_viewport_fields(state: &mut SessionState) {
-    let (zoom_level, pan_offset) = legacy_viewport_metrics(state.base_bounds, state.visible_bounds);
+fn sync_legacy_viewport_fields(state: &mut SessionState, x_scale: &AxisScale, y_scale: &AxisScale) {
+    let (zoom_level, pan_offset) =
+        legacy_viewport_metrics(state.base_bounds, state.visible_bounds, x_scale, y_scale);
     state.zoom_level = zoom_level;
     state.pan_offset = pan_offset;
 }
 
-fn set_visible_bounds(state: &mut SessionState, bounds: DataBounds) {
-    state.visible_bounds = normalize_visible_bounds(bounds, state.base_bounds);
-    sync_legacy_viewport_fields(state);
+fn set_visible_bounds(
+    state: &mut SessionState,
+    bounds: DataBounds,
+    x_scale: &AxisScale,
+    y_scale: &AxisScale,
+) {
+    state.visible_bounds = normalize_visible_bounds(bounds, state.base_bounds, x_scale, y_scale);
+    sync_legacy_viewport_fields(state, x_scale, y_scale);
 }
 
 fn direction_for_span(span: f64, fallback: f64) -> f64 {
@@ -2051,11 +2358,6 @@ fn direction_for_span(span: f64, fallback: f64) -> f64 {
     } else {
         1.0
     }
-}
-
-fn signed_span_with_min_magnitude(span: f64, min_magnitude: f64) -> f64 {
-    let direction = if span < 0.0 { -1.0 } else { 1.0 };
-    span.abs().max(min_magnitude) * direction
 }
 
 fn data_bounds_to_viewport_rect(bounds: DataBounds) -> ViewportRect {
@@ -2072,30 +2374,28 @@ fn plot_area_to_viewport_rect(plot_area: tiny_skia::Rect) -> ViewportRect {
     }
 }
 
-fn screen_to_data(
-    bounds: DataBounds,
-    plot_area: tiny_skia::Rect,
-    position_px: ViewportPoint,
-) -> ViewportPoint {
-    let (normalized_x, normalized_y) = screen_to_normalized(plot_area, position_px);
-    ViewportPoint::new(
-        bounds.x_min + bounds.width() * normalized_x,
-        bounds.y_max - bounds.height() * normalized_y,
-    )
+fn value_in_bounds(value: f64, bounds: (f64, f64)) -> bool {
+    value >= bounds.0.min(bounds.1) && value <= bounds.0.max(bounds.1)
 }
 
-fn screen_to_normalized(plot_area: tiny_skia::Rect, position_px: ViewportPoint) -> (f64, f64) {
-    let left = plot_area.left() as f64;
-    let right = plot_area.right() as f64;
-    let top = plot_area.top() as f64;
-    let bottom = plot_area.bottom() as f64;
-    let clamped_x = position_px.x.clamp(left, right);
-    let clamped_y = position_px.y.clamp(top, bottom);
-    let width = f64::from(plot_area.width()).max(1.0);
-    let height = f64::from(plot_area.height()).max(1.0);
-    (
-        ((clamped_x - left) / width).clamp(0.0, 1.0),
-        ((clamped_y - top) / height).clamp(0.0, 1.0),
+fn clamp_to_bounds(value: f64, bounds: (f64, f64)) -> f64 {
+    value.clamp(bounds.0.min(bounds.1), bounds.0.max(bounds.1))
+}
+
+fn require_finite_point(point: ViewportPoint, label: &str) -> Result<()> {
+    if point.x.is_finite() && point.y.is_finite() {
+        Ok(())
+    } else {
+        Err(PlottingError::InvalidInput(format!(
+            "{label} must contain finite coordinates"
+        )))
+    }
+}
+
+fn displayed_geometry_unavailable() -> PlottingError {
+    PlottingError::InvalidInput(
+        "interactive coordinate conversion is unavailable before a base frame is displayed"
+            .to_string(),
     )
 }
 
@@ -2148,13 +2448,21 @@ fn geometry_snapshot_for_state(
         plot_area: layout.plot_area_rect,
         x_bounds: (visible.x_min, visible.x_max),
         y_bounds: (visible.y_min, visible.y_max),
+        x_scale: plot.layout.x_scale.clone(),
+        y_scale: plot.layout.y_scale.clone(),
+        transform: CoordinateTransform::new(
+            visible.x_min..visible.x_max,
+            visible.y_min..visible.y_max,
+            layout.plot_area_rect.left()..layout.plot_area_rect.right(),
+            layout.plot_area_rect.top()..layout.plot_area_rect.bottom(),
+        ),
     })
 }
 
 fn refresh_hit_result(
     hit: &HitResult,
     plot: &Plot,
-    resolved_series: &[ResolvedSeries<'_>],
+    displayed_data: &DisplayedFrameData,
     geometry: &GeometrySnapshot,
 ) -> Option<HitResult> {
     match hit {
@@ -2164,38 +2472,17 @@ fn refresh_hit_result(
             distance_px,
             ..
         } => {
-            let series = plot.series_mgr.series.get(*series_index)?;
-            let resolved = resolved_series.get(*series_index)?;
-            let (x_val, y_val) = match (&series.series_type, resolved) {
-                (
-                    SeriesType::Line { .. }
-                    | SeriesType::Scatter { .. }
-                    | SeriesType::ErrorBars { .. }
-                    | SeriesType::ErrorBarsXY { .. },
-                    ResolvedSeries::Line { x, y }
-                    | ResolvedSeries::Scatter { x, y }
-                    | ResolvedSeries::ErrorBars { x, y, .. }
-                    | ResolvedSeries::ErrorBarsXY { x, y, .. },
-                ) => (*x.get(*point_index)?, *y.get(*point_index)?),
-                _ => return None,
-            };
+            let (x, y) = displayed_data.xy(plot, *series_index)?;
+            let (x_val, y_val) = (*x.get(*point_index)?, *y.get(*point_index)?);
             if !x_val.is_finite() || !y_val.is_finite() {
                 return None;
             }
-            let (screen_x, screen_y) = map_data_to_pixels(
-                x_val,
-                y_val,
-                geometry.x_bounds.0,
-                geometry.x_bounds.1,
-                geometry.y_bounds.0,
-                geometry.y_bounds.1,
-                geometry.plot_area,
-            );
+            let screen_position = geometry.data_to_screen(ViewportPoint::new(x_val, y_val));
 
             Some(HitResult::SeriesPoint {
                 series_index: *series_index,
                 point_index: *point_index,
-                screen_position: ViewportPoint::new(screen_x as f64, screen_y as f64),
+                screen_position,
                 data_position: ViewportPoint::new(x_val, y_val),
                 distance_px: *distance_px,
             })
@@ -2219,32 +2506,16 @@ fn refresh_hit_result(
             }
 
             let ((x1, x2), (y1, y2)) = data.cell_data_bounds(*row, *col);
-            let (sx1, sy1) = map_data_to_pixels(
-                x1,
-                y2,
-                geometry.x_bounds.0,
-                geometry.x_bounds.1,
-                geometry.y_bounds.0,
-                geometry.y_bounds.1,
-                geometry.plot_area,
-            );
-            let (sx2, sy2) = map_data_to_pixels(
-                x2,
-                y1,
-                geometry.x_bounds.0,
-                geometry.x_bounds.1,
-                geometry.y_bounds.0,
-                geometry.y_bounds.1,
-                geometry.plot_area,
-            );
+            let first = geometry.data_to_screen(ViewportPoint::new(x1, y2));
+            let second = geometry.data_to_screen(ViewportPoint::new(x2, y1));
             Some(HitResult::HeatmapCell {
                 series_index: *series_index,
                 row: *row,
                 col: *col,
                 value,
                 screen_rect: ViewportRect {
-                    min: ViewportPoint::new(sx1.min(sx2) as f64, sy1.min(sy2) as f64),
-                    max: ViewportPoint::new(sx1.max(sx2) as f64, sy1.max(sy2) as f64),
+                    min: ViewportPoint::new(first.x.min(second.x), first.y.min(second.y)),
+                    max: ViewportPoint::new(first.x.max(second.x), first.y.max(second.y)),
                 },
             })
         }
@@ -2324,3 +2595,30 @@ mod helpers;
 #[cfg(test)]
 mod tests;
 use self::helpers::*;
+
+#[cfg(test)]
+use crate::render::skia::map_data_to_pixels;
+
+#[cfg(test)]
+fn screen_to_data(
+    bounds: DataBounds,
+    plot_area: tiny_skia::Rect,
+    position_px: ViewportPoint,
+) -> ViewportPoint {
+    let position_px = ViewportPoint::new(
+        position_px
+            .x
+            .clamp(plot_area.left() as f64, plot_area.right() as f64),
+        position_px
+            .y
+            .clamp(plot_area.top() as f64, plot_area.bottom() as f64),
+    );
+    let transform = CoordinateTransform::new(
+        bounds.x_min..bounds.x_max,
+        bounds.y_min..bounds.y_max,
+        plot_area.left()..plot_area.right(),
+        plot_area.top()..plot_area.bottom(),
+    );
+    let (x, y) = transform.screen_to_data(position_px.x as f32, position_px.y as f32);
+    ViewportPoint::new(x, y)
+}

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -13,12 +13,49 @@ use crate::{
     },
 };
 use std::{
+    cell::RefCell,
+    collections::HashSet,
     sync::{
         Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
+
+thread_local! {
+    static ACTIVE_RENDER_SESSIONS: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+}
+
+struct ActiveRenderGuard {
+    session_id: usize,
+}
+
+impl ActiveRenderGuard {
+    fn enter(session_id: usize) -> Result<Self> {
+        let inserted = ACTIVE_RENDER_SESSIONS.with(|sessions| {
+            sessions
+                .try_borrow_mut()
+                .map(|mut sessions| sessions.insert(session_id))
+                .unwrap_or(false)
+        });
+        if !inserted {
+            return Err(PlottingError::RenderError(
+                "reentrant interactive render request".to_string(),
+            ));
+        }
+        Ok(Self { session_id })
+    }
+}
+
+impl Drop for ActiveRenderGuard {
+    fn drop(&mut self) {
+        ACTIVE_RENDER_SESSIONS.with(|sessions| {
+            if let Ok(mut sessions) = sessions.try_borrow_mut() {
+                sessions.remove(&self.session_id);
+            }
+        });
+    }
+}
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
@@ -1463,6 +1500,7 @@ impl InteractivePlotSession {
         scale_factor: f32,
         time_seconds: f64,
     ) -> Result<InteractiveFrame> {
+        let _active_render = ActiveRenderGuard::enter(Arc::as_ptr(&self.inner) as usize)?;
         let _render_guard = self
             .inner
             .render_gate

--- a/src/core/plot/interactive_session/helpers.rs
+++ b/src/core/plot/interactive_session/helpers.rs
@@ -209,16 +209,8 @@ pub(super) fn apply_streaming_draw_ops(
     for op in draw_ops {
         let mut mapped_points: Vec<(f32, f32)> = Vec::with_capacity(op.points.len());
         for &(x, y) in &op.points {
-            let (px, py) = map_data_to_pixels(
-                x,
-                y,
-                geometry.x_bounds.0,
-                geometry.x_bounds.1,
-                geometry.y_bounds.0,
-                geometry.y_bounds.1,
-                geometry.plot_area,
-            );
-            mapped_points.push((px, py));
+            let point = geometry.data_to_screen(ViewportPoint::new(x, y));
+            mapped_points.push((point.x as f32, point.y as f32));
         }
 
         if op.kind == StreamingDrawKind::Line {
@@ -265,16 +257,8 @@ pub(super) fn draw_incremental_polyline(
     let mut path = tiny_skia::PathBuilder::new();
 
     if let Some((x, y)) = previous_point {
-        let (px, py) = map_data_to_pixels(
-            x,
-            y,
-            geometry.x_bounds.0,
-            geometry.x_bounds.1,
-            geometry.y_bounds.0,
-            geometry.y_bounds.1,
-            geometry.plot_area,
-        );
-        path.move_to(px, py);
+        let point = geometry.data_to_screen(ViewportPoint::new(x, y));
+        path.move_to(point.x as f32, point.y as f32);
     } else if let Some(&(px, py)) = points.first() {
         path.move_to(px, py);
     } else {
@@ -509,15 +493,21 @@ pub(super) fn blend_channel(background: u8, foreground: u8, alpha: f32) -> u8 {
     ((bg * (1.0 - alpha) + fg * alpha) * 255.0) as u8
 }
 
-pub(super) fn draw_hit(pixels: &mut [u8], size_px: (u32, u32), hit: &HitResult, color: Color) {
+pub(super) fn draw_hit(
+    pixels: &mut [u8],
+    size_px: (u32, u32),
+    hit: &HitResult,
+    color: Color,
+    clip: Option<ViewportRect>,
+) {
     match hit {
         HitResult::SeriesPoint {
             screen_position, ..
         } => {
-            draw_circle(pixels, size_px, *screen_position, 6.0, color);
+            draw_circle_clipped(pixels, size_px, *screen_position, 6.0, color, clip);
         }
         HitResult::HeatmapCell { screen_rect, .. } => {
-            draw_rect(pixels, size_px, *screen_rect, color)
+            draw_rect_clipped(pixels, size_px, *screen_rect, color, clip)
         }
         HitResult::None => {}
     }
@@ -529,6 +519,17 @@ pub(super) fn draw_circle(
     center: ViewportPoint,
     radius: f64,
     color: Color,
+) {
+    draw_circle_clipped(pixels, size_px, center, radius, color, None);
+}
+
+fn draw_circle_clipped(
+    pixels: &mut [u8],
+    size_px: (u32, u32),
+    center: ViewportPoint,
+    radius: f64,
+    color: Color,
+    clip: Option<ViewportRect>,
 ) {
     let width = size_px.0 as i32;
     let height = size_px.1 as i32;
@@ -546,6 +547,14 @@ pub(super) fn draw_circle(
             if x < 0 || y < 0 || x >= width || y >= height {
                 continue;
             }
+            if clip.is_some_and(|clip| {
+                f64::from(x) < clip.min.x
+                    || f64::from(x) > clip.max.x
+                    || f64::from(y) < clip.min.y
+                    || f64::from(y) > clip.max.y
+            }) {
+                continue;
+            }
             let index = ((y * width + x) * 4) as usize;
             let alpha = color.a as f32 / 255.0;
             pixels[index] = blend_channel(pixels[index], color.r, alpha);
@@ -557,6 +566,16 @@ pub(super) fn draw_circle(
 }
 
 pub(super) fn draw_rect(pixels: &mut [u8], size_px: (u32, u32), rect: ViewportRect, color: Color) {
+    draw_rect_clipped(pixels, size_px, rect, color, None);
+}
+
+fn draw_rect_clipped(
+    pixels: &mut [u8],
+    size_px: (u32, u32),
+    rect: ViewportRect,
+    color: Color,
+    clip: Option<ViewportRect>,
+) {
     let width = size_px.0 as i32;
     let height = size_px.1 as i32;
     let x1 = rect.min.x.round() as i32;
@@ -565,8 +584,13 @@ pub(super) fn draw_rect(pixels: &mut [u8], size_px: (u32, u32), rect: ViewportRe
     let y2 = rect.max.y.round() as i32;
     let alpha = color.a as f32 / 255.0;
 
-    for y in y1.max(0)..y2.min(height) {
-        for x in x1.max(0)..x2.min(width) {
+    let clip_x1 = clip.map_or(0, |clip| clip.min.x.ceil() as i32);
+    let clip_y1 = clip.map_or(0, |clip| clip.min.y.ceil() as i32);
+    let clip_x2 = clip.map_or(width, |clip| clip.max.x.floor() as i32 + 1);
+    let clip_y2 = clip.map_or(height, |clip| clip.max.y.floor() as i32 + 1);
+
+    for y in y1.max(0).max(clip_y1)..y2.min(height).min(clip_y2) {
+        for x in x1.max(0).max(clip_x1)..x2.min(width).min(clip_x2) {
             let index = ((y * width + x) * 4) as usize;
             pixels[index] = blend_channel(pixels[index], color.r, alpha);
             pixels[index + 1] = blend_channel(pixels[index + 1], color.g, alpha);

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -1057,6 +1057,48 @@ fn test_overlapping_render_requests_cannot_commit_stale_base_cache() {
 }
 
 #[test]
+fn test_reentrant_render_request_returns_error() {
+    let session_slot = Arc::new(std::sync::Mutex::new(None));
+    let nested_error = Arc::new(std::sync::Mutex::new(None));
+    let session_slot_for_signal = Arc::clone(&session_slot);
+    let nested_error_for_signal = Arc::clone(&nested_error);
+    let color = signal::of(move |_| {
+        let session: Option<InteractivePlotSession> = session_slot_for_signal
+            .lock()
+            .expect("session slot lock poisoned")
+            .clone();
+        if let Some(session) = session {
+            let error = session
+                .render_to_surface(render_target())
+                .expect_err("reentrant render should return an error")
+                .to_string();
+            *nested_error_for_signal
+                .lock()
+                .expect("nested error lock poisoned") = Some(error);
+        }
+        Color::RED
+    });
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .color_source(color)
+        .into();
+    let session = plot.prepare_interactive();
+    *session_slot.lock().expect("session slot lock poisoned") = Some(session.clone());
+
+    session
+        .render_to_surface(render_target())
+        .expect("outer render should complete");
+
+    assert!(
+        nested_error
+            .lock()
+            .expect("nested error lock poisoned")
+            .as_deref()
+            .is_some_and(|error| error.contains("reentrant interactive render"))
+    );
+}
+
+#[test]
 fn test_session_invalidate_forces_base_rerender() {
     let plot: Plot = Plot::new()
         .line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 4.0])

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::useless_conversion)]
 
 use super::*;
+use crate::core::IntoPlot;
 use crate::data::{Observable, StreamingBuffer, StreamingXY, signal};
 use crate::prelude::Plot;
 use crate::render::{Color, MarkerStyle};
@@ -120,6 +121,612 @@ fn test_small_interactive_frame_renders() {
     );
 }
 
+#[test]
+fn test_viewport_snapshot_remains_available_before_first_render() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .xlim(1.0, 0.0)
+        .into();
+    let session = plot.prepare_interactive();
+    session.resize((320, 240), 1.0);
+
+    let snapshot = session
+        .viewport_snapshot()
+        .expect("viewport snapshot should preserve pre-render compatibility");
+    assert_eq!(
+        (snapshot.visible_bounds.min.x, snapshot.visible_bounds.max.x),
+        (1.0, 0.0)
+    );
+    assert!(snapshot.plot_area.width() > 0.0);
+    assert!(snapshot.plot_area.height() > 0.0);
+}
+
+#[test]
+fn test_displayed_coordinate_conversion_supports_scales_reversal_and_clamping() {
+    let plot: Plot = Plot::new()
+        .line(&[1.0, 1000.0], &[-100.0, 100.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .yscale(crate::axes::AxisScale::symlog(1.0))
+        .xlim(1000.0, 1.0)
+        .ylim(100.0, -100.0)
+        .into();
+    let session = plot.prepare_interactive();
+
+    assert!(
+        session
+            .screen_to_data(ViewportPoint::new(0.0, 0.0))
+            .is_err()
+    );
+    session
+        .render_to_surface(render_target())
+        .expect("scaled conversion frame should render");
+
+    let plot_area = session
+        .viewport_snapshot()
+        .expect("displayed viewport should be available")
+        .plot_area;
+    let center = ViewportPoint::new(
+        (plot_area.min.x + plot_area.max.x) * 0.5,
+        (plot_area.min.y + plot_area.max.y) * 0.5,
+    );
+    let center_data = session
+        .screen_to_data(center)
+        .expect("checked screen conversion should succeed")
+        .expect("plot center should be inside the displayed geometry");
+    assert!((center_data.x.log10() - 1.5).abs() < 1e-6);
+    assert!(center_data.y.abs() < 1e-6);
+
+    let round_trip = session
+        .data_to_screen(center_data)
+        .expect("checked data conversion should succeed")
+        .expect("converted center data should be inside the displayed bounds");
+    assert!((round_trip.x - center.x).abs() < 1e-4);
+    assert!((round_trip.y - center.y).abs() < 1e-4);
+
+    assert_eq!(
+        session
+            .screen_to_data(ViewportPoint::new(plot_area.min.x - 1.0, center.y))
+            .expect("outside checked screen conversion should succeed"),
+        None
+    );
+    assert_eq!(
+        session
+            .data_to_screen(ViewportPoint::new(0.5, 0.0))
+            .expect("outside checked data conversion should succeed"),
+        None
+    );
+    assert_eq!(
+        session
+            .data_to_screen(ViewportPoint::new(0.0, 0.0))
+            .expect("zero log input should be rejected without conversion"),
+        None
+    );
+    assert_eq!(
+        session
+            .data_to_screen(ViewportPoint::new(-1.0, 0.0))
+            .expect("negative log input should be rejected without conversion"),
+        None
+    );
+    assert_eq!(
+        session
+            .screen_to_data(ViewportPoint::new(f64::NAN, center.y))
+            .expect("non-finite checked conversion should return no point"),
+        None
+    );
+
+    let clamped_data = session
+        .screen_to_data_clamped(ViewportPoint::new(
+            plot_area.min.x - 100.0,
+            plot_area.min.y - 100.0,
+        ))
+        .expect("clamped screen conversion should succeed");
+    assert!((clamped_data.x - 1000.0).abs() < 1e-6);
+    assert!((clamped_data.y + 100.0).abs() < 1e-6);
+    let clamped_screen = session
+        .data_to_screen_clamped(ViewportPoint::new(2000.0, -200.0))
+        .expect("clamped data conversion should succeed");
+    assert!((clamped_screen.x - plot_area.min.x).abs() < 1e-4);
+    assert!((clamped_screen.y - plot_area.min.y).abs() < 1e-4);
+    assert!(
+        session
+            .data_to_screen_clamped(ViewportPoint::new(f64::INFINITY, 0.0))
+            .is_err()
+    );
+}
+
+#[test]
+fn test_high_dpi_conversion_uses_backing_pixels_and_logical_hit_tolerance() {
+    let plot: Plot = Plot::new()
+        .scatter(&[10.0], &[0.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .xlim(1.0, 100.0)
+        .ylim(-1.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(SurfaceTarget {
+            size_px: (640, 480),
+            scale_factor: 2.0,
+            time_seconds: 0.0,
+        })
+        .expect("high-DPI frame should render");
+
+    let data_position = ViewportPoint::new(10.0, 0.0);
+    let screen_position = session
+        .data_to_screen(data_position)
+        .expect("high-DPI data conversion should succeed")
+        .expect("point should be inside the displayed bounds");
+    let round_trip = session
+        .screen_to_data(screen_position)
+        .expect("high-DPI screen conversion should succeed")
+        .expect("backing-pixel point should be inside the plot area");
+    assert!((round_trip.x - data_position.x).abs() < 1e-6);
+    assert!((round_trip.y - data_position.y).abs() < 1e-6);
+
+    let six_logical_pixels_away = ViewportPoint::new(screen_position.x + 12.0, screen_position.y);
+    assert!(matches!(
+        session.hit_test(six_logical_pixels_away),
+        HitResult::SeriesPoint { point_index: 0, .. }
+    ));
+
+    let nine_logical_pixels_away = ViewportPoint::new(screen_position.x + 18.0, screen_position.y);
+    assert_eq!(session.hit_test(nine_logical_pixels_away), HitResult::None);
+}
+
+#[test]
+fn test_interactive_log_conversion_preserves_sub_epsilon_positive_limits() {
+    let min = f64::EPSILON / 1024.0;
+    let max = f64::EPSILON / 16.0;
+    let plot: Plot = Plot::new()
+        .line(&[min, max], &[0.0, 1.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .xlim(min, max)
+        .ylim(0.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("sub-epsilon log frame should render");
+    let snapshot = session.viewport_snapshot().unwrap();
+    assert_eq!(
+        (snapshot.visible_bounds.min.x, snapshot.visible_bounds.max.x),
+        (min, max)
+    );
+    let center = ViewportPoint::new(
+        (snapshot.plot_area.min.x + snapshot.plot_area.max.x) * 0.5,
+        (snapshot.plot_area.min.y + snapshot.plot_area.max.y) * 0.5,
+    );
+    let data = session.screen_to_data(center).unwrap().unwrap();
+    assert!(((data.x - (min * max).sqrt()) / data.x).abs() < 1e-12);
+
+    session.apply_input(PlotInputEvent::Zoom {
+        factor: 2.0,
+        center_px: center,
+    });
+    session
+        .render_to_surface(render_target())
+        .expect("zoomed sub-epsilon log frame should render");
+    let zoomed = session.screen_to_data(center).unwrap().unwrap();
+    assert!(((zoomed.x - data.x) / data.x).abs() < 1e-6);
+}
+
+#[test]
+fn test_interactive_log_auto_bounds_preserve_sub_epsilon_positive_range() {
+    let min = f64::EPSILON / 1024.0;
+    let max = f64::EPSILON / 16.0;
+    let plot: Plot = Plot::new()
+        .line(&[min, max], &[0.0, 1.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .ylim(0.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("auto-bounded sub-epsilon log frame should render");
+
+    let snapshot = session.viewport_snapshot().unwrap();
+    assert_eq!(
+        (snapshot.visible_bounds.min.x, snapshot.visible_bounds.max.x),
+        (min, max)
+    );
+}
+
+#[test]
+fn test_log_zoom_and_symlog_pan_follow_displayed_transform() {
+    let plot: Plot = Plot::new()
+        .line(&[1.0, 10.0, 1000.0], &[-100.0, 0.0, 100.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .yscale(crate::axes::AxisScale::symlog(1.0))
+        .xlim(1.0, 1000.0)
+        .ylim(-100.0, 100.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial nonlinear frame should render");
+    let plot_area = session.viewport_snapshot().unwrap().plot_area;
+    let anchor = ViewportPoint::new(
+        plot_area.min.x + plot_area.width() * 0.3,
+        plot_area.min.y + plot_area.height() * 0.65,
+    );
+    let anchor_data = session.screen_to_data(anchor).unwrap().unwrap();
+
+    session.apply_input(PlotInputEvent::Zoom {
+        factor: 2.0,
+        center_px: anchor,
+    });
+    session
+        .render_to_surface(render_target())
+        .expect("zoomed nonlinear frame should render");
+    let after_zoom = session.screen_to_data(anchor).unwrap().unwrap();
+    assert!(
+        ((after_zoom.x - anchor_data.x) / anchor_data.x).abs() < 1e-6,
+        "x anchor moved from {} to {}",
+        anchor_data.x,
+        after_zoom.x
+    );
+    assert!(
+        (after_zoom.y - anchor_data.y).abs() < 1e-6,
+        "y anchor moved from {} to {}",
+        anchor_data.y,
+        after_zoom.y
+    );
+
+    let tracked_data = ViewportPoint::new(10.0, 0.0);
+    let before_pan = session.data_to_screen(tracked_data).unwrap().unwrap();
+    let delta = ViewportPoint::new(18.0, 12.0);
+    session.apply_input(PlotInputEvent::Pan { delta_px: delta });
+    session
+        .render_to_surface(render_target())
+        .expect("panned nonlinear frame should render");
+    let after_pan = session.data_to_screen(tracked_data).unwrap().unwrap();
+    assert!((after_pan.x - before_pan.x - delta.x).abs() < 1e-4);
+    assert!((after_pan.y - before_pan.y - delta.y).abs() < 1e-4);
+}
+
+#[test]
+fn test_zoom_limit_preserves_off_center_anchor_and_reuses_base_at_limit() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 100.0], &[0.0, 100.0])
+        .xlim(0.0, 100.0)
+        .ylim(0.0, 100.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial zoom-limit frame should render");
+    let plot_area = session.viewport_snapshot().unwrap().plot_area;
+    let anchor = ViewportPoint::new(
+        plot_area.min.x + plot_area.width() * 0.2,
+        plot_area.min.y + plot_area.height() * 0.7,
+    );
+    let anchor_before = session.screen_to_data(anchor).unwrap().unwrap();
+
+    session.apply_input(PlotInputEvent::Zoom {
+        factor: 1e12,
+        center_px: anchor,
+    });
+    session
+        .render_to_surface(render_target())
+        .expect("clamped zoom-limit frame should render");
+    let anchor_after = session.screen_to_data(anchor).unwrap().unwrap();
+    assert!((anchor_after.x - anchor_before.x).abs() < 1e-8);
+    assert!((anchor_after.y - anchor_before.y).abs() < 1e-8);
+
+    session.apply_input(PlotInputEvent::Zoom {
+        factor: 1e12,
+        center_px: anchor,
+    });
+    let repeated = session
+        .render_to_surface(render_target())
+        .expect("repeated zoom-limit frame should reuse the base");
+    assert!(!repeated.layer_state.base_dirty);
+}
+
+#[test]
+fn test_failed_reactive_log_render_rolls_back_viewport_state() {
+    let y = Observable::new(vec![1.0, 10.0]);
+    let plot: Plot = Plot::new()
+        .line_source(vec![1.0, 2.0], y.clone())
+        .yscale(crate::axes::AxisScale::Log)
+        .xlim(1.0, 2.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial positive log frame should render");
+    let before = session.viewport_snapshot().unwrap();
+
+    y.set(vec![-10.0, -1.0]);
+    assert!(session.render_to_surface(render_target()).is_err());
+
+    let after = session.viewport_snapshot().unwrap();
+    assert_eq!(after.base_bounds, before.base_bounds);
+    assert_eq!(after.visible_bounds, before.visible_bounds);
+    assert_eq!(after.plot_area, before.plot_area);
+}
+
+#[test]
+fn test_restore_visible_bounds_rejects_invalid_log_domain() {
+    let plot: Plot = Plot::new()
+        .line(&[1.0, 100.0], &[0.0, 1.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .xlim(1.0, 100.0)
+        .ylim(0.0, 1.0)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial log frame should render");
+    let before = session.viewport_snapshot().unwrap();
+
+    assert!(!session.restore_visible_bounds(ViewportRect {
+        min: ViewportPoint::new(-10.0, 0.0),
+        max: ViewportPoint::new(-1.0, 1.0),
+    }));
+    assert_eq!(session.viewport_snapshot().unwrap(), before);
+    assert!(!session.dirty_domains().needs_base_render());
+}
+
+#[test]
+fn test_equal_tiny_positive_log_bounds_expand_multiplicatively() {
+    let value = f64::EPSILON / 1024.0;
+    let static_plot: Plot = Plot::new()
+        .scatter(&[value], &[1.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let (x_min, x_max, _, _) = static_plot
+        .effective_data_bounds()
+        .expect("static log bounds should resolve");
+    assert!(x_min > 0.0 && x_min < x_max);
+    static_plot
+        .render()
+        .expect("static equal-value log plot should render");
+
+    let interactive_plot: Plot = Plot::new()
+        .scatter(&[value], &[1.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = interactive_plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("interactive equal-value log plot should render");
+    let bounds = session.viewport_snapshot().unwrap().base_bounds;
+    assert!(bounds.min.x > 0.0 && bounds.min.x < bounds.max.x);
+}
+
+#[test]
+fn test_selected_hit_overlay_is_clipped_after_pan() {
+    let plot: Plot = Plot::new()
+        .scatter(&[5.0], &[5.0])
+        .xlim(0.0, 10.0)
+        .ylim(0.0, 10.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial selection frame should render");
+    let before = session.viewport_snapshot().unwrap();
+    let point = session
+        .data_to_screen(ViewportPoint::new(5.0, 5.0))
+        .unwrap()
+        .unwrap();
+    session.apply_input(PlotInputEvent::SelectAt { position_px: point });
+    session.apply_input(PlotInputEvent::Pan {
+        delta_px: ViewportPoint::new(before.plot_area.width() * 0.5 + 3.0, 0.0),
+    });
+
+    let frame = session
+        .render_to_surface(render_target())
+        .expect("panned selection frame should render");
+    let after = session.viewport_snapshot().unwrap();
+    assert_eq!(after.selected_count, 1);
+    let overlay = frame
+        .layers
+        .overlay
+        .expect("selection overlay should exist");
+    let plot_area = tiny_skia::Rect::from_ltrb(
+        after.plot_area.min.x as f32,
+        after.plot_area.min.y as f32,
+        after.plot_area.max.x as f32,
+        after.plot_area.max.y as f32,
+    )
+    .unwrap();
+    assert_eq!(
+        count_matching_pixels_outside_rect(&overlay, plot_area, |pixel| pixel[3] > 0),
+        0
+    );
+}
+
+#[test]
+fn test_large_offset_narrow_range_pan_is_not_discarded() {
+    let x_min = 1e15;
+    let x_max = x_min + 100.0;
+    let plot: Plot = Plot::new()
+        .line(&[x_min, x_max], &[0.0, 1.0])
+        .xlim(x_min, x_max)
+        .ylim(0.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial large-offset frame should render");
+    let tracked = ViewportPoint::new(x_min + 0.5, 0.5);
+    let before = session.data_to_screen(tracked).unwrap().unwrap();
+    let delta = ViewportPoint::new(20.0, 0.0);
+
+    session.apply_input(PlotInputEvent::Pan { delta_px: delta });
+    session
+        .render_to_surface(render_target())
+        .expect("large-offset panned frame should render");
+    let after = session.data_to_screen(tracked).unwrap().unwrap();
+    assert!((after.x - before.x - delta.x).abs() < 0.1);
+}
+
+#[test]
+fn test_scaled_error_bar_hit_and_selection_refresh_use_displayed_geometry() {
+    let plot: Plot = Plot::new()
+        .error_bars(&[1.0, 10.0, 100.0], &[-10.0, 0.0, 10.0], &[1.0, 1.0, 1.0])
+        .into_plot()
+        .xscale(crate::axes::AxisScale::Log)
+        .yscale(crate::axes::AxisScale::symlog(1.0))
+        .xlim(1.0, 100.0)
+        .ylim(-10.0, 10.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("scaled error-bar frame should render");
+    let data_position = ViewportPoint::new(10.0, 0.0);
+    let screen_position = session.data_to_screen(data_position).unwrap().unwrap();
+
+    assert!(matches!(
+        session.hit_test(screen_position),
+        HitResult::SeriesPoint { point_index: 1, .. }
+    ));
+    session.apply_input(PlotInputEvent::SelectAt {
+        position_px: screen_position,
+    });
+    let plot_area = session.viewport_snapshot().unwrap().plot_area;
+    session.apply_input(PlotInputEvent::Zoom {
+        factor: 2.0,
+        center_px: ViewportPoint::new(
+            (plot_area.min.x + plot_area.max.x) * 0.5,
+            (plot_area.min.y + plot_area.max.y) * 0.5,
+        ),
+    });
+    session
+        .render_to_surface(render_target())
+        .expect("zoomed error-bar frame should render");
+
+    let expected = session.data_to_screen(data_position).unwrap().unwrap();
+    let state = session
+        .inner
+        .state
+        .lock()
+        .expect("InteractivePlotSession state lock poisoned");
+    match state.selected.as_slice() {
+        [
+            HitResult::SeriesPoint {
+                point_index,
+                screen_position,
+                ..
+            },
+        ] => {
+            assert_eq!(*point_index, 1);
+            assert!((screen_position.x - expected.x).abs() < 1e-4);
+            assert!((screen_position.y - expected.y).abs() < 1e-4);
+        }
+        other => panic!("expected refreshed error-bar selection, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_heatmap_axis_hit_uses_scaled_screen_to_data_and_cell_geometry() {
+    let values = vec![vec![1.0, 2.0]];
+    let plot: Plot = Plot::new()
+        .heatmap(
+            &values,
+            Some(
+                crate::plots::heatmap::HeatmapConfig::new()
+                    .extent(1.0, 100.0, 1.0, 100.0)
+                    .colorbar(false),
+            ),
+        )
+        .xscale(crate::axes::AxisScale::Log)
+        .yscale(crate::axes::AxisScale::Log)
+        .xlim(1.0, 100.0)
+        .ylim(1.0, 100.0)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("log-axis heatmap frame should render");
+    let screen_position = session
+        .data_to_screen(ViewportPoint::new(10.0, 10.0))
+        .unwrap()
+        .unwrap();
+
+    match session.hit_test(screen_position) {
+        HitResult::HeatmapCell {
+            row,
+            col,
+            value,
+            screen_rect,
+            ..
+        } => {
+            assert_eq!((row, col), (0, 0));
+            assert_eq!(value, 1.0);
+            assert!(screen_rect.contains(screen_position));
+        }
+        other => panic!("expected scaled heatmap cell hit, got {other:?}"),
+    }
+}
+
+#[test]
+fn test_incremental_streaming_uses_scaled_geometry_and_displayed_hit_data() {
+    let stream = StreamingXY::new(32);
+    stream.push_many(vec![(1.0, -10.0), (10.0, 0.0)]);
+    let plot: Plot = Plot::new()
+        .line_streaming(&stream)
+        .color(Color::new(220, 20, 20))
+        .into_plot()
+        .xscale(crate::axes::AxisScale::Log)
+        .yscale(crate::axes::AxisScale::symlog(1.0))
+        .xlim(1.0, 1000.0)
+        .ylim(-100.0, 100.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial scaled streaming frame should render");
+
+    stream.push(100.0, 10.0);
+    let incremental = session
+        .render_to_surface(render_target())
+        .expect("incremental scaled streaming frame should render");
+    assert!(incremental.layer_state.used_incremental_data);
+    let screen_position = session
+        .data_to_screen(ViewportPoint::new(100.0, 10.0))
+        .unwrap()
+        .unwrap();
+    assert!(
+        count_matching_pixels_near(
+            incremental.layers.base.as_ref(),
+            screen_position,
+            6,
+            |pixel| pixel[3] > 0 && pixel[0] > 150 && pixel[1] < 100 && pixel[2] < 100
+        ) > 0
+    );
+    assert!(matches!(
+        session.hit_test(screen_position),
+        HitResult::SeriesPoint { point_index: 2, .. }
+    ));
+}
 fn color_centroid<F>(image: &Image, predicate: F) -> Option<ViewportPoint>
 where
     F: Fn(&[u8]) -> bool,
@@ -1133,6 +1740,17 @@ fn test_interactive_render_resolves_each_temporal_source_once() {
 
     assert_eq!(resolutions.load(Ordering::Relaxed), 1);
     assert_eq!(text_resolutions.load(Ordering::Relaxed), 1);
+
+    let plot_area = session.viewport_snapshot().unwrap().plot_area;
+    let center = ViewportPoint::new(
+        (plot_area.min.x + plot_area.max.x) * 0.5,
+        (plot_area.min.y + plot_area.max.y) * 0.5,
+    );
+    let data = session.screen_to_data(center).unwrap().unwrap();
+    assert!(session.data_to_screen(data).unwrap().is_some());
+    let _ = session.hit_test(center);
+    assert_eq!(resolutions.load(Ordering::Relaxed), 1);
+    assert_eq!(text_resolutions.load(Ordering::Relaxed), 1);
 }
 
 #[test]
@@ -1305,9 +1923,16 @@ fn test_refresh_hit_result_drops_masked_log_heatmap_cells() {
         .geometry_snapshot()
         .expect("geometry should be available after log heatmap render");
     let source_plot = session.prepared_plot().plot();
-    let frame = source_plot
-        .resolve_frame(0.0)
-        .expect("heatmap frame should resolve");
+    let displayed_data = session
+        .inner
+        .state
+        .lock()
+        .expect("InteractivePlotSession state lock poisoned")
+        .base_cache
+        .as_ref()
+        .expect("displayed base cache should be available")
+        .displayed_data
+        .clone();
 
     let masked = HitResult::HeatmapCell {
         series_index: 0,
@@ -1319,7 +1944,7 @@ fn test_refresh_hit_result_drops_masked_log_heatmap_cells() {
             ViewportPoint::new(1.0, 1.0),
         ),
     };
-    assert!(refresh_hit_result(&masked, source_plot, &frame.series, &geometry).is_none());
+    assert!(refresh_hit_result(&masked, source_plot, &displayed_data, &geometry).is_none());
 
     let valid = HitResult::HeatmapCell {
         series_index: 0,
@@ -1331,7 +1956,7 @@ fn test_refresh_hit_result_drops_masked_log_heatmap_cells() {
             ViewportPoint::new(1.0, 1.0),
         ),
     };
-    match refresh_hit_result(&valid, source_plot, &frame.series, &geometry) {
+    match refresh_hit_result(&valid, source_plot, &displayed_data, &geometry) {
         Some(HitResult::HeatmapCell {
             row, col, value, ..
         }) => {
@@ -1492,8 +2117,8 @@ fn test_reversed_manual_limits_survive_zoom_and_zoom_rect() {
     assert!(after_zoom_visible.height() < 0.0);
 
     let zoom_geometry = session
-        .geometry_snapshot()
-        .expect("geometry should be available after reversed zoom");
+        .interaction_geometry()
+        .expect("displayed geometry should remain available after reversed zoom");
     let start_px = ViewportPoint::new(
         zoom_geometry.plot_area.left() as f64 + 32.0,
         zoom_geometry.plot_area.top() as f64 + 28.0,
@@ -1571,6 +2196,41 @@ fn test_pan_uses_plot_area_dimensions() {
     assert!(((after_visible.x_max - before_visible.x_max) - expected_dx).abs() < 1e-9);
     assert!(((after_visible.y_min - before_visible.y_min) - expected_dy).abs() < 1e-9);
     assert!(((after_visible.y_max - before_visible.y_max) - expected_dy).abs() < 1e-9);
+}
+
+#[test]
+fn test_pan_accumulates_before_the_next_render() {
+    let plot: Plot = Plot::new()
+        .line(&[1.0, 1000.0], &[-100.0, 100.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .yscale(crate::axes::AxisScale::symlog(1.0))
+        .xlim(1.0, 1000.0)
+        .ylim(-100.0, 100.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial nonlinear frame should render");
+
+    let tracked_data = ViewportPoint::new(10.0, 0.0);
+    let before = session.data_to_screen(tracked_data).unwrap().unwrap();
+    let first_delta = ViewportPoint::new(12.0, 7.0);
+    let second_delta = ViewportPoint::new(9.0, 5.0);
+    session.apply_input(PlotInputEvent::Pan {
+        delta_px: first_delta,
+    });
+    session.apply_input(PlotInputEvent::Pan {
+        delta_px: second_delta,
+    });
+    session
+        .render_to_surface(render_target())
+        .expect("accumulated nonlinear pan should render");
+
+    let after = session.data_to_screen(tracked_data).unwrap().unwrap();
+    assert!((after.x - before.x - first_delta.x - second_delta.x).abs() < 1e-4);
+    assert!((after.y - before.y - first_delta.y - second_delta.y).abs() < 1e-4);
 }
 
 #[test]

--- a/src/core/plot/mixed_render.rs
+++ b/src/core/plot/mixed_render.rs
@@ -1422,14 +1422,10 @@ impl Plot {
             y_max = y_max_manual;
         }
 
-        if (x_max - x_min).abs() < f64::EPSILON {
-            x_min -= 1.0;
-            x_max += 1.0;
-        }
-        if (y_max - y_min).abs() < f64::EPSILON {
-            y_min -= 1.0;
-            y_max += 1.0;
-        }
+        (x_min, x_max) =
+            crate::axes::scale::expand_degenerate_range(x_min, x_max, &self.layout.x_scale);
+        (y_min, y_max) =
+            crate::axes::scale::expand_degenerate_range(y_min, y_max, &self.layout.y_scale);
 
         (x_min, x_max, y_min, y_max)
     }

--- a/src/core/plot/parallel_render.rs
+++ b/src/core/plot/parallel_render.rs
@@ -1351,14 +1351,8 @@ impl Plot {
             &mut y_max,
         );
 
-        if (x_max - x_min).abs() < f64::EPSILON {
-            x_min -= 1.0;
-            x_max += 1.0;
-        }
-        if (y_max - y_min).abs() < f64::EPSILON {
-            y_min -= 1.0;
-            y_max += 1.0;
-        }
+        (x_min, x_max) = crate::axes::expand_degenerate_range(x_min, x_max, &self.layout.x_scale);
+        (y_min, y_max) = crate::axes::expand_degenerate_range(y_min, y_max, &self.layout.y_scale);
 
         (x_min, x_max, y_min, y_max)
     }
@@ -1619,14 +1613,8 @@ impl Plot {
         );
 
         // Handle edge cases
-        if (x_max - x_min).abs() < f64::EPSILON {
-            x_min -= 1.0;
-            x_max += 1.0;
-        }
-        if (y_max - y_min).abs() < f64::EPSILON {
-            y_min -= 1.0;
-            y_max += 1.0;
-        }
+        (x_min, x_max) = crate::axes::expand_degenerate_range(x_min, x_max, &self.layout.x_scale);
+        (y_min, y_max) = crate::axes::expand_degenerate_range(y_min, y_max, &self.layout.y_scale);
 
         Ok((x_min, x_max, y_min, y_max))
     }
@@ -1829,14 +1817,8 @@ impl Plot {
             }
         }
 
-        if (x_max - x_min).abs() < f64::EPSILON {
-            x_min -= 1.0;
-            x_max += 1.0;
-        }
-        if (y_max - y_min).abs() < f64::EPSILON {
-            y_min -= 1.0;
-            y_max += 1.0;
-        }
+        (x_min, x_max) = crate::axes::expand_degenerate_range(x_min, x_max, &self.layout.x_scale);
+        (y_min, y_max) = crate::axes::expand_degenerate_range(y_min, y_max, &self.layout.y_scale);
 
         Ok((x_min, x_max, y_min, y_max))
     }
@@ -2060,14 +2042,8 @@ impl Plot {
             }
         }
 
-        if (x_max - x_min).abs() < f64::EPSILON {
-            x_min -= 1.0;
-            x_max += 1.0;
-        }
-        if (y_max - y_min).abs() < f64::EPSILON {
-            y_min -= 1.0;
-            y_max += 1.0;
-        }
+        (x_min, x_max) = crate::axes::expand_degenerate_range(x_min, x_max, &self.layout.x_scale);
+        (y_min, y_max) = crate::axes::expand_degenerate_range(y_min, y_max, &self.layout.y_scale);
 
         Ok((x_min, x_max, y_min, y_max))
     }

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -120,7 +120,7 @@ impl Plot {
         plot_area: tiny_skia::Rect,
         scale: &AxisScale,
     ) -> f32 {
-        if (max - min).abs() < f64::EPSILON {
+        if min == max || (!matches!(scale, AxisScale::Log) && (max - min).abs() < f64::EPSILON) {
             plot_area.left() + plot_area.width() * 0.5
         } else {
             let normalized = scale.normalized_position(value, min, max);
@@ -135,7 +135,7 @@ impl Plot {
         plot_area: tiny_skia::Rect,
         scale: &AxisScale,
     ) -> f32 {
-        if (max - min).abs() < f64::EPSILON {
+        if min == max || (!matches!(scale, AxisScale::Log) && (max - min).abs() < f64::EPSILON) {
             plot_area.top() + plot_area.height() * 0.5
         } else {
             let normalized = scale.normalized_position(value, min, max);
@@ -164,10 +164,10 @@ impl Plot {
                 && *tick <= range_max
                 && !major_ticks
                     .iter()
-                    .any(|major| Self::tick_values_overlap(*major, *tick))
+                    .any(|major| Self::tick_values_overlap(*major, *tick, scale))
         });
         ticks.sort_by(f64::total_cmp);
-        ticks.dedup_by(|left, right| Self::tick_values_overlap(*left, *right));
+        ticks.dedup_by(|left, right| Self::tick_values_overlap(*left, *right, scale));
         ticks
     }
 
@@ -193,8 +193,13 @@ impl Plot {
         ticks
     }
 
-    fn tick_values_overlap(left: f64, right: f64) -> bool {
-        (left - right).abs() <= left.abs().max(right.abs()).max(1.0) * 1e-10
+    fn tick_values_overlap(left: f64, right: f64, scale: &AxisScale) -> bool {
+        match scale {
+            AxisScale::Log => left == right,
+            AxisScale::Linear | AxisScale::SymLog { .. } => {
+                (left - right).abs() <= left.abs().max(right.abs()).max(1.0) * 1e-10
+            }
+        }
     }
 
     pub(crate) fn grid_tick_pixels(

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -2099,6 +2099,19 @@ fn test_log_minor_ticks_are_generated_between_decades_by_default() {
 }
 
 #[test]
+fn test_sub_epsilon_log_minor_ticks_are_not_deduplicated_as_linear_values() {
+    let min = f64::EPSILON / 1024.0;
+    let max = f64::EPSILON / 8.0;
+    let major_ticks = crate::axes::generate_log_ticks(min, max, 6);
+    let minor_ticks =
+        Plot::minor_tick_values_for_scale(&major_ticks, min, max, &crate::axes::AxisScale::Log, 4);
+
+    assert!(!minor_ticks.is_empty());
+    assert!(minor_ticks.windows(2).all(|pair| pair[0] < pair[1]));
+    assert!(minor_ticks.iter().all(|tick| *tick >= min && *tick <= max));
+}
+
+#[test]
 fn test_log_axis_raster_draws_minor_tick_marks() {
     let plot: Plot = Plot::new()
         .size_px(480, 360)

--- a/src/render/skia.rs
+++ b/src/render/skia.rs
@@ -582,7 +582,10 @@ impl SkiaRenderer {
         x_max: f64,
         scale: &crate::axes::AxisScale,
     ) -> f32 {
-        if (x_max - x_min).abs() < f64::EPSILON {
+        if x_min == x_max
+            || (!matches!(scale, crate::axes::AxisScale::Log)
+                && (x_max - x_min).abs() < f64::EPSILON)
+        {
             plot_area.center_x()
         } else {
             let normalized = scale.normalized_position(x_value, x_min, x_max);
@@ -606,7 +609,10 @@ impl SkiaRenderer {
         y_max: f64,
         scale: &crate::axes::AxisScale,
     ) -> f32 {
-        if (y_max - y_min).abs() < f64::EPSILON {
+        if y_min == y_max
+            || (!matches!(scale, crate::axes::AxisScale::Log)
+                && (y_max - y_min).abs() < f64::EPSILON)
+        {
             plot_area.center_y()
         } else {
             let normalized = scale.normalized_position(y_value, y_min, y_max);


### PR DESCRIPTION
## Summary

- keep interactive geometry and hit testing coherent across display scale factors
- use scale-aware coordinate transforms for viewport input and selection
- add regression coverage for scaled interaction behavior

## Validation

- focused interactive and scale-transform tests
- Rustfmt and all-target/all-feature Clippy
