### PR TITLE
Unify resolved plot styling

### DIFF
--- a/src/core/plot/configuration.rs
+++ b/src/core/plot/configuration.rs
@@ -154,7 +154,7 @@ impl PlotConfiguration {
 
     /// Set the plot theme
     pub fn with_theme(mut self, theme: Theme) -> Self {
-        self.theme = theme;
+        self.apply_theme(theme);
         self
     }
 
@@ -286,9 +286,15 @@ impl PlotConfiguration {
         self.dpi = dpi;
     }
 
+    pub(crate) fn apply_theme(&mut self, theme: Theme) {
+        self.config.typography = theme.to_typography_config();
+        self.config.lines = theme.to_line_config();
+        self.theme = theme;
+    }
+
     /// Set theme (mutable version)
     pub(crate) fn set_theme(&mut self, theme: Theme) {
-        self.theme = theme;
+        self.apply_theme(theme);
     }
 
     /// Set text rendering backend mode.

--- a/src/core/plot/construction.rs
+++ b/src/core/plot/construction.rs
@@ -1,8 +1,27 @@
 use super::*;
+use std::collections::HashMap;
 
 struct CachedResolvedData {
     source: PlotData,
     values: Arc<[f64]>,
+}
+
+fn resolve_reactive_style<T: Clone>(
+    source: &ReactiveValue<T>,
+    time: f64,
+    cache: &mut HashMap<data::ReactiveSourceId, T>,
+) -> T {
+    if let Some(source_id) = source.source_id() {
+        if let Some(value) = cache.get(&source_id) {
+            return value.clone();
+        }
+
+        let value = source.resolve(time);
+        cache.insert(source_id, value.clone());
+        return value;
+    }
+
+    source.resolve(time)
 }
 
 fn resolve_plot_data<'a>(
@@ -149,21 +168,24 @@ impl Plot {
     /// ```
     pub fn new() -> Self {
         let config = PlotConfig::default();
+        let theme = Theme::default();
         let (width, height) = config.canvas_size();
+        let mut layout = LayoutManager::new();
+        layout.grid_style.line_width = config.lines.grid_width;
         let display = PlotConfiguration {
             title: None,
             xlabel: None,
             ylabel: None,
             dimensions: (width, height),
             dpi: config.figure.dpi as u32,
-            theme: Theme::default(),
+            theme,
             text_engine: TextEngineMode::Plain,
             config,
         };
         Self {
             display,
             series_mgr: SeriesManager::new(),
-            layout: LayoutManager::new(),
+            layout,
             render: RenderPipeline::new(),
             annotations: Vec::new(),
             null_policy: NullPolicy::Error,
@@ -189,6 +211,7 @@ impl Plot {
         let mut plot = Self::new();
         plot.display.dimensions = (width, height);
         plot.display.dpi = config.figure.dpi as u32;
+        plot.layout.grid_style.line_width = config.lines.grid_width;
         plot.display.config = config;
         plot
     }
@@ -233,11 +256,7 @@ impl Plot {
     /// # Ok::<(), Box<dyn std::error::Error>>(())
     /// ```
     pub fn with_theme(theme: Theme) -> Self {
-        let mut plot = Self::new();
-        plot.display.config.typography.family =
-            crate::render::FontFamily::from(theme.font_family.as_str());
-        plot.display.theme = theme;
-        plot
+        Self::new().theme(theme)
     }
 
     /// Set null handling policy for dataframe-backed numeric ingestion.
@@ -303,6 +322,13 @@ impl Plot {
             .collect();
 
         for (idx, series) in self.series_mgr.series.iter().enumerate() {
+            let palette_slot = self
+                .series_mgr
+                .auto_color_slots
+                .get(idx)
+                .copied()
+                .flatten()
+                .unwrap_or(idx);
             if let Some(group_id) = series.group_id {
                 if !seen_group_ids.insert(group_id) {
                     continue;
@@ -312,7 +338,7 @@ impl Plot {
                     continue;
                 };
 
-                let default_color = self.display.theme.get_color(idx);
+                let default_color = self.display.theme.get_color(palette_slot);
                 if let Some(item) = series.to_legend_item_with_label(
                     label.to_string(),
                     default_color,
@@ -323,7 +349,7 @@ impl Plot {
                 continue;
             }
 
-            legend_items.extend(series.to_legend_items(idx, &self.display.theme));
+            legend_items.extend(series.to_legend_items(palette_slot, &self.display.theme));
         }
 
         legend_items
@@ -361,9 +387,10 @@ impl Plot {
     /// the current typography settings, including the font family. Call
     /// [`Plot::font_family`] after `theme` to override the theme's family.
     pub fn theme(mut self, theme: Theme) -> Self {
-        self.display.config.typography.family =
-            crate::render::FontFamily::from(theme.font_family.as_str());
-        self.display.theme = theme;
+        self.layout.grid_style.color = theme.grid_color;
+        self.display.apply_theme(theme);
+        self.layout.grid_style.line_width = self.display.config.lines.grid_width;
+        self.layout.legend.font_size = None;
         self
     }
 
@@ -390,6 +417,7 @@ impl Plot {
     /// ```
     pub fn scale_typography(mut self, factor: f32) -> Self {
         self.display.config.typography = self.display.config.typography.scale(factor);
+        self.layout.legend.font_size = None;
         self
     }
 
@@ -873,6 +901,8 @@ impl Plot {
     /// ```
     pub fn plot_style(mut self, style: PlotStyle) -> Self {
         self.display.config = style.config();
+        self.layout.grid_style.line_width = self.display.config.lines.grid_width;
+        self.layout.legend.font_size = None;
         let (w, h) = self.display.config.canvas_size();
         self.display.dimensions = (w, h);
         self.display.dpi = self.display.config.figure.dpi as u32;
@@ -894,6 +924,8 @@ impl Plot {
         let (w, h) = config.canvas_size();
         self.display.dimensions = (w, h);
         self.display.dpi = config.figure.dpi as u32;
+        self.layout.grid_style.line_width = config.lines.grid_width;
+        self.layout.legend.font_size = None;
         self.display.config = config;
         self
     }
@@ -903,6 +935,7 @@ impl Plot {
     /// All other font sizes (title, labels, ticks) scale relative to this.
     pub fn font_size(mut self, size: f32) -> Self {
         self.display.config.typography.base_size = size.max(4.0);
+        self.layout.legend.font_size = None;
         self
     }
 
@@ -1223,7 +1256,120 @@ impl Plot {
         }
     }
 
+    fn resolve_style(&self, time: f64) -> ResolvedStyle {
+        let config = self.display.config.clone();
+        let mut theme = self.display.theme.clone();
+        theme.line_width = config.lines.data_width;
+        theme.font_family = config.typography.family.as_str().to_string();
+        theme.font_size = config.typography.base_size;
+        theme.title_font_size = config.typography.title_size();
+        theme.legend_font_size = config.typography.legend_size();
+        theme.axis_label_font_size = config.typography.label_size();
+        theme.tick_label_font_size = config.typography.tick_size();
+        theme.grid_color = self.layout.grid_style.color;
+
+        let resolver = StyleResolver::new(&theme);
+        let mut color_cache = HashMap::new();
+        let mut f32_cache = HashMap::new();
+        let mut line_style_cache = HashMap::new();
+        let mut marker_style_cache = HashMap::new();
+        let mut series_styles = Vec::with_capacity(self.series_mgr.series.len());
+
+        debug_assert_eq!(
+            self.series_mgr.series.len(),
+            self.series_mgr.auto_color_slots.len()
+        );
+        for (series_index, series) in self.series_mgr.series.iter().enumerate() {
+            let palette_slot = self
+                .series_mgr
+                .auto_color_slots
+                .get(series_index)
+                .copied()
+                .flatten()
+                .unwrap_or(series_index);
+
+            let color = series
+                .color_source
+                .as_ref()
+                .map(|source| resolve_reactive_style(source, time, &mut color_cache))
+                .or(series.color);
+            let line_width = series
+                .line_width_source
+                .as_ref()
+                .map(|source| resolve_reactive_style(source, time, &mut f32_cache))
+                .or(series.line_width);
+            let line_style = series
+                .line_style_source
+                .as_ref()
+                .map(|source| resolve_reactive_style(source, time, &mut line_style_cache))
+                .or_else(|| series.line_style.clone())
+                .unwrap_or_else(|| theme.line_style.clone());
+            let marker_style = series
+                .marker_style_source
+                .as_ref()
+                .map(|source| resolve_reactive_style(source, time, &mut marker_style_cache))
+                .or(series.marker_style);
+            let marker_size = series
+                .marker_size_source
+                .as_ref()
+                .map(|source| resolve_reactive_style(source, time, &mut f32_cache))
+                .or(series.marker_size);
+            let alpha = series
+                .alpha_source
+                .as_ref()
+                .map(|source| resolve_reactive_style(source, time, &mut f32_cache))
+                .or(series.alpha);
+            let resolved_color = resolver.series_color(color, palette_slot);
+            let has_top_level_color = series.color.is_some() || series.color_source.is_some();
+            let radar_colors = match &series.series_type {
+                SeriesType::Radar { data } => Some(Arc::from(
+                    data.series
+                        .iter()
+                        .enumerate()
+                        .map(|(index, _)| {
+                            data.config
+                                .colors
+                                .as_ref()
+                                .and_then(|colors| colors.get(index).copied())
+                                .filter(|color| *color != Color::TRANSPARENT)
+                                .or_else(|| has_top_level_color.then_some(resolved_color))
+                                .unwrap_or_else(|| theme.get_color(palette_slot + index))
+                        })
+                        .collect::<Vec<_>>(),
+                )),
+                _ => None,
+            };
+
+            series_styles.push(ResolvedSeriesStyle {
+                color: resolved_color,
+                line_width: line_width.map(|width| resolver.line_width(Some(width)).max(0.1)),
+                line_style,
+                marker_style,
+                marker_size: marker_size.map(|size| resolver.marker_size(Some(size)).max(0.1)),
+                alpha: resolver.fill_alpha(alpha, 1.0),
+                radar_colors,
+            });
+        }
+
+        let mut legend = self
+            .layout
+            .legend
+            .to_legend(config.typography.legend_size());
+        legend.text_color = theme.foreground;
+        legend.style.face_color = theme.background;
+        legend.style.edge_color = Some(theme.grid_color);
+
+        ResolvedStyle {
+            theme,
+            config,
+            grid_style: self.layout.grid_style.clone(),
+            legend,
+            series: series_styles,
+        }
+    }
+
     pub(super) fn resolve_frame(&self, time: f64) -> Result<ResolvedFrame<'_>> {
+        let style = self.resolve_style(time);
         let mut data_cache = Vec::new();
         let mut streaming_acknowledgements = Vec::new();
         let mut paired_acknowledgements: Vec<ResolvedStreamingPair> = Vec::new();
@@ -1278,6 +1424,7 @@ impl Plot {
         let mut text_cache = Vec::new();
         Ok(ResolvedFrame {
             series: resolved,
+            style,
             title: self
                 .display
                 .title
@@ -1343,34 +1490,31 @@ impl Plot {
             .collect()
     }
 
-    pub(super) fn resolved_plot(&self, time: f64) -> Plot {
-        let mut resolved = self.clone();
-        resolved.series_mgr.series = self.snapshot_series(time);
-        for series in &mut resolved.series_mgr.series {
-            series.resolve_style_sources(time);
-        }
-        resolved.display.title = self
-            .display
-            .title
-            .as_ref()
-            .map(|title| data::PlotText::Static(title.resolve(time)));
-        resolved.display.xlabel = self
-            .display
-            .xlabel
-            .as_ref()
-            .map(|label| data::PlotText::Static(label.resolve(time)));
-        resolved.display.ylabel = self
-            .display
-            .ylabel
-            .as_ref()
-            .map(|label| data::PlotText::Static(label.resolve(time)));
-        resolved
+    pub(super) fn resolved_style_shell(&self, style: &ResolvedStyle) -> Plot {
+        self.apply_resolved_style(self.clone_for_resolved_frame(), style)
     }
 
-    pub(super) fn resolved_style_shell(&self, time: f64) -> Plot {
-        let mut resolved = self.clone_for_resolved_frame();
-        for series in &mut resolved.series_mgr.series {
-            series.resolve_style_sources(time);
+    fn apply_resolved_style(&self, mut resolved: Plot, style: &ResolvedStyle) -> Plot {
+        resolved.display.theme = style.theme.clone();
+        resolved.display.config = style.config.clone();
+        resolved.layout.grid_style = style.grid_style.clone();
+        resolved.layout.legend.font_size = Some(style.legend.font_size);
+
+        debug_assert_eq!(resolved.series_mgr.series.len(), style.series.len());
+        for (series, series_style) in resolved.series_mgr.series.iter_mut().zip(&style.series) {
+            series.color = Some(series_style.color);
+            series.color_source = None;
+            series.line_width = series_style.line_width;
+            series.line_width_source = None;
+            series.line_style = Some(series_style.line_style.clone());
+            series.line_style_source = None;
+            series.marker_style = series_style.marker_style;
+            series.marker_style_source = None;
+            series.marker_size = series_style.marker_size;
+            series.marker_size_source = None;
+            series.alpha = Some(series_style.alpha);
+            series.alpha_source = None;
+            series.resolved_radar_colors = series_style.radar_colors.clone();
         }
         resolved
     }
@@ -1385,6 +1529,7 @@ impl Plot {
                     .iter()
                     .map(PlotSeries::clone_for_resolved_frame)
                     .collect(),
+                auto_color_slots: self.series_mgr.auto_color_slots.clone(),
                 auto_color_index: self.series_mgr.auto_color_index,
             },
             layout: self.layout.clone(),
@@ -1403,7 +1548,24 @@ impl Plot {
         scale_factor: f32,
         time: f64,
     ) -> Plot {
-        self.configure_prepared_frame_plot(self.clone(), size_px, scale_factor, time, true)
+        let style = self.resolve_style(time);
+        let mut plot = self.apply_resolved_style(self.clone(), &style);
+        plot.display.title = self
+            .display
+            .title
+            .as_ref()
+            .map(|title| data::PlotText::Static(title.resolve(time)));
+        plot.display.xlabel = self
+            .display
+            .xlabel
+            .as_ref()
+            .map(|label| data::PlotText::Static(label.resolve(time)));
+        plot.display.ylabel = self
+            .display
+            .ylabel
+            .as_ref()
+            .map(|label| data::PlotText::Static(label.resolve(time)));
+        self.configure_prepared_frame_plot(plot, size_px, scale_factor)
     }
 
     pub(crate) fn prepared_frame_shell(
@@ -1412,13 +1574,18 @@ impl Plot {
         scale_factor: f32,
         time: f64,
     ) -> Plot {
-        self.configure_prepared_frame_plot(
-            self.clone_for_resolved_frame(),
-            size_px,
-            scale_factor,
-            time,
-            false,
-        )
+        let style = self.resolve_style(time);
+        self.prepared_frame_shell_with_style(size_px, scale_factor, &style)
+    }
+
+    pub(crate) fn prepared_frame_shell_with_style(
+        &self,
+        size_px: (u32, u32),
+        scale_factor: f32,
+        style: &ResolvedStyle,
+    ) -> Plot {
+        let plot = self.resolved_style_shell(style);
+        self.configure_prepared_frame_plot(plot, size_px, scale_factor)
     }
 
     fn configure_prepared_frame_plot(
@@ -1426,31 +1593,9 @@ impl Plot {
         mut plot: Plot,
         size_px: (u32, u32),
         scale_factor: f32,
-        time: f64,
-        resolve_text: bool,
     ) -> Plot {
         let device_scale = Self::sanitize_prepared_scale_factor(scale_factor);
         let size_px = (size_px.0.max(1), size_px.1.max(1));
-        for series in &mut plot.series_mgr.series {
-            series.resolve_style_sources(time);
-        }
-        if resolve_text {
-            plot.display.title = self
-                .display
-                .title
-                .as_ref()
-                .map(|title| data::PlotText::Static(title.resolve(time)));
-            plot.display.xlabel = self
-                .display
-                .xlabel
-                .as_ref()
-                .map(|label| data::PlotText::Static(label.resolve(time)));
-            plot.display.ylabel = self
-                .display
-                .ylabel
-                .as_ref()
-                .map(|label| data::PlotText::Static(label.resolve(time)));
-        }
         plot.render.allow_subplot_dimensions = true;
         let dpi = Self::exact_canvas_dpi_for_figure(
             &plot.display.config.figure,

--- a/src/core/plot/data.rs
+++ b/src/core/plot/data.rs
@@ -15,6 +15,12 @@ use crate::data::{Observable, StreamingBuffer, StreamingRenderState};
 use std::borrow::Cow;
 use std::sync::Arc;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub(crate) enum ReactiveSourceId {
+    Temporal(usize),
+    Reactive(usize),
+}
+
 // ============================================================================
 // ReactiveValue
 // ============================================================================
@@ -75,6 +81,14 @@ impl<T> ReactiveValue<T> {
             (Self::Temporal(left), Self::Temporal(right)) => left.shares_source(right),
             (Self::Reactive(left), Self::Reactive(right)) => left.shares_source(right),
             _ => false,
+        }
+    }
+
+    pub(crate) fn source_id(&self) -> Option<ReactiveSourceId> {
+        match self {
+            Self::Static(_) => None,
+            Self::Temporal(signal) => Some(ReactiveSourceId::Temporal(signal.source_id())),
+            Self::Reactive(observable) => Some(ReactiveSourceId::Reactive(observable.source_id())),
         }
     }
 

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -1539,7 +1539,7 @@ impl InteractivePlotSession {
         let source_plot = self.inner.prepared.plot();
         let frame = frame.expect("dirty base render must resolve a frame");
         let mut plot = source_plot
-            .prepared_frame_shell(state.size_px, state.scale_factor, state.time_seconds)
+            .prepared_frame_shell_with_style(state.size_px, state.scale_factor, &frame.style)
             .xlim(geometry.x_bounds.0, geometry.x_bounds.1)
             .ylim(geometry.y_bounds.0, geometry.y_bounds.1);
         if self.prefer_gpu() {
@@ -1937,8 +1937,16 @@ impl InteractivePlotSession {
 }
 
 fn compute_data_bounds(plot: &Plot, time: f64) -> Result<DataBounds> {
-    let frame = plot.resolve_frame(time)?;
-    compute_data_bounds_from_frame(plot, &frame)
+    let series = plot.snapshot_series(time);
+    if series.is_empty() {
+        let bounds = plot.empty_cartesian_bounds();
+        return Ok(DataBounds::from_limits(
+            bounds.0, bounds.1, bounds.2, bounds.3,
+        ));
+    }
+
+    let (x_min, x_max, y_min, y_max) = plot.calculate_data_bounds_for_series(&series)?;
+    Ok(DataBounds::from_limits(x_min, x_max, y_min, y_max))
 }
 
 fn compute_data_bounds_from_frame(plot: &Plot, frame: &ResolvedFrame<'_>) -> Result<DataBounds> {
@@ -2267,11 +2275,11 @@ fn compute_plot_layout_from_frame(
     plot: &Plot,
     size_px: (u32, u32),
     scale_factor: f32,
-    time_seconds: f64,
+    _time_seconds: f64,
     visible: DataBounds,
     frame: &ResolvedFrame<'_>,
 ) -> Result<ComputedSessionLayout> {
-    let layout_plot = plot.prepared_frame_shell(size_px, scale_factor, time_seconds);
+    let layout_plot = plot.prepared_frame_shell_with_style(size_px, scale_factor, &frame.style);
     layout_plot.validate_runtime_environment()?;
     let dpi = layout_plot.display.config.figure.dpi;
 

--- a/src/core/plot/interactive_session/helpers.rs
+++ b/src/core/plot/interactive_session/helpers.rs
@@ -23,7 +23,7 @@ pub(super) fn collect_streaming_draw_ops(
     frame: &ResolvedFrame<'_>,
     size_px: (u32, u32),
     scale_factor: f32,
-    time_seconds: f64,
+    _time_seconds: f64,
 ) -> Result<Option<Vec<StreamingDrawOp>>> {
     if plot
         .display
@@ -49,21 +49,25 @@ pub(super) fn collect_streaming_draw_ops(
         return Ok(None);
     }
 
-    let prepared_plot = plot.prepared_frame_shell(size_px, scale_factor, time_seconds);
+    let prepared_plot = plot.prepared_frame_shell_with_style(size_px, scale_factor, &frame.style);
     let mut draw_ops = Vec::new();
     let mut saw_streaming_update = false;
 
     for (series_index, series) in plot.series_mgr.series.iter().enumerate() {
-        let color = series
+        let style = frame.style.series.get(series_index).ok_or_else(|| {
+            PlottingError::RenderError("resolved series style count mismatch".to_string())
+        })?;
+        let color = style
             .color
-            .unwrap_or_else(|| prepared_plot.display.theme.get_color(series_index));
-        let line_width_pt = series
-            .line_width
-            .unwrap_or(prepared_plot.display.config.lines.data_width);
-        let line_width_px = prepared_plot.line_width_px(line_width_pt);
-        let dash_pattern = series.line_style.clone().unwrap_or(LineStyle::Solid);
-        let marker_style = series.marker_style.unwrap_or(MarkerStyle::Circle);
-        let marker_size_px = prepared_plot.line_width_px(series.marker_size.unwrap_or(8.0));
+            .with_alpha((f32::from(style.color.a) / 255.0) * style.alpha);
+        let line_width_px = prepared_plot.line_width_px(style.line_width.unwrap_or(2.0));
+        let dash_pattern = style.line_style.clone();
+        let marker_style = style.marker_style.unwrap_or(MarkerStyle::Circle);
+        let marker_size = match series.series_type {
+            SeriesType::Scatter { .. } => style.marker_size.unwrap_or(10.0),
+            _ => style.marker_size.unwrap_or(8.0),
+        };
+        let marker_size_px = prepared_plot.line_width_px(marker_size);
 
         match &series.series_type {
             SeriesType::Line { x_data, y_data } => {

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -1679,6 +1679,24 @@ fn test_incremental_line_render_preserves_markers() {
 }
 
 #[test]
+fn test_incremental_stream_style_multiplies_intrinsic_and_series_alpha_once() {
+    let stream = StreamingXY::new(16);
+    stream.push_many(vec![(0.0, 0.0), (1.0, 1.0)]);
+    let plot: Plot = Plot::new()
+        .line_streaming(&stream)
+        .color(Color::RED.with_alpha(0.5))
+        .alpha(0.5)
+        .into();
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    let ops = collect_streaming_draw_ops(&plot, &frame, (320, 240), 1.0, 0.0)
+        .expect("draw ops should resolve")
+        .expect("stream should support incremental rendering");
+
+    assert_eq!(ops.len(), 1);
+    assert_eq!(ops[0].color.a, 63);
+}
+
+#[test]
 fn test_reactive_manual_ylim_stays_pinned_across_updates() {
     let y = Observable::new(vec![0.0, 0.5, 1.0, -0.25]);
     let plot: Plot = Plot::new()

--- a/src/core/plot/mixed_render.rs
+++ b/src/core/plot/mixed_render.rs
@@ -455,10 +455,9 @@ impl Plot {
         y_min: f64,
         y_max: f64,
     ) -> Result<()> {
-        let color = series.color.unwrap_or(default_color);
+        let color = series.color_with_alpha(default_color);
         let render_scale = self.render_scale();
-        let line_width = render_scale
-            .points_to_pixels(series.line_width.unwrap_or(self.display.theme.line_width));
+        let line_width = render_scale.points_to_pixels(series.line_width.unwrap_or(2.0));
         let line_style = series.line_style.clone().unwrap_or(LineStyle::Solid);
 
         match (&series.series_type, resolved) {
@@ -484,7 +483,7 @@ impl Plot {
                 svg.draw_polyline(&points, color, line_width, line_style);
                 if let Some(marker_style) = series.marker_style {
                     let marker_size =
-                        render_scale.points_to_pixels(series.marker_size.unwrap_or(6.0));
+                        render_scale.points_to_pixels(series.marker_size.unwrap_or(8.0));
                     for &(px, py) in &points {
                         svg.draw_marker(px, py, marker_size, marker_style, color);
                     }
@@ -492,7 +491,7 @@ impl Plot {
             }
             (SeriesType::Scatter { .. }, ResolvedSeries::Scatter { x, y }) => {
                 let marker_style = series.marker_style.unwrap_or(MarkerStyle::Circle);
-                let marker_size = render_scale.points_to_pixels(series.marker_size.unwrap_or(6.0));
+                let marker_size = render_scale.points_to_pixels(series.marker_size.unwrap_or(10.0));
                 for (&x, &y) in x.iter().zip(y.iter()) {
                     let (px, py) = crate::render::skia::map_data_to_pixels_scaled(
                         x,
@@ -528,25 +527,212 @@ impl Plot {
                     svg.draw_rectangle(bar_x, bar_y, bar_width, bar_height, color, true);
                 }
             }
+            (SeriesType::Heatmap { data }, ResolvedSeries::Other(_)) => {
+                let area = crate::plots::PlotArea::new(
+                    plot_area.x(),
+                    plot_area.y(),
+                    plot_area.width(),
+                    plot_area.height(),
+                    x_min,
+                    x_max,
+                    y_min,
+                    y_max,
+                );
+                let alpha = data.config.alpha * series.alpha.unwrap_or(1.0);
+                for (row, values) in data.values.iter().enumerate() {
+                    for (col, &value) in values.iter().enumerate() {
+                        if data.should_mask_value(value) {
+                            continue;
+                        }
+                        let (x, y, width, height) = data.cell_screen_rect(&area, row, col);
+                        let cell_color = data.get_color(value).with_alpha(alpha);
+                        svg.draw_rectangle(x, y, width, height, cell_color, true);
+                    }
+                }
+            }
+            (SeriesType::Kde { data }, ResolvedSeries::Other(_)) => {
+                let points: Vec<(f32, f32)> = data
+                    .x
+                    .iter()
+                    .zip(&data.y)
+                    .map(|(&x, &y)| {
+                        crate::render::skia::map_data_to_pixels_scaled(
+                            x,
+                            y,
+                            x_min,
+                            x_max,
+                            y_min,
+                            y_max,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
+                        )
+                    })
+                    .collect();
+                if data.config.fill && !points.is_empty() {
+                    let (_, baseline) = crate::render::skia::map_data_to_pixels_scaled(
+                        x_min,
+                        0.0,
+                        x_min,
+                        x_max,
+                        y_min,
+                        y_max,
+                        plot_area,
+                        &self.layout.x_scale,
+                        &self.layout.y_scale,
+                    );
+                    let mut polygon = Vec::with_capacity(points.len() + 2);
+                    polygon.push((points[0].0, baseline));
+                    polygon.extend_from_slice(&points);
+                    polygon.push((points[points.len() - 1].0, baseline));
+                    let fill_color =
+                        color.with_alpha((f32::from(color.a) / 255.0) * data.config.fill_alpha);
+                    svg.draw_filled_polygon(&polygon, fill_color);
+                }
+                let width = render_scale
+                    .points_to_pixels(series.line_width.unwrap_or(data.config.line_width));
+                svg.draw_polyline(&points, color, width, line_style);
+            }
+            (SeriesType::Ecdf { data }, ResolvedSeries::Other(_)) => {
+                let points: Vec<(f32, f32)> = data
+                    .step_vertices
+                    .iter()
+                    .map(|&(x, y)| {
+                        crate::render::skia::map_data_to_pixels_scaled(
+                            x,
+                            y,
+                            x_min,
+                            x_max,
+                            y_min,
+                            y_max,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
+                        )
+                    })
+                    .collect();
+                let width = render_scale
+                    .points_to_pixels(series.line_width.unwrap_or(data.config.line_width));
+                svg.draw_polyline(&points, color, width, line_style);
+                if data.config.show_markers {
+                    let marker_size = render_scale
+                        .points_to_pixels(series.marker_size.unwrap_or(data.config.marker_size));
+                    for (&x, &y) in data.x.iter().zip(&data.y) {
+                        let (px, py) = crate::render::skia::map_data_to_pixels_scaled(
+                            x,
+                            y,
+                            x_min,
+                            x_max,
+                            y_min,
+                            y_max,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
+                        );
+                        svg.draw_marker(px, py, marker_size, MarkerStyle::Circle, color);
+                    }
+                }
+            }
+            (SeriesType::Violin { data }, ResolvedSeries::Other(_)) => {
+                let half_width = data.config.width / 2.0;
+                let (left, right) =
+                    crate::plots::distribution::violin_polygon(data, 0.5, half_width, &data.config);
+                let polygon = crate::plots::distribution::close_violin_polygon(&left, &right);
+                let points: Vec<(f32, f32)> = polygon
+                    .iter()
+                    .map(|&(x, y)| {
+                        crate::render::skia::map_data_to_pixels_scaled(
+                            x,
+                            y,
+                            x_min,
+                            x_max,
+                            y_min,
+                            y_max,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
+                        )
+                    })
+                    .collect();
+                let alpha = series.alpha.unwrap_or(1.0);
+                let fill_base = data
+                    .config
+                    .fill_color
+                    .unwrap_or(series.color.unwrap_or(default_color));
+                let fill_color = fill_base
+                    .with_alpha((f32::from(fill_base.a) / 255.0) * data.config.fill_alpha * alpha);
+                svg.draw_filled_polygon(&points, fill_color);
+                let edge_color = data
+                    .config
+                    .line_color
+                    .unwrap_or(series.color.unwrap_or(default_color));
+                let edge_color = edge_color.with_alpha((f32::from(edge_color.a) / 255.0) * alpha);
+                let width = render_scale
+                    .points_to_pixels(series.line_width.unwrap_or(data.config.line_width));
+                svg.draw_polygon_outline(&points, edge_color, width);
+            }
+            (SeriesType::Contour { data }, ResolvedSeries::Other(_)) => {
+                let alpha = data.config.alpha * series.alpha.unwrap_or(1.0);
+                let cmap = crate::render::ColorMap::by_name(&data.config.cmap)
+                    .unwrap_or_else(crate::render::ColorMap::viridis);
+                let width = render_scale
+                    .points_to_pixels(series.line_width.unwrap_or(data.config.line_width));
+                for (index, level) in data.lines.iter().enumerate() {
+                    let line_color = data.config.line_color.unwrap_or_else(|| {
+                        if data.lines.len() > 1 {
+                            cmap.sample(index as f64 / (data.lines.len() - 1) as f64)
+                        } else {
+                            series.color.unwrap_or(default_color)
+                        }
+                    });
+                    let line_color =
+                        line_color.with_alpha((f32::from(line_color.a) / 255.0) * alpha);
+                    for &(x1, y1, x2, y2) in &level.segments {
+                        let (sx1, sy1) = crate::render::skia::map_data_to_pixels_scaled(
+                            x1,
+                            y1,
+                            x_min,
+                            x_max,
+                            y_min,
+                            y_max,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
+                        );
+                        let (sx2, sy2) = crate::render::skia::map_data_to_pixels_scaled(
+                            x2,
+                            y2,
+                            x_min,
+                            x_max,
+                            y_min,
+                            y_max,
+                            plot_area,
+                            &self.layout.x_scale,
+                            &self.layout.y_scale,
+                        );
+                        svg.draw_line(sx1, sy1, sx2, sy2, line_color, width, line_style.clone());
+                    }
+                }
+            }
             (SeriesType::Pie { data }, ResolvedSeries::Other(_)) => {
-                self.render_pie_series_svg(svg, data, plot_area)?;
+                self.render_pie_series_svg(svg, data, series, plot_area)?;
             }
             (SeriesType::Radar { data }, ResolvedSeries::Other(_)) => {
-                self.render_radar_series_svg(svg, data, plot_area)?;
+                self.render_radar_series_svg(svg, data, series, plot_area)?;
             }
             (SeriesType::Polar { data }, ResolvedSeries::Other(_)) => {
                 self.render_polar_series_svg(
-                    svg, data, plot_area, x_min, x_max, y_min, y_max, color,
+                    svg, data, series, plot_area, x_min, x_max, y_min, y_max, color,
                 )?;
             }
             (SeriesType::Boxen { data }, ResolvedSeries::Other(_)) => {
                 self.render_boxen_series_svg(
-                    svg, data, plot_area, x_min, x_max, y_min, y_max, color,
+                    svg, data, series, plot_area, x_min, x_max, y_min, y_max, color,
                 );
             }
             (SeriesType::Quiver { data }, ResolvedSeries::Other(_)) => {
                 self.render_quiver_series_svg(
-                    svg, data, plot_area, x_min, x_max, y_min, y_max, color,
+                    svg, data, series, plot_area, x_min, x_max, y_min, y_max, color,
                 );
             }
             (SeriesType::Histogram { .. }, ResolvedSeries::Histogram { data }) => {
@@ -642,7 +828,8 @@ impl Plot {
         y_max: f64,
     ) {
         let config = series.error_config.clone().unwrap_or_default();
-        let bar_color = config.color.unwrap_or(color).with_alpha(config.alpha);
+        let bar_color = config.color.unwrap_or(color);
+        let bar_color = bar_color.with_alpha((f32::from(bar_color.a) / 255.0) * config.alpha);
         let render_scale = self.render_scale();
         let line_width = render_scale
             .logical_pixels_to_pixels(config.line_width)
@@ -858,6 +1045,7 @@ impl Plot {
         &self,
         svg: &mut crate::export::SvgRenderer,
         data: &crate::plots::BoxenData,
+        series: &PlotSeries,
         plot_area: tiny_skia::Rect,
         x_min: f64,
         x_max: f64,
@@ -870,8 +1058,13 @@ impl Plot {
         }
 
         let center = 0.5;
-        let base_color = data.config.color.unwrap_or(default_color);
-        let edge_width = self.render_scale().points_to_pixels(data.config.line_width);
+        let alpha = series.alpha.unwrap_or(1.0);
+        let base_color = data.config.color.map_or(default_color, |color| {
+            color.with_alpha((f32::from(color.a) / 255.0) * alpha)
+        });
+        let edge_width = self
+            .render_scale()
+            .points_to_pixels(series.line_width.unwrap_or(data.config.line_width));
 
         for (index, boxen_box) in data.boxes.iter().enumerate() {
             let saturation_factor =
@@ -975,7 +1168,7 @@ impl Plot {
         if data.config.show_outliers {
             let marker_size = self
                 .render_scale()
-                .points_to_pixels(data.config.outlier_size);
+                .points_to_pixels(series.marker_size.unwrap_or(data.config.outlier_size));
             for &outlier in &data.outliers {
                 let (px, py) = match data.config.orient {
                     crate::plots::distribution::BoxenOrientation::Vertical => {
@@ -1014,6 +1207,7 @@ impl Plot {
         &self,
         svg: &mut crate::export::SvgRenderer,
         data: &crate::plots::QuiverPlotData,
+        series: &PlotSeries,
         plot_area: tiny_skia::Rect,
         x_min: f64,
         x_max: f64,
@@ -1025,7 +1219,10 @@ impl Plot {
             return;
         }
 
-        let base_color = data.config.color.unwrap_or(default_color);
+        let alpha = series.alpha.unwrap_or(1.0);
+        let base_color = data.config.color.map_or(default_color, |color| {
+            color.with_alpha((f32::from(color.a) / 255.0) * alpha)
+        });
         let cmap = data.config.color_by_magnitude.then(|| {
             crate::render::ColorMap::by_name(&data.config.cmap)
                 .unwrap_or_else(crate::render::ColorMap::viridis)
@@ -1036,12 +1233,18 @@ impl Plot {
         } else {
             max_mag - min_mag
         };
-        let arrow_width = self.render_scale().points_to_pixels(data.config.width);
+        let arrow_width = self
+            .render_scale()
+            .points_to_pixels(series.line_width.unwrap_or(data.config.width));
 
         for arrow in &data.arrows {
             let arrow_color = cmap
                 .as_ref()
-                .map(|colormap| colormap.sample((arrow.magnitude - min_mag) / mag_range))
+                .map(|colormap| {
+                    colormap
+                        .sample((arrow.magnitude - min_mag) / mag_range)
+                        .with_alpha(alpha)
+                })
                 .unwrap_or(base_color);
             let (sx1, sy1) = crate::render::skia::map_data_to_pixels_scaled(
                 arrow.start.0,
@@ -1100,6 +1303,7 @@ impl Plot {
         &self,
         svg: &mut crate::export::SvgRenderer,
         data: &crate::plots::composition::pie::PieData,
+        series: &PlotSeries,
         plot_area: tiny_skia::Rect,
     ) -> Result<()> {
         if data.wedges.is_empty() {
@@ -1117,6 +1321,7 @@ impl Plot {
             radius as f64,
             &data.config,
         );
+        let alpha = series.alpha.unwrap_or(1.0);
         let colors = if let Some(ref colors) = data.config.colors {
             colors.clone()
         } else {
@@ -1124,14 +1329,17 @@ impl Plot {
             (0..screen_data.wedges.len())
                 .map(|i| palette[i % palette.len()])
                 .collect()
-        };
+        }
+        .into_iter()
+        .map(|color| color.with_alpha((f32::from(color.a) / 255.0) * alpha))
+        .collect::<Vec<_>>();
         let segments = 64;
         let render_scale = svg.render_scale();
         let shadow_offset = render_scale.points_to_pixels(data.config.shadow as f32) as f64;
         let label_font_size = render_scale.points_to_pixels(data.config.label_font_size);
 
         if data.config.shadow > 0.0 {
-            let shadow_color = Color::new(100, 100, 100).with_alpha(0.3);
+            let shadow_color = Color::new(100, 100, 100).with_alpha(0.3 * alpha);
             for wedge in &screen_data.wedges {
                 let polygon: Vec<(f32, f32)> = wedge
                     .as_polygon(segments)
@@ -1150,7 +1358,10 @@ impl Plot {
                 .collect();
             svg.draw_filled_polygon(&polygon, colors[idx % colors.len()]);
             if let Some(edge_color) = data.config.edge_color {
-                let scaled_edge_width = svg.render_scale().points_to_pixels(data.config.edge_width);
+                let edge_color = edge_color.with_alpha((f32::from(edge_color.a) / 255.0) * alpha);
+                let scaled_edge_width = svg
+                    .render_scale()
+                    .points_to_pixels(series.line_width.unwrap_or(data.config.edge_width));
                 svg.draw_polygon_outline(&polygon, edge_color, scaled_edge_width);
             }
         }
@@ -1207,6 +1418,7 @@ impl Plot {
         &self,
         svg: &mut crate::export::SvgRenderer,
         data: &crate::plots::polar::radar::RadarPlotData,
+        plot_series: &PlotSeries,
         plot_area: tiny_skia::Rect,
     ) -> Result<()> {
         if data.series.is_empty() {
@@ -1217,9 +1429,13 @@ impl Plot {
         let render_scale = svg.render_scale();
         let label_font_size = render_scale.points_to_pixels(data.config.label_font_size);
 
-        if data.config.show_grid {
-            let grid_color = self.display.theme.grid_color;
-            let grid_line_width = render_scale.logical_pixels_to_pixels(0.5);
+        if data.config.show_grid && self.layout.grid_style.visible {
+            let grid_color = self
+                .layout
+                .grid_style
+                .color
+                .with_alpha(self.layout.grid_style.alpha);
+            let grid_line_width = render_scale.points_to_pixels(self.layout.grid_style.line_width);
             for ring in &data.grid_rings {
                 if ring.len() < 2 {
                     continue;
@@ -1236,7 +1452,7 @@ impl Plot {
                         sy2,
                         grid_color,
                         grid_line_width,
-                        LineStyle::Solid,
+                        self.layout.grid_style.line_style.clone(),
                     );
                 }
             }
@@ -1251,7 +1467,7 @@ impl Plot {
                     sy2,
                     grid_color,
                     grid_line_width,
-                    LineStyle::Solid,
+                    self.layout.grid_style.line_style.clone(),
                 );
             }
         }
@@ -1269,15 +1485,26 @@ impl Plot {
             }
         }
 
-        let scaled_line_width = render_scale.points_to_pixels(data.config.line_width);
-        let scaled_marker_size = render_scale.points_to_pixels(data.config.marker_size);
+        let scaled_line_width =
+            render_scale.points_to_pixels(plot_series.line_width.unwrap_or(data.config.line_width));
+        let marker_size = plot_series.marker_size.unwrap_or(data.config.marker_size);
+        let scaled_marker_size = render_scale.points_to_pixels(marker_size);
+        let alpha = plot_series.alpha.unwrap_or(1.0);
         for (series_idx, series_data) in data.series.iter().enumerate() {
-            let series_color = data
-                .config
-                .colors
+            let series_color = plot_series
+                .resolved_radar_colors
                 .as_ref()
                 .and_then(|colors| colors.get(series_idx).copied())
+                .or_else(|| {
+                    data.config
+                        .colors
+                        .as_ref()
+                        .and_then(|colors| colors.get(series_idx).copied())
+                        .filter(|color| *color != Color::TRANSPARENT)
+                })
                 .unwrap_or_else(|| self.display.theme.get_color(series_idx));
+            let series_alpha = (f32::from(series_color.a) / 255.0) * alpha;
+            let stroke_color = series_color.with_alpha(series_alpha);
 
             if data.config.fill && !series_data.polygon.is_empty() {
                 let polygon: Vec<(f32, f32)> = series_data
@@ -1285,7 +1512,10 @@ impl Plot {
                     .iter()
                     .map(|(x, y)| area.data_to_screen(*x, *y))
                     .collect();
-                svg.draw_filled_polygon(&polygon, series_color.with_alpha(data.config.fill_alpha));
+                svg.draw_filled_polygon(
+                    &polygon,
+                    series_color.with_alpha(data.config.fill_alpha * series_alpha),
+                );
             }
 
             if series_data.polygon.len() > 1 {
@@ -1294,10 +1524,10 @@ impl Plot {
                     .iter()
                     .map(|(x, y)| area.data_to_screen(*x, *y))
                     .collect();
-                svg.draw_polygon_outline(&polygon, series_color, scaled_line_width);
+                svg.draw_polygon_outline(&polygon, stroke_color, scaled_line_width);
             }
 
-            if data.config.marker_size > 0.0 {
+            if marker_size > 0.0 {
                 for (x, y) in &series_data.markers {
                     let (sx, sy) = area.data_to_screen(*x, *y);
                     svg.draw_marker(
@@ -1305,7 +1535,7 @@ impl Plot {
                         sy,
                         scaled_marker_size,
                         MarkerStyle::Circle,
-                        series_color,
+                        stroke_color,
                     );
                 }
             }
@@ -1318,6 +1548,7 @@ impl Plot {
         &self,
         svg: &mut crate::export::SvgRenderer,
         data: &crate::plots::polar::polar_plot::PolarPlotData,
+        series: &PlotSeries,
         plot_area: tiny_skia::Rect,
         x_min: f64,
         x_max: f64,
@@ -1342,7 +1573,10 @@ impl Plot {
             y_min,
             y_max,
         );
-        let line_color = data.config.color.unwrap_or(default_color);
+        let alpha = series.alpha.unwrap_or(1.0);
+        let line_color = data.config.color.map_or(default_color, |color| {
+            color.with_alpha((f32::from(color.a) / 255.0) * alpha)
+        });
         let render_scale = svg.render_scale();
         let label_font_size = render_scale.points_to_pixels(data.config.label_font_size);
 
@@ -1352,7 +1586,10 @@ impl Plot {
                 .iter()
                 .map(|(x, y)| area.data_to_screen(*x, *y))
                 .collect();
-            svg.draw_filled_polygon(&polygon, line_color.with_alpha(data.config.fill_alpha));
+            svg.draw_filled_polygon(
+                &polygon,
+                line_color.with_alpha((f32::from(line_color.a) / 255.0) * data.config.fill_alpha),
+            );
         }
 
         if data.points.len() > 1 {
@@ -1361,12 +1598,14 @@ impl Plot {
                 .iter()
                 .map(|point| area.data_to_screen(point.x, point.y))
                 .collect();
-            let scaled_line_width = render_scale.points_to_pixels(data.config.line_width);
+            let scaled_line_width =
+                render_scale.points_to_pixels(series.line_width.unwrap_or(data.config.line_width));
             svg.draw_polyline(&points, line_color, scaled_line_width, LineStyle::Solid);
         }
 
-        if data.config.marker_size > 0.0 {
-            let scaled_marker_size = render_scale.points_to_pixels(data.config.marker_size);
+        let marker_size = series.marker_size.unwrap_or(data.config.marker_size);
+        if marker_size > 0.0 {
+            let scaled_marker_size = render_scale.points_to_pixels(marker_size);
             for point in &data.points {
                 let (sx, sy) = area.data_to_screen(point.x, point.y);
                 svg.draw_marker(sx, sy, scaled_marker_size, MarkerStyle::Circle, line_color);
@@ -1512,10 +1751,8 @@ impl Plot {
         render_scale: RenderScale,
     ) -> Result<()> {
         let config = error_config.cloned().unwrap_or_default();
-        let bar_color = config
-            .color
-            .unwrap_or(series_color)
-            .with_alpha(config.alpha);
+        let bar_color = config.color.unwrap_or(series_color);
+        let bar_color = bar_color.with_alpha((f32::from(bar_color.a) / 255.0) * config.alpha);
         // Error-bar configuration is still authored in legacy logical pixels.
         let scaled_config_width = render_scale.logical_pixels_to_pixels(config.line_width);
         let line_width = scaled_config_width.max(default_line_width * 0.75); // Slightly thinner than data line

--- a/src/core/plot/mod.rs
+++ b/src/core/plot/mod.rs
@@ -505,7 +505,7 @@ use crate::{
         Annotation, ArrowStyle, FillStyle, GridStyle, LayoutCalculator, LayoutConfig, Legend,
         LegendItem, LegendItemType, LegendPosition, MarginConfig, MeasuredDimensions, PlotConfig,
         PlotContent, PlotLayout, PlotStyle, PlottingError, Position, REFERENCE_DPI, RenderScale,
-        Result, ShapeStyle, TextStyle, pt_to_px,
+        Result, ShapeStyle, StyleResolver, TextStyle, pt_to_px,
     },
     data::{
         Data1D, DataShader, NullPolicy, NumericData1D, NumericData2D, StreamingXY,
@@ -531,7 +531,8 @@ use std::{
 use self::data::{ReactiveTeardown, SharedReactiveCallback};
 pub(crate) use self::types::{
     LegendConfig, PendingIngestionError, PlotSeries, ResolvedData, ResolvedFrame, ResolvedSeries,
-    ResolvedStreamingPair, SeriesGroupMeta, SeriesType, TickConfig,
+    ResolvedSeriesStyle, ResolvedStreamingPair, ResolvedStyle, SeriesGroupMeta, SeriesType,
+    TickConfig,
 };
 
 #[cfg(feature = "parallel")]

--- a/src/core/plot/parallel_render.rs
+++ b/src/core/plot/parallel_render.rs
@@ -147,11 +147,18 @@ fn include_annotation_data_bounds(
 }
 
 impl Plot {
+    #[cfg(feature = "parallel")]
+    pub(super) fn parallel_marker_size_px(&self, series: &PlotSeries, fallback_points: f32) -> f32 {
+        self.render_scale()
+            .points_to_pixels(series.marker_size.unwrap_or(fallback_points))
+    }
+
     /// Render plot using parallel processing for multiple series
     #[cfg(feature = "parallel")]
     pub(super) fn render_with_parallel(&self) -> Result<Image> {
         let frame = self.resolve_frame(0.0)?;
-        let result = self.render_with_parallel_resolved(&frame);
+        let style_shell = self.resolved_style_shell(&frame.style);
+        let result = style_shell.render_with_parallel_resolved(&frame);
         if result.is_ok() {
             frame.acknowledge_rendered(self);
         }
@@ -359,16 +366,13 @@ impl Plot {
         }
 
         // Process all series in parallel
+        let render_scale = self.render_scale();
         let processed_series = self.render.parallel_renderer.process_series_parallel(
             &self.series_mgr.series,
             |series, index| -> Result<SeriesRenderData> {
                 // Get series styling with defaults
-                let color = series
-                    .color
-                    .unwrap_or_else(|| self.display.theme.get_color(index));
-                let line_width = self.dpi_scaled_line_width(
-                    series.line_width.unwrap_or(self.display.theme.line_width),
-                );
+                let color = series.color_with_alpha(self.display.theme.get_color(index));
+                let line_width = self.dpi_scaled_line_width(series.line_width.unwrap_or(2.0));
                 let alpha = series.alpha.unwrap_or(1.0);
                 let resolved = &resolved_series[index];
 
@@ -444,7 +448,7 @@ impl Plot {
                             &points,
                             series.marker_style.unwrap_or(MarkerStyle::Circle),
                             color,
-                            8.0, // Default marker size
+                            self.parallel_marker_size_px(series, 10.0),
                         )?;
 
                         RenderSeriesType::Scatter { markers }
@@ -534,9 +538,9 @@ impl Plot {
 
                         let markers = self.render.parallel_renderer.process_markers_parallel(
                             &points,
-                            MarkerStyle::Circle,
+                            series.marker_style.unwrap_or(MarkerStyle::Circle),
                             color,
-                            6.0,
+                            self.parallel_marker_size_px(series, 8.0),
                         )?;
 
                         RenderSeriesType::Scatter { markers }
@@ -775,7 +779,7 @@ impl Plot {
                                     }
 
                                     let cell_color =
-                                        data.get_color(value).with_alpha(data.config.alpha);
+                                        data.get_color(value).with_alpha(data.config.alpha * alpha);
                                     Some(crate::render::parallel::HeatmapCell {
                                         x: left,
                                         y: top,
@@ -963,35 +967,43 @@ impl Plot {
                         RenderSeriesType::Line { segments: vec![] }
                     }
                     SeriesType::Radar { data: radar_data } => {
-                        // Radar plots use polygon rendering, not supported in parallel mode
-                        // Fall back to line rendering of radar polygon outlines
-                        let mut all_points = Vec::new();
-                        for series_data in &radar_data.series {
-                            for &(x, y) in &series_data.polygon {
-                                all_points.push((x, y));
+                        // Preserve each internal polygon's frame-resolved color instead of
+                        // joining all radar payloads into one top-level palette color.
+                        let mut segments = Vec::new();
+                        for (internal_index, series_data) in radar_data.series.iter().enumerate() {
+                            let mut polygon = series_data.polygon.clone();
+                            if let Some(&first) = polygon.first() {
+                                polygon.push(first);
                             }
+                            let poly_x: Vec<f64> = polygon.iter().map(|(x, _)| *x).collect();
+                            let poly_y: Vec<f64> = polygon.iter().map(|(_, y)| *y).collect();
+                            let points = self
+                                .render
+                                .parallel_renderer
+                                .transform_coordinates_parallel_scaled(
+                                    &poly_x,
+                                    &poly_y,
+                                    data_bounds.clone(),
+                                    parallel_plot_area.clone(),
+                                    &self.layout.x_scale,
+                                    &self.layout.y_scale,
+                                )?;
+                            let radar_color = series
+                                .resolved_radar_colors
+                                .as_ref()
+                                .and_then(|colors| colors.get(internal_index).copied())
+                                .unwrap_or(series.color.unwrap_or(color));
+                            let radar_color =
+                                radar_color.with_alpha((f32::from(radar_color.a) / 255.0) * alpha);
+                            segments.extend(
+                                self.render.parallel_renderer.process_polyline_parallel(
+                                    &points,
+                                    LineStyle::Solid,
+                                    radar_color,
+                                    line_width,
+                                )?,
+                            );
                         }
-
-                        let poly_x: Vec<f64> = all_points.iter().map(|(x, _)| *x).collect();
-                        let poly_y: Vec<f64> = all_points.iter().map(|(_, y)| *y).collect();
-                        let points = self
-                            .render
-                            .parallel_renderer
-                            .transform_coordinates_parallel_scaled(
-                                &poly_x,
-                                &poly_y,
-                                data_bounds.clone(),
-                                parallel_plot_area.clone(),
-                                &self.layout.x_scale,
-                                &self.layout.y_scale,
-                            )?;
-
-                        let segments = self.render.parallel_renderer.process_polyline_parallel(
-                            &points,
-                            LineStyle::Solid,
-                            color,
-                            line_width,
-                        )?;
 
                         RenderSeriesType::Line { segments }
                     }
@@ -1312,12 +1324,8 @@ impl Plot {
         }
 
         let legend_items = self.collect_legend_items();
-        if !legend_items.is_empty() && self.layout.legend.enabled {
-            let legend = self
-                .layout
-                .legend
-                .to_legend(self.display.config.typography.legend_size());
-            renderer.draw_legend_full(&legend_items, &legend, plot_area, None)?;
+        if !legend_items.is_empty() && frame.style.legend.enabled {
+            renderer.draw_legend_full(&legend_items, &frame.style.legend, plot_area, None)?;
         }
 
         // Record performance statistics
@@ -1488,7 +1496,7 @@ impl Plot {
                 }
                 SeriesType::Heatmap { data } => {
                     let ((series_x_min, series_x_max), (series_y_min, series_y_max)) =
-                        crate::plots::traits::PlotData::data_bounds(data);
+                        crate::plots::traits::PlotData::data_bounds(data.as_ref());
                     x_min = x_min.min(series_x_min);
                     x_max = x_max.max(series_x_max);
                     y_min = y_min.min(series_y_min);
@@ -1552,7 +1560,13 @@ impl Plot {
                     x_max = x_max.max(1.0);
                 }
                 SeriesType::Boxen { data } => {
-                    include_plot_data_bounds(data, &mut x_min, &mut x_max, &mut y_min, &mut y_max);
+                    include_plot_data_bounds(
+                        data.as_ref(),
+                        &mut x_min,
+                        &mut x_max,
+                        &mut y_min,
+                        &mut y_max,
+                    );
                 }
                 SeriesType::Quiver { data } => {
                     include_quiver_data_bounds(
@@ -1733,7 +1747,7 @@ impl Plot {
                 ResolvedSeries::Other(series) => match series {
                     SeriesType::Heatmap { data } => {
                         let ((sx_min, sx_max), (sy_min, sy_max)) =
-                            crate::plots::traits::PlotData::data_bounds(data);
+                            crate::plots::traits::PlotData::data_bounds(data.as_ref());
                         x_min = x_min.min(sx_min);
                         x_max = x_max.max(sx_max);
                         y_min = y_min.min(sy_min);
@@ -1780,7 +1794,11 @@ impl Plot {
                         x_max = x_max.max(1.0);
                     }
                     SeriesType::Boxen { data } => include_plot_data_bounds(
-                        data, &mut x_min, &mut x_max, &mut y_min, &mut y_max,
+                        data.as_ref(),
+                        &mut x_min,
+                        &mut x_max,
+                        &mut y_min,
+                        &mut y_max,
                     ),
                     SeriesType::Quiver { data } => include_quiver_data_bounds(
                         data, &mut x_min, &mut x_max, &mut y_min, &mut y_max,
@@ -1958,7 +1976,7 @@ impl Plot {
                 }
                 SeriesType::Heatmap { data } => {
                     let ((series_x_min, series_x_max), (series_y_min, series_y_max)) =
-                        crate::plots::traits::PlotData::data_bounds(data);
+                        crate::plots::traits::PlotData::data_bounds(data.as_ref());
                     x_min = x_min.min(series_x_min);
                     x_max = x_max.max(series_x_max);
                     y_min = y_min.min(series_y_min);
@@ -2009,7 +2027,13 @@ impl Plot {
                     x_max = x_max.max(1.0);
                 }
                 SeriesType::Boxen { data } => {
-                    include_plot_data_bounds(data, &mut x_min, &mut x_max, &mut y_min, &mut y_max);
+                    include_plot_data_bounds(
+                        data.as_ref(),
+                        &mut x_min,
+                        &mut x_max,
+                        &mut y_min,
+                        &mut y_max,
+                    );
                 }
                 SeriesType::Quiver { data } => {
                     include_quiver_data_bounds(

--- a/src/core/plot/prepared.rs
+++ b/src/core/plot/prepared.rs
@@ -1,7 +1,7 @@
 //! Prepared plot runtime for repeated frame rendering.
 
 use super::{
-    Image, InteractivePlotSession, Plot, RenderDiagnostics, RenderExecutionMode,
+    Image, InteractivePlotSession, Plot, RenderDiagnostics, RenderExecutionMode, ResolvedStyle,
     data::{ReactiveTeardown, SharedReactiveCallback},
     raster_batches::SeriesRasterPlan,
 };
@@ -235,28 +235,32 @@ impl PreparedPlot {
 
     fn prepared_render_plot(
         &self,
+        key: &PreparedFrameKey,
         size_px: (u32, u32),
         scale_factor: f32,
-        time: f64,
+        style: &ResolvedStyle,
     ) -> Result<Arc<Plot>> {
-        let key = self.frame_key(size_px, scale_factor, time);
         if let Some(plot) = self
             .resolved_cache
             .lock()
             .expect("PreparedPlot resolved cache lock poisoned")
             .as_ref()
-            .and_then(|cached| (cached.key == key).then(|| Arc::clone(&cached.plot)))
+            .and_then(|cached| (cached.key == *key).then(|| Arc::clone(&cached.plot)))
         {
             return Ok(plot);
         }
 
-        let plot = Arc::new(self.plot.prepared_frame_shell(size_px, scale_factor, time));
+        let plot = Arc::new(self.plot.prepared_frame_shell_with_style(
+            size_px,
+            scale_factor,
+            style,
+        ));
         *self
             .resolved_cache
             .lock()
             .expect("PreparedPlot resolved cache lock poisoned") =
             Some(PreparedResolvedPlotCache {
-                key,
+                key: key.clone(),
                 plot: Arc::clone(&plot),
             });
         Ok(plot)
@@ -271,7 +275,7 @@ impl PreparedPlot {
         let key = self.frame_key(size_px, scale_factor, time);
         self.plot.validate_before_frame_resolution()?;
         let frame = self.plot.resolve_frame(time)?;
-        let prepared_plot = self.prepared_render_plot(size_px, scale_factor, time)?;
+        let prepared_plot = self.prepared_render_plot(&key, size_px, scale_factor, &frame.style)?;
 
         let result = prepared_plot
             .render_renderer_with_resolved_frame(
@@ -313,7 +317,7 @@ impl PreparedPlot {
                         if let Some(plan) =
                             prepared_geometry.get(series_index).and_then(Option::as_ref)
                         {
-                            let color = series.color.unwrap_or(crate::render::Color::new(0, 0, 0));
+                            let color = series.color_with_alpha(crate::render::Color::new(0, 0, 0));
                             let line_width =
                                 plot.dpi_scaled_line_width(series.line_width.unwrap_or(2.0));
                             let line_style = series
@@ -714,6 +718,38 @@ mod tests {
         };
         assert!(x_data.as_static().is_some_and(Vec::is_empty));
         assert!(y_data.as_static().is_some_and(Vec::is_empty));
+    }
+
+    #[test]
+    fn test_prepared_style_shell_uses_pre_sample_version_key() {
+        let color = Observable::new(Color::RED);
+        let plot: Plot = Plot::new()
+            .line(&[0.0, 1.0], &[0.0, 1.0])
+            .color_source(color.clone())
+            .into();
+        let prepared = plot.prepare();
+        let size = (320, 240);
+        let key_before = prepared.frame_key(size, 1.0, 0.0);
+        let frame = prepared
+            .plot
+            .resolve_frame(0.0)
+            .expect("frame should resolve");
+
+        color.set(Color::BLUE);
+        let key_after = prepared.frame_key(size, 1.0, 0.0);
+        assert_ne!(key_before, key_after);
+
+        prepared
+            .prepared_render_plot(&key_before, size, 1.0, &frame.style)
+            .expect("prepared style shell should build");
+        let cache = prepared
+            .resolved_cache
+            .lock()
+            .expect("PreparedPlot resolved cache lock poisoned");
+        let cached = cache.as_ref().expect("style shell should be cached");
+        assert_eq!(cached.key, key_before);
+        assert_ne!(cached.key, key_after);
+        assert_eq!(cached.plot.series_mgr.series[0].color, Some(Color::RED));
     }
 
     #[test]

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -78,7 +78,7 @@ impl Plot {
         time: f64,
     ) -> Result<(Image, RenderDiagnostics)> {
         let frame = self.resolve_frame(time)?;
-        let style_shell = self.resolved_style_shell(time);
+        let style_shell = self.resolved_style_shell(&frame.style);
         let result = style_shell.render_image_with_resolved_frame(mode, &frame);
         if result.is_ok() {
             frame.acknowledge_rendered(self);
@@ -557,12 +557,8 @@ impl Plot {
         )?;
 
         let legend_items = self.collect_legend_items();
-        if !legend_items.is_empty() && self.layout.legend.enabled {
-            let legend = self
-                .layout
-                .legend
-                .to_legend(self.display.config.typography.legend_size());
-            renderer.draw_legend_full(&legend_items, &legend, plot_area, None)?;
+        if !legend_items.is_empty() && frame.style.legend.enabled {
+            renderer.draw_legend_full(&legend_items, &frame.style.legend, plot_area, None)?;
         }
 
         let diagnostics = renderer.render_diagnostics().clone();
@@ -601,8 +597,22 @@ impl Plot {
                             && series.x_errors.is_none()
                             && series.y_errors.is_none()
                     }
-                    SeriesType::Heatmap { .. } | SeriesType::Quiver { .. } => false,
-                    _ => true,
+                    SeriesType::Scatter { .. }
+                    | SeriesType::Bar { .. }
+                    | SeriesType::ErrorBars { .. }
+                    | SeriesType::ErrorBarsXY { .. }
+                    | SeriesType::Histogram { .. }
+                    | SeriesType::BoxPlot { .. } => true,
+                    SeriesType::Heatmap { .. }
+                    | SeriesType::Kde { .. }
+                    | SeriesType::Ecdf { .. }
+                    | SeriesType::Violin { .. }
+                    | SeriesType::Boxen { .. }
+                    | SeriesType::Contour { .. }
+                    | SeriesType::Pie { .. }
+                    | SeriesType::Radar { .. }
+                    | SeriesType::Polar { .. }
+                    | SeriesType::Quiver { .. } => false,
                 });
 
         if has_mixed_coordinates
@@ -650,15 +660,16 @@ impl Plot {
     {
         self.validate_before_frame_resolution()?;
         let frame = self.resolve_frame(time)?;
+        let style_shell = self.resolved_style_shell(&frame.style);
         #[cfg(feature = "parallel")]
         if let Some(parallel_render) =
-            self.try_render_parallel_image_with_diagnostics(mode, &frame)?
+            style_shell.try_render_parallel_image_with_diagnostics(mode, &frame)?
         {
             frame.acknowledge_rendered(self);
             return Ok(parallel_render);
         }
 
-        let result = self
+        let result = style_shell
             .render_renderer_with_resolved_frame(mode, &frame, draw_series)
             .map(|(renderer, diagnostics)| (renderer.into_image(), diagnostics));
         if result.is_ok() {
@@ -791,10 +802,7 @@ impl Plot {
     }
 
     fn public_png_render_mode(&self) -> RenderExecutionMode {
-        self.resolve_frame(0.0)
-            .map_or(RenderExecutionMode::Reference, |frame| {
-                self.public_png_render_mode_from_resolved(&frame.series)
-            })
+        self.public_png_render_mode_for_series(&self.series_mgr.series)
     }
 
     fn public_png_render_mode_from_resolved(
@@ -988,11 +996,7 @@ impl Plot {
     pub fn render_to_renderer(&self, renderer: &mut SkiaRenderer, dpi: f32) -> Result<()> {
         self.validate_before_frame_resolution()?;
         let frame = self.resolve_frame(0.0)?;
-        let mut plot = if self.has_dynamic_style_sources() {
-            self.resolved_style_shell(0.0)
-        } else {
-            self.clone_for_resolved_frame()
-        };
+        let mut plot = self.resolved_style_shell(&frame.style);
         plot.display.config.figure.dpi = dpi;
         let plot = plot.set_subplot_output_pixels(renderer.width(), renderer.height());
         let (subplot_renderer, _) = plot
@@ -1868,10 +1872,7 @@ impl Plot {
     ) -> Result<(Vec<u8>, &'static str, RenderDiagnostics, ResolvedFrame<'_>)> {
         let frame = self.resolve_frame(0.0)?;
         let mode = self.public_png_render_mode_from_resolved(&frame.series);
-        let style_shell = self
-            .has_dynamic_style_sources()
-            .then(|| self.resolved_style_shell(0.0));
-        let render_plot = style_shell.as_ref().unwrap_or(self);
+        let render_plot = self.resolved_style_shell(&frame.style);
         let (renderer, diagnostics) =
             render_plot.render_renderer_with_frame_and_diagnostics(mode, &frame)?;
         let png_bytes = renderer.encode_png_bytes()?;
@@ -1903,10 +1904,7 @@ impl Plot {
     pub fn export_svg<P: AsRef<Path>>(self, path: P) -> Result<()> {
         self.validate_before_frame_resolution()?;
         let frame = self.resolve_frame(0.0)?;
-        let style_shell = self
-            .has_dynamic_style_sources()
-            .then(|| self.resolved_style_shell(0.0));
-        let render_plot = style_shell.as_ref().unwrap_or(&self);
+        let render_plot = self.resolved_style_shell(&frame.style);
         let svg_content = render_plot.render_to_svg_with_frame(&frame)?;
         crate::export::write_bytes_atomic(path, svg_content.as_bytes())?;
         frame.acknowledge_rendered(&self);
@@ -2256,10 +2254,7 @@ impl Plot {
     pub fn render_to_svg(&self) -> Result<String> {
         self.validate_before_frame_resolution()?;
         let frame = self.resolve_frame(0.0)?;
-        let style_shell = self
-            .has_dynamic_style_sources()
-            .then(|| self.resolved_style_shell(0.0));
-        let render_plot = style_shell.as_ref().unwrap_or(self);
+        let render_plot = self.resolved_style_shell(&frame.style);
         let result = render_plot.render_to_svg_with_frame(&frame);
         if result.is_ok() {
             frame.acknowledge_rendered(self);
@@ -2639,7 +2634,9 @@ impl Plot {
         for (idx, (series, resolved)) in
             self.series_mgr.series.iter().zip(&frame.series).enumerate()
         {
-            let default_color = self.display.theme.get_color(idx);
+            let default_color = series
+                .color
+                .unwrap_or_else(|| self.display.theme.get_color(idx));
             let inset_rect = inset_rects[idx];
             let (series_area, series_bounds) = if let Some(inset_rect) = inset_rect {
                 (
@@ -2733,15 +2730,9 @@ impl Plot {
         }
 
         // Draw legend if we have labeled series and legend is enabled
-        if !legend_items.is_empty() && self.layout.legend.enabled {
-            // Convert old LegendConfig to new Legend type
-            let legend = self
-                .layout
-                .legend
-                .to_legend(self.display.config.typography.legend_size());
-            // Use new legend rendering with proper handles
+        if !legend_items.is_empty() && frame.style.legend.enabled {
             let plot_bounds = (plot_left, plot_top, plot_right, plot_bottom);
-            svg.draw_legend_full(&legend_items, &legend, plot_bounds, None)?;
+            svg.draw_legend_full(&legend_items, &frame.style.legend, plot_bounds, None)?;
         }
 
         Ok(svg.to_svg_string())
@@ -2793,10 +2784,7 @@ impl Plot {
         self = self.set_output_pixels(width_px, height_px);
 
         let frame = self.resolve_frame(0.0)?;
-        let style_shell = self
-            .has_dynamic_style_sources()
-            .then(|| self.resolved_style_shell(0.0));
-        let render_plot = style_shell.as_ref().unwrap_or(&self);
+        let render_plot = self.resolved_style_shell(&frame.style);
         let svg_content = render_plot.render_to_svg_with_frame(&frame)?;
         let pdf_data = crate::export::svg_to_pdf(&svg_content)?;
         crate::export::write_bytes_atomic(path, &pdf_data)?;

--- a/src/core/plot/series_api.rs
+++ b/src/core/plot/series_api.rs
@@ -237,6 +237,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(self, series)
@@ -365,6 +366,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(self, series)
@@ -642,6 +644,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(plot, series)
@@ -678,6 +681,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(self, series)
@@ -744,6 +748,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(plot, series)
@@ -779,6 +784,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(self, series)
@@ -833,50 +839,8 @@ impl Plot {
         match crate::plots::heatmap::process_heatmap_flat(&flat, rows, cols, heatmap_config) {
             Ok(heatmap_data) => {
                 let series = PlotSeries {
-                    series_type: SeriesType::Heatmap { data: heatmap_data },
-                    streaming_source: None,
-                    label: None,
-                    color: None,
-                    color_source: None,
-                    line_width: None,
-                    line_width_source: None,
-                    line_style: None,
-                    line_style_source: None,
-                    marker_style: None,
-                    marker_style_source: None,
-                    marker_size: None,
-                    marker_size_source: None,
-                    alpha: None,
-                    alpha_source: None,
-                    y_errors: None,
-                    x_errors: None,
-                    error_config: None,
-                    inset_layout: None,
-                    group_id: None,
-                };
-                PlotSeriesBuilder::new(self, series)
-            }
-            Err(err) => {
-                // Return empty plot if data processing fails
-                // This allows chaining to continue without panicking
-                self.set_pending_ingestion_error(PlottingError::DataExtractionFailed {
-                    source: "heatmap".to_string(),
-                    message: err,
-                });
-                let series = PlotSeries {
                     series_type: SeriesType::Heatmap {
-                        data: crate::plots::heatmap::HeatmapData {
-                            values: vec![vec![0.0]],
-                            n_rows: 1,
-                            n_cols: 1,
-                            data_min: 0.0,
-                            data_max: 0.0,
-                            vmin: 0.0,
-                            vmax: 1.0,
-                            x_extent: (0.0, 1.0),
-                            y_extent: (0.0, 1.0),
-                            config: crate::plots::heatmap::HeatmapConfig::default(),
-                        },
+                        data: Arc::new(heatmap_data),
                     },
                     streaming_source: None,
                     label: None,
@@ -897,6 +861,52 @@ impl Plot {
                     error_config: None,
                     inset_layout: None,
                     group_id: None,
+                    resolved_radar_colors: None,
+                };
+                PlotSeriesBuilder::new(self, series)
+            }
+            Err(err) => {
+                // Return empty plot if data processing fails
+                // This allows chaining to continue without panicking
+                self.set_pending_ingestion_error(PlottingError::DataExtractionFailed {
+                    source: "heatmap".to_string(),
+                    message: err,
+                });
+                let series = PlotSeries {
+                    series_type: SeriesType::Heatmap {
+                        data: Arc::new(crate::plots::heatmap::HeatmapData {
+                            values: vec![vec![0.0]],
+                            n_rows: 1,
+                            n_cols: 1,
+                            data_min: 0.0,
+                            data_max: 0.0,
+                            vmin: 0.0,
+                            vmax: 1.0,
+                            x_extent: (0.0, 1.0),
+                            y_extent: (0.0, 1.0),
+                            config: crate::plots::heatmap::HeatmapConfig::default(),
+                        }),
+                    },
+                    streaming_source: None,
+                    label: None,
+                    color: None,
+                    color_source: None,
+                    line_width: None,
+                    line_width_source: None,
+                    line_style: None,
+                    line_style_source: None,
+                    marker_style: None,
+                    marker_style_source: None,
+                    marker_size: None,
+                    marker_size_source: None,
+                    alpha: None,
+                    alpha_source: None,
+                    y_errors: None,
+                    x_errors: None,
+                    error_config: None,
+                    inset_layout: None,
+                    group_id: None,
+                    resolved_radar_colors: None,
                 };
                 PlotSeriesBuilder::new(self, series)
             }
@@ -958,6 +968,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(plot, series)
@@ -995,6 +1006,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(self, series)
@@ -1070,6 +1082,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(plot, series)
@@ -1115,6 +1128,7 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
         PlotSeriesBuilder::new(self, series)

--- a/src/core/plot/series_builders.rs
+++ b/src/core/plot/series_builders.rs
@@ -15,7 +15,7 @@ pub struct SeriesGroupBuilder {
     plot: Plot,
     style: builder::SeriesStyle,
     group_id: usize,
-    resolved_auto_color: Option<Color>,
+    auto_palette_slot_consumed: bool,
 }
 
 impl SeriesGroupBuilder {
@@ -25,7 +25,7 @@ impl SeriesGroupBuilder {
             plot,
             style: builder::SeriesStyle::default(),
             group_id,
-            resolved_auto_color: None,
+            auto_palette_slot_consumed: false,
         }
     }
 
@@ -125,14 +125,9 @@ impl SeriesGroupBuilder {
             }
         };
 
-        let mut style = self.style.clone();
-        let mut consume_palette_index = true;
-        if self.style.color.is_none() && self.style.color_source.is_none() {
-            if let Some(color) = self.resolved_auto_color {
-                style.color = Some(color);
-                consume_palette_index = false;
-            }
-        }
+        let style = self.style.clone();
+        let uses_auto_color = self.style.color.is_none() && self.style.color_source.is_none();
+        let consume_palette_index = !uses_auto_color || !self.auto_palette_slot_consumed;
 
         self.plot = self.plot.add_line_series_grouped(
             PlotData::Static(x_vec),
@@ -143,11 +138,8 @@ impl SeriesGroupBuilder {
             consume_palette_index,
         );
 
-        if self.style.color.is_none()
-            && self.style.color_source.is_none()
-            && self.resolved_auto_color.is_none()
-        {
-            self.resolved_auto_color = self.plot.series_mgr.series.last().and_then(|s| s.color);
+        if uses_auto_color {
+            self.auto_palette_slot_consumed = true;
         }
         self
     }
@@ -158,14 +150,9 @@ impl SeriesGroupBuilder {
         X: IntoPlotData,
         Y: IntoPlotData,
     {
-        let mut style = self.style.clone();
-        let mut consume_palette_index = true;
-        if self.style.color.is_none() && self.style.color_source.is_none() {
-            if let Some(color) = self.resolved_auto_color {
-                style.color = Some(color);
-                consume_palette_index = false;
-            }
-        }
+        let style = self.style.clone();
+        let uses_auto_color = self.style.color.is_none() && self.style.color_source.is_none();
+        let consume_palette_index = !uses_auto_color || !self.auto_palette_slot_consumed;
 
         self.plot = self.plot.add_line_series_grouped(
             x_data.into_plot_data(),
@@ -176,11 +163,8 @@ impl SeriesGroupBuilder {
             consume_palette_index,
         );
 
-        if self.style.color.is_none()
-            && self.style.color_source.is_none()
-            && self.resolved_auto_color.is_none()
-        {
-            self.resolved_auto_color = self.plot.series_mgr.series.last().and_then(|s| s.color);
+        if uses_auto_color {
+            self.auto_palette_slot_consumed = true;
         }
         self
     }
@@ -206,14 +190,9 @@ impl SeriesGroupBuilder {
             }
         };
 
-        let mut style = self.style.clone();
-        let mut consume_palette_index = true;
-        if self.style.color.is_none() && self.style.color_source.is_none() {
-            if let Some(color) = self.resolved_auto_color {
-                style.color = Some(color);
-                consume_palette_index = false;
-            }
-        }
+        let style = self.style.clone();
+        let uses_auto_color = self.style.color.is_none() && self.style.color_source.is_none();
+        let consume_palette_index = !uses_auto_color || !self.auto_palette_slot_consumed;
 
         self.plot = self.plot.add_scatter_series_grouped(
             PlotData::Static(x_vec),
@@ -224,11 +203,8 @@ impl SeriesGroupBuilder {
             consume_palette_index,
         );
 
-        if self.style.color.is_none()
-            && self.style.color_source.is_none()
-            && self.resolved_auto_color.is_none()
-        {
-            self.resolved_auto_color = self.plot.series_mgr.series.last().and_then(|s| s.color);
+        if uses_auto_color {
+            self.auto_palette_slot_consumed = true;
         }
         self
     }
@@ -239,14 +215,9 @@ impl SeriesGroupBuilder {
         X: IntoPlotData,
         Y: IntoPlotData,
     {
-        let mut style = self.style.clone();
-        let mut consume_palette_index = true;
-        if self.style.color.is_none() && self.style.color_source.is_none() {
-            if let Some(color) = self.resolved_auto_color {
-                style.color = Some(color);
-                consume_palette_index = false;
-            }
-        }
+        let style = self.style.clone();
+        let uses_auto_color = self.style.color.is_none() && self.style.color_source.is_none();
+        let consume_palette_index = !uses_auto_color || !self.auto_palette_slot_consumed;
 
         self.plot = self.plot.add_scatter_series_grouped(
             x_data.into_plot_data(),
@@ -257,11 +228,8 @@ impl SeriesGroupBuilder {
             consume_palette_index,
         );
 
-        if self.style.color.is_none()
-            && self.style.color_source.is_none()
-            && self.resolved_auto_color.is_none()
-        {
-            self.resolved_auto_color = self.plot.series_mgr.series.last().and_then(|s| s.color);
+        if uses_auto_color {
+            self.auto_palette_slot_consumed = true;
         }
         self
     }
@@ -281,14 +249,9 @@ impl SeriesGroupBuilder {
             }
         };
 
-        let mut style = self.style.clone();
-        let mut consume_palette_index = true;
-        if self.style.color.is_none() && self.style.color_source.is_none() {
-            if let Some(color) = self.resolved_auto_color {
-                style.color = Some(color);
-                consume_palette_index = false;
-            }
-        }
+        let style = self.style.clone();
+        let uses_auto_color = self.style.color.is_none() && self.style.color_source.is_none();
+        let consume_palette_index = !uses_auto_color || !self.auto_palette_slot_consumed;
 
         self.plot = self.plot.add_bar_series_grouped(
             cat_vec,
@@ -299,11 +262,8 @@ impl SeriesGroupBuilder {
             consume_palette_index,
         );
 
-        if self.style.color.is_none()
-            && self.style.color_source.is_none()
-            && self.resolved_auto_color.is_none()
-        {
-            self.resolved_auto_color = self.plot.series_mgr.series.last().and_then(|s| s.color);
+        if uses_auto_color {
+            self.auto_palette_slot_consumed = true;
         }
         self
     }
@@ -314,14 +274,9 @@ impl SeriesGroupBuilder {
         S: ToString,
         V: IntoPlotData,
     {
-        let mut style = self.style.clone();
-        let mut consume_palette_index = true;
-        if self.style.color.is_none() && self.style.color_source.is_none() {
-            if let Some(color) = self.resolved_auto_color {
-                style.color = Some(color);
-                consume_palette_index = false;
-            }
-        }
+        let style = self.style.clone();
+        let uses_auto_color = self.style.color.is_none() && self.style.color_source.is_none();
+        let consume_palette_index = !uses_auto_color || !self.auto_palette_slot_consumed;
 
         self.plot = self.plot.add_bar_series_grouped(
             categories.iter().map(ToString::to_string).collect(),
@@ -332,11 +287,8 @@ impl SeriesGroupBuilder {
             consume_palette_index,
         );
 
-        if self.style.color.is_none()
-            && self.style.color_source.is_none()
-            && self.resolved_auto_color.is_none()
-        {
-            self.resolved_auto_color = self.plot.series_mgr.series.last().and_then(|s| s.color);
+        if uses_auto_color {
+            self.auto_palette_slot_consumed = true;
         }
         self
     }
@@ -767,18 +719,17 @@ impl PlotSeriesBuilder {
         note = "Not needed - series finalize automatically. Use .save() directly or .into() for explicit conversion."
     )]
     pub fn end_series(mut self) -> Plot {
-        // Auto-assign color if none specified
-        if self.series.color.is_none() && self.series.color_source.is_none() {
-            self.series.color = Some(
-                self.plot
-                    .display
-                    .theme
-                    .get_color(self.plot.series_mgr.auto_color_index),
-            );
+        let auto_color_slot = if self.series.color.is_none() && self.series.color_source.is_none() {
+            let slot = self.plot.series_mgr.auto_color_index;
             self.plot.series_mgr.auto_color_index += 1;
-        }
+            Some(slot)
+        } else {
+            None
+        };
 
-        self.plot.series_mgr.series.push(self.series);
+        self.plot
+            .series_mgr
+            .push_with_auto_color_slot(self.series, auto_color_slot);
         self.plot
     }
 }

--- a/src/core/plot/series_internal.rs
+++ b/src/core/plot/series_internal.rs
@@ -36,11 +36,7 @@ impl Plot {
             },
             streaming_source: None,
             label: None,
-            color: Some(
-                self.display
-                    .theme
-                    .get_color(self.series_mgr.auto_color_index),
-            ),
+            color: None,
             color_source: None,
             line_width: None,
             line_width_source: None,
@@ -57,9 +53,13 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
 
         Ok(())
@@ -74,16 +74,12 @@ impl Plot {
         style: crate::core::plot::builder::SeriesStyle,
     ) -> Self {
         let series = PlotSeries {
-            series_type: SeriesType::Kde { data: kde_data },
+            series_type: SeriesType::Kde {
+                data: Arc::new(kde_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -100,9 +96,13 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -114,16 +114,12 @@ impl Plot {
         style: crate::core::plot::builder::SeriesStyle,
     ) -> Self {
         let series = PlotSeries {
-            series_type: SeriesType::Ecdf { data: ecdf_data },
+            series_type: SeriesType::Ecdf {
+                data: Arc::new(ecdf_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -140,9 +136,13 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -154,16 +154,12 @@ impl Plot {
         style: crate::core::plot::builder::SeriesStyle,
     ) -> Self {
         let series = PlotSeries {
-            series_type: SeriesType::Contour { data: contour_data },
+            series_type: SeriesType::Contour {
+                data: Arc::new(contour_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -180,9 +176,13 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -194,16 +194,12 @@ impl Plot {
         style: crate::core::plot::builder::SeriesStyle,
     ) -> Self {
         let series = PlotSeries {
-            series_type: SeriesType::Pie { data: pie_data },
+            series_type: SeriesType::Pie {
+                data: Arc::new(pie_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -220,9 +216,13 @@ impl Plot {
             error_config: None,
             inset_layout: Some(style.inset_layout.unwrap_or_default().normalized()),
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -234,16 +234,12 @@ impl Plot {
         style: crate::core::plot::builder::SeriesStyle,
     ) -> Self {
         let series = PlotSeries {
-            series_type: SeriesType::Radar { data: radar_data },
+            series_type: SeriesType::Radar {
+                data: Arc::new(radar_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -260,9 +256,13 @@ impl Plot {
             error_config: None,
             inset_layout: Some(style.inset_layout.unwrap_or_default().normalized()),
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -274,16 +274,12 @@ impl Plot {
         style: crate::core::plot::builder::SeriesStyle,
     ) -> Self {
         let series = PlotSeries {
-            series_type: SeriesType::Violin { data: violin_data },
+            series_type: SeriesType::Violin {
+                data: Arc::new(violin_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -300,9 +296,13 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -321,16 +321,12 @@ impl Plot {
         }
 
         let series = PlotSeries {
-            series_type: SeriesType::Boxen { data: boxen_data },
+            series_type: SeriesType::Boxen {
+                data: Arc::new(boxen_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -347,9 +343,13 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -361,16 +361,12 @@ impl Plot {
         style: crate::core::plot::builder::SeriesStyle,
     ) -> Self {
         let series = PlotSeries {
-            series_type: SeriesType::Polar { data: polar_data },
+            series_type: SeriesType::Polar {
+                data: Arc::new(polar_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -387,9 +383,13 @@ impl Plot {
             error_config: None,
             inset_layout: Some(style.inset_layout.unwrap_or_default().normalized()),
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -408,16 +408,12 @@ impl Plot {
         }
 
         let series = PlotSeries {
-            series_type: SeriesType::Quiver { data: quiver_data },
+            series_type: SeriesType::Quiver {
+                data: Arc::new(quiver_data),
+            },
             streaming_source: None,
             label: style.label,
-            color: style.color.or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
             line_width: style.line_width,
             line_width_source: style.line_width_source,
@@ -434,9 +430,13 @@ impl Plot {
             error_config: None,
             inset_layout: None,
             group_id: None,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = (series.color.is_none() && series.color_source.is_none())
+            .then_some(self.series_mgr.auto_color_index);
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         self.series_mgr.auto_color_index += 1;
         self
     }
@@ -468,25 +468,15 @@ impl Plot {
             series_type: SeriesType::Line { x_data, y_data },
             streaming_source: None,
             label: style.label,
-            color: style.color.or(config.color).or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
-            line_width: style.line_width.or(config.line_width),
+            line_width: style.line_width,
             line_width_source: style.line_width_source,
             line_style: style.line_style.or(Some(config.line_style.clone())),
             line_style_source: style.line_style_source,
             marker_style: style.marker_style.or(config.marker),
             marker_style_source: style.marker_style_source,
-            marker_size: style.marker_size.or(if config.show_markers {
-                Some(config.marker_size)
-            } else {
-                None
-            }),
+            marker_size: style.marker_size,
             marker_size_source: style.marker_size_source,
             alpha: style.alpha.or(Some(config.alpha)),
             alpha_source: style.alpha_source,
@@ -495,9 +485,20 @@ impl Plot {
             error_config: style.error_config,
             inset_layout: None,
             group_id,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = if series.color.is_none() && series.color_source.is_none() {
+            Some(if consume_palette_index {
+                self.series_mgr.auto_color_index
+            } else {
+                self.series_mgr.auto_color_index.saturating_sub(1)
+            })
+        } else {
+            None
+        };
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         if consume_palette_index {
             self.series_mgr.auto_color_index += 1;
         }
@@ -531,21 +532,15 @@ impl Plot {
             series_type: SeriesType::Scatter { x_data, y_data },
             streaming_source: None,
             label: style.label,
-            color: style.color.or(config.color).or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color,
             color_source: style.color_source,
-            line_width: style.line_width.or(Some(config.edge_width)),
+            line_width: style.line_width,
             line_width_source: style.line_width_source,
             line_style: style.line_style,
             line_style_source: style.line_style_source,
             marker_style: style.marker_style.or(Some(config.marker)),
             marker_style_source: style.marker_style_source,
-            marker_size: style.marker_size.or(Some(config.size)),
+            marker_size: style.marker_size,
             marker_size_source: style.marker_size_source,
             alpha: style.alpha.or(Some(config.alpha)),
             alpha_source: style.alpha_source,
@@ -554,9 +549,20 @@ impl Plot {
             error_config: style.error_config,
             inset_layout: None,
             group_id,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = if series.color.is_none() && series.color_source.is_none() {
+            Some(if consume_palette_index {
+                self.series_mgr.auto_color_index
+            } else {
+                self.series_mgr.auto_color_index.saturating_sub(1)
+            })
+        } else {
+            None
+        };
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         if consume_palette_index {
             self.series_mgr.auto_color_index += 1;
         }
@@ -590,13 +596,7 @@ impl Plot {
             series_type: SeriesType::Bar { categories, values },
             streaming_source: None,
             label: style.label,
-            color: style.color.or(config.color).or_else(|| {
-                Some(
-                    self.display
-                        .theme
-                        .get_color(self.series_mgr.auto_color_index),
-                )
-            }),
+            color: style.color.or(config.color),
             color_source: style.color_source,
             line_width: style.line_width.or(Some(config.edge_width)),
             line_width_source: style.line_width_source,
@@ -613,9 +613,20 @@ impl Plot {
             error_config: style.error_config,
             inset_layout: None,
             group_id,
+            resolved_radar_colors: None,
         };
 
-        self.series_mgr.series.push(series);
+        let auto_color_slot = if series.color.is_none() && series.color_source.is_none() {
+            Some(if consume_palette_index {
+                self.series_mgr.auto_color_index
+            } else {
+                self.series_mgr.auto_color_index.saturating_sub(1)
+            })
+        } else {
+            None
+        };
+        self.series_mgr
+            .push_with_auto_color_slot(series, auto_color_slot);
         if consume_palette_index {
             self.series_mgr.auto_color_index += 1;
         }
@@ -633,7 +644,7 @@ impl Plot {
         y_max: f64,
         mode: RenderExecutionMode,
     ) -> Result<Option<SeriesRasterPlan>> {
-        let color = series.color.unwrap_or(Color::new(0, 0, 0));
+        let color = series.color_with_alpha(Color::new(0, 0, 0));
         let line_width = self.dpi_scaled_line_width(series.line_width.unwrap_or(2.0));
         let line_style = series.line_style.clone().unwrap_or(LineStyle::Solid);
         let clip_rect = clip_rect_from_plot_area(plot_area);
@@ -707,13 +718,16 @@ impl Plot {
             }
             (SeriesType::Heatmap { data }, ResolvedSeries::Other(_)) => {
                 let heatmap_plot_area = plot_area_from_rect(plot_area, x_min, x_max, y_min, y_max);
-                RectGridBatch::from_heatmap_data(data, heatmap_plot_area, data.config.alpha).map(
-                    |rect_grid| {
-                        let mut raster_plan = SeriesRasterPlan::default();
-                        raster_plan.push_rect_grid(rect_grid);
-                        raster_plan
-                    },
+                RectGridBatch::from_heatmap_data(
+                    data,
+                    heatmap_plot_area,
+                    data.config.alpha * series.alpha.unwrap_or(1.0),
                 )
+                .map(|rect_grid| {
+                    let mut raster_plan = SeriesRasterPlan::default();
+                    raster_plan.push_rect_grid(rect_grid);
+                    raster_plan
+                })
             }
             _ => None,
         };
@@ -770,8 +784,9 @@ impl Plot {
                             continue;
                         }
 
-                        let cell_color = if data.config.alpha < 1.0 {
-                            data.get_color(value).with_alpha(data.config.alpha)
+                        let alpha = data.config.alpha * series.alpha.unwrap_or(1.0);
+                        let cell_color = if alpha < 1.0 {
+                            data.get_color(value).with_alpha(alpha)
                         } else {
                             data.get_color(value)
                         };
@@ -829,12 +844,16 @@ impl Plot {
         y_min: f64,
         y_max: f64,
         default_color: Color,
+        alpha: f32,
+        line_width: Option<f32>,
     ) -> Result<()> {
         if data.arrows.is_empty() {
             return Ok(());
         }
 
-        let base_color = data.config.color.unwrap_or(default_color);
+        let base_color = data.config.color.map_or(default_color, |color| {
+            color.with_alpha((f32::from(color.a) / 255.0) * alpha)
+        });
         let cmap = data.config.color_by_magnitude.then(|| {
             crate::render::ColorMap::by_name(&data.config.cmap)
                 .unwrap_or_else(crate::render::ColorMap::viridis)
@@ -845,12 +864,18 @@ impl Plot {
         } else {
             max_mag - min_mag
         };
-        let arrow_width = self.render_scale().points_to_pixels(data.config.width);
+        let arrow_width = self
+            .render_scale()
+            .points_to_pixels(line_width.unwrap_or(data.config.width));
 
         for arrow in &data.arrows {
             let arrow_color = cmap
                 .as_ref()
-                .map(|colormap| colormap.sample((arrow.magnitude - min_mag) / mag_range))
+                .map(|colormap| {
+                    colormap
+                        .sample((arrow.magnitude - min_mag) / mag_range)
+                        .with_alpha(alpha)
+                })
                 .unwrap_or(base_color);
             let (sx1, sy1) = crate::render::skia::map_data_to_pixels_scaled(
                 arrow.start.0,
@@ -920,7 +945,9 @@ impl Plot {
         y_max: f64,
         mode: RenderExecutionMode,
     ) -> Result<()> {
-        let color = series.color.unwrap_or(Color::new(0, 0, 0)); // Default black
+        let base_color = series.color.unwrap_or(Color::new(0, 0, 0));
+        let alpha = series.alpha.unwrap_or(1.0);
+        let color = series.color_with_alpha(Color::new(0, 0, 0)); // Default black
         let line_width = self.dpi_scaled_line_width(series.line_width.unwrap_or(2.0));
         let line_style = series.line_style.clone().unwrap_or(LineStyle::Solid);
         let clip_rect = clip_rect_from_plot_area(plot_area);
@@ -1185,7 +1212,7 @@ impl Plot {
             }
             (SeriesType::Heatmap { data }, ResolvedSeries::Other(_)) => {
                 let heatmap_plot_area = plot_area_from_rect(plot_area, x_min, x_max, y_min, y_max);
-                data.draw_cells_batch(renderer, &heatmap_plot_area, data.config.alpha)?;
+                data.draw_cells_batch(renderer, &heatmap_plot_area, data.config.alpha * alpha)?;
                 self.render_series_overlays_after_raster(
                     series,
                     resolved,
@@ -1298,7 +1325,14 @@ impl Plot {
                     y_min,
                     y_max,
                 );
-                data.render(renderer, &plot_area, &self.display.theme, color)?;
+                data.render_styled(
+                    renderer,
+                    &plot_area,
+                    &self.display.theme,
+                    base_color,
+                    alpha,
+                    series.line_width,
+                )?;
             }
             (SeriesType::Ecdf { data }, ResolvedSeries::Other(_)) => {
                 // Use PlotRender trait to render ECDF
@@ -1312,7 +1346,14 @@ impl Plot {
                     y_min,
                     y_max,
                 );
-                data.render(renderer, &plot_area, &self.display.theme, color)?;
+                data.render_styled(
+                    renderer,
+                    &plot_area,
+                    &self.display.theme,
+                    base_color,
+                    alpha,
+                    series.line_width,
+                )?;
             }
             (SeriesType::Violin { data }, ResolvedSeries::Other(_)) => {
                 // Use PlotRender trait to render Violin
@@ -1326,7 +1367,14 @@ impl Plot {
                     y_min,
                     y_max,
                 );
-                data.render(renderer, &plot_area, &self.display.theme, color)?;
+                data.render_styled(
+                    renderer,
+                    &plot_area,
+                    &self.display.theme,
+                    base_color,
+                    alpha,
+                    series.line_width,
+                )?;
             }
             (SeriesType::Boxen { data }, ResolvedSeries::Other(_)) => {
                 // Use PlotRender trait to render Boxen
@@ -1340,11 +1388,27 @@ impl Plot {
                     y_min,
                     y_max,
                 );
-                data.render(renderer, &plot_area, &self.display.theme, color)?;
+                data.render_styled(
+                    renderer,
+                    &plot_area,
+                    &self.display.theme,
+                    base_color,
+                    alpha,
+                    series.line_width,
+                )?;
             }
             (SeriesType::Quiver { data }, ResolvedSeries::Other(_)) => {
                 self.render_quiver_series_scaled(
-                    renderer, data, plot_area, x_min, x_max, y_min, y_max, color,
+                    renderer,
+                    data,
+                    plot_area,
+                    x_min,
+                    x_max,
+                    y_min,
+                    y_max,
+                    color,
+                    alpha,
+                    series.line_width,
                 )?;
             }
             (SeriesType::Contour { data }, ResolvedSeries::Other(_)) => {
@@ -1359,7 +1423,14 @@ impl Plot {
                     y_min,
                     y_max,
                 );
-                data.render(renderer, &contour_plot_area, &self.display.theme, color)?;
+                data.render_styled(
+                    renderer,
+                    &contour_plot_area,
+                    &self.display.theme,
+                    base_color,
+                    alpha,
+                    series.line_width,
+                )?;
 
                 // Draw colorbar if enabled
                 if data.config.colorbar {
@@ -1413,13 +1484,32 @@ impl Plot {
                 let pie_plot_area = crate::plots::PlotArea::new(
                     pie_x, pie_y, pie_size, pie_size, 0.0, 1.0, 0.0, 1.0,
                 );
-                data.render(renderer, &pie_plot_area, &self.display.theme, color)?;
+                data.render_styled(
+                    renderer,
+                    &pie_plot_area,
+                    &self.display.theme,
+                    base_color,
+                    alpha,
+                    series.line_width,
+                )?;
             }
             (SeriesType::Radar { data }, ResolvedSeries::Other(_)) => {
                 // Use PlotRender trait to render Radar with 1:1 aspect ratio
                 // and extra top padding for title clearance
                 let radar_plot_area = Self::radar_plot_area(plot_area, x_min, x_max, y_min, y_max);
-                data.render(renderer, &radar_plot_area, &self.display.theme, color)?;
+                let mut radar_theme = self.display.theme.clone();
+                if let Some(colors) = &series.resolved_radar_colors {
+                    radar_theme.color_palette = colors.to_vec();
+                }
+                data.render_styled_with_grid(
+                    renderer,
+                    &radar_plot_area,
+                    &radar_theme,
+                    base_color,
+                    alpha,
+                    series.line_width,
+                    Some(&self.layout.grid_style),
+                )?;
             }
             (SeriesType::Polar { data }, ResolvedSeries::Other(_)) => {
                 // Use PlotRender trait to render Polar with 1:1 aspect ratio
@@ -1433,7 +1523,14 @@ impl Plot {
                 let polar_plot_area = crate::plots::PlotArea::new(
                     polar_x, polar_y, polar_size, polar_size, x_min, x_max, y_min, y_max,
                 );
-                data.render(renderer, &polar_plot_area, &self.display.theme, color)?;
+                data.render_styled(
+                    renderer,
+                    &polar_plot_area,
+                    &self.display.theme,
+                    base_color,
+                    alpha,
+                    series.line_width,
+                )?;
             }
             _ => unreachable!("resolved series variant must match its declarative series"),
         }
@@ -1459,7 +1556,7 @@ impl Plot {
         y_max: f64,
         mode: RenderExecutionMode,
     ) -> Result<()> {
-        let color = series.color.unwrap_or(Color::new(0, 0, 0));
+        let color = series.color_with_alpha(Color::new(0, 0, 0));
         let line_width = self.dpi_scaled_line_width(series.line_width.unwrap_or(2.0));
         let line_style = series.line_style.clone().unwrap_or(LineStyle::Solid);
         let clip_rect = (

--- a/src/core/plot/series_manager.rs
+++ b/src/core/plot/series_manager.rs
@@ -26,6 +26,8 @@ use super::{PlotSeries, SeriesType};
 pub struct SeriesManager {
     /// Data series
     pub(crate) series: Vec<PlotSeries>,
+    /// Palette slot reserved for each automatically colored series.
+    pub(crate) auto_color_slots: Vec<Option<usize>>,
     /// Auto-generate colors for series without explicit colors
     pub(crate) auto_color_index: usize,
 }
@@ -35,6 +37,7 @@ impl SeriesManager {
     pub fn new() -> Self {
         Self {
             series: Vec::new(),
+            auto_color_slots: Vec::new(),
             auto_color_index: 0,
         }
     }
@@ -66,9 +69,19 @@ impl SeriesManager {
         color
     }
 
-    /// Add a series to the manager
+    /// Add a series to the manager.
     pub(crate) fn push(&mut self, series: PlotSeries) {
+        self.push_with_auto_color_slot(series, None);
+    }
+
+    /// Add a series and retain its deferred automatic palette slot.
+    pub(crate) fn push_with_auto_color_slot(
+        &mut self,
+        series: PlotSeries,
+        auto_color_slot: Option<usize>,
+    ) {
         self.series.push(series);
+        self.auto_color_slots.push(auto_color_slot);
     }
 
     /// Increment the auto-color index
@@ -141,6 +154,7 @@ impl SeriesManager {
     /// Clear all series
     pub fn clear(&mut self) {
         self.series.clear();
+        self.auto_color_slots.clear();
         self.auto_color_index = 0;
     }
 

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -437,6 +437,7 @@ fn test_plot_series_static_source_helpers_materialize_values() {
         error_config: None,
         inset_layout: None,
         group_id: None,
+        resolved_radar_colors: None,
     };
 
     series.set_color_source_value(Color::RED.into());
@@ -1981,14 +1982,9 @@ fn test_group_without_color_uses_single_palette_color() {
         .line(&x, &y3)
         .end_series();
     assert_eq!(plot.series_mgr.series.len(), 3);
-    assert_eq!(
-        plot.series_mgr.series[0].color,
-        plot.series_mgr.series[1].color
-    );
-    assert_ne!(
-        plot.series_mgr.series[0].color,
-        plot.series_mgr.series[2].color
-    );
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    assert_eq!(frame.style.series[0].color, frame.style.series[1].color);
+    assert_ne!(frame.style.series[0].color, frame.style.series[2].color);
 }
 
 #[test]
@@ -3930,16 +3926,16 @@ fn test_generic_streaming_buffers_are_acknowledged_after_png_and_save() {
 }
 
 #[test]
-fn test_streaming_resolved_plot_acknowledges_exact_captured_sequence() {
+fn test_resolved_frame_acknowledges_exact_captured_sequence() {
     use crate::data::{StreamingRenderState, StreamingXY};
 
     let stream = StreamingXY::new(100);
     stream.push_many(vec![(0.0, 0.0), (1.0, 1.0)]);
     let plot = Plot::new().line_streaming(&stream).end_series();
 
-    let resolved = plot.resolved_plot(0.0);
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
     stream.push(2.0, 4.0);
-    resolved.mark_reactive_sources_rendered();
+    frame.acknowledge_rendered(&plot);
 
     assert_eq!(stream.appended_count(), 1);
     assert_eq!(stream.read_appended_x(), vec![2.0]);
@@ -4938,6 +4934,7 @@ fn test_pie_svg_scales_edge_width_with_dpi() {
         let SeriesType::Pie { data } = &mut plot.series_mgr.series[0].series_type else {
             panic!("expected pie series");
         };
+        let data = Arc::make_mut(data);
         data.config.edge_color = Some(Color::BLACK);
         data.config.edge_width = 2.5;
     }
@@ -5063,6 +5060,141 @@ fn test_mixed_cartesian_radar_renders_svg_with_inset_geometry() {
         svg.contains(">Speed<"),
         "expected radar axis labels in SVG: {svg}"
     );
+}
+
+#[test]
+fn test_radar_internal_palette_is_shared_by_frame_shell_svg_and_legend() {
+    let theme = Theme {
+        color_palette: vec![Color::RED, Color::BLUE, Color::GREEN],
+        ..Theme::default()
+    };
+    let plot: Plot = Plot::new()
+        .theme(theme.clone())
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .radar(&["A", "B", "C"])
+        .add_series("first", &[1.0, 2.0, 3.0])
+        .add_series("second", &[3.0, 2.0, 1.0])
+        .into();
+
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    let colors = frame.style.series[1]
+        .radar_colors
+        .as_ref()
+        .expect("radar colors should resolve");
+    assert_eq!(colors.as_ref(), &[Color::BLUE, Color::GREEN]);
+    assert_eq!(colors[0], theme.get_color(1));
+
+    let shell = plot.resolved_style_shell(&frame.style);
+    let legend = shell.collect_legend_items();
+    assert_eq!(legend.len(), 2);
+    assert!(matches!(
+        legend[0].item_type,
+        LegendItemType::Area {
+            edge_color: Some(Color::BLUE)
+        }
+    ));
+    assert!(matches!(
+        legend[1].item_type,
+        LegendItemType::Area {
+            edge_color: Some(Color::GREEN)
+        }
+    ));
+
+    let svg = plot.render_to_svg().expect("radar SVG should render");
+    assert!(svg.contains("rgb(0,0,255)"));
+    assert!(svg.contains("rgb(0,128,0)"));
+}
+
+#[test]
+fn test_radar_top_level_reactive_color_styles_unconfigured_internal_series_once() {
+    use crate::data::Signal;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_signal = Arc::clone(&calls);
+    let color = Signal::new(move |_| {
+        calls_for_signal.fetch_add(1, Ordering::Relaxed);
+        Color::RED
+    });
+    let plot: Plot = Plot::new()
+        .radar(&["A", "B", "C"])
+        .add_series("configured", &[1.0, 2.0, 3.0])
+        .with_color(Color::GREEN)
+        .add_series("reactive", &[3.0, 2.0, 1.0])
+        .color_source(color)
+        .into();
+
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    let colors = frame.style.series[0]
+        .radar_colors
+        .as_deref()
+        .expect("radar colors should resolve");
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    assert_eq!(colors, &[Color::GREEN, Color::RED]);
+
+    let shell = plot.resolved_style_shell(&frame.style);
+    let legend = shell.collect_legend_items();
+    assert!(matches!(
+        legend[0].item_type,
+        LegendItemType::Area {
+            edge_color: Some(Color::GREEN)
+        }
+    ));
+    assert!(matches!(
+        legend[1].item_type,
+        LegendItemType::Area {
+            edge_color: Some(Color::RED)
+        }
+    ));
+}
+
+#[test]
+fn test_radar_grid_uses_canonical_resolved_style_in_svg() {
+    let grid = GridStyle::default()
+        .color(Color::RED)
+        .alpha(1.0)
+        .line_width(3.0)
+        .line_style(LineStyle::Dashed);
+    let plot: Plot = Plot::new()
+        .with_grid_style(grid.clone())
+        .radar(&["A", "B", "C"])
+        .add_series("series", &[1.0, 2.0, 3.0])
+        .into();
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    assert_eq!(frame.style.grid_style, grid);
+
+    let svg = plot.render_to_svg().expect("radar SVG should render");
+    let grid_line = svg
+        .lines()
+        .find(|line| line.contains("<line ") && line.contains("stroke=\"rgb(255,0,0)\""))
+        .expect("resolved radar grid line should be present");
+    assert!(grid_line.contains("stroke-dasharray="));
+    let width = parse_svg_attr(grid_line, "stroke-width");
+    let expected = plot.render_scale().points_to_pixels(3.0);
+    assert!(
+        (width - expected).abs() < 0.01,
+        "width={width}, expected={expected}"
+    );
+}
+
+#[test]
+fn test_resolved_shell_shares_specialized_payloads() {
+    let plot: Plot = Plot::new()
+        .radar(&["A", "B", "C"])
+        .add_series("large", &[1.0, 2.0, 3.0])
+        .into();
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    let shell = plot.resolved_style_shell(&frame.style);
+    let (SeriesType::Radar { data: original }, SeriesType::Radar { data: resolved }) = (
+        &plot.series_mgr.series[0].series_type,
+        &shell.series_mgr.series[0].series_type,
+    ) else {
+        panic!("expected radar payloads");
+    };
+    assert!(Arc::ptr_eq(original, resolved));
 }
 
 // ========== IntoPlot Trait Tests ==========
@@ -5328,6 +5460,371 @@ fn test_plot_builder_font_family_forwards_to_plot() {
         plot.get_config().typography.family,
         crate::render::FontFamily::Name("New Computer Modern Sans".to_string())
     );
+}
+
+#[test]
+fn test_theme_and_plot_config_follow_last_builder_call_precedence() {
+    let theme = crate::render::Theme::publication();
+    let config = PlotConfig::builder()
+        .font_size(18.0)
+        .font_family("Config Font")
+        .lines(|lines| lines.data_width(4.0).axis_width(2.0).grid_width(1.25))
+        .build();
+
+    let theme_last = Plot::new().plot_config(config.clone()).theme(theme.clone());
+    assert_eq!(
+        theme_last.get_config().typography,
+        theme.to_typography_config()
+    );
+    assert_eq!(theme_last.get_config().lines, theme.to_line_config());
+    assert_eq!(theme_last.layout.grid_style.color, theme.grid_color);
+    assert_eq!(
+        theme_last.layout.grid_style.line_width,
+        theme.to_line_config().grid_width
+    );
+
+    let config_last = Plot::new().theme(theme.clone()).plot_config(config.clone());
+    assert_eq!(config_last.get_config().typography, config.typography);
+    assert_eq!(config_last.get_config().lines, config.lines);
+    assert_eq!(config_last.layout.grid_style.color, theme.grid_color);
+    assert_eq!(
+        config_last.layout.grid_style.line_width,
+        config.lines.grid_width
+    );
+
+    let explicit_grid_last = Plot::new()
+        .theme(theme)
+        .with_grid_style(GridStyle::default().color(Color::RED).line_width(3.0));
+    assert_eq!(explicit_grid_last.layout.grid_style.color, Color::RED);
+    assert_eq!(explicit_grid_last.layout.grid_style.line_width, 3.0);
+}
+
+#[test]
+fn test_default_theme_application_preserves_default_metrics() {
+    let baseline = Plot::new();
+    let themed = Plot::new().theme(Theme::default());
+
+    assert_eq!(
+        baseline.get_config().typography,
+        themed.get_config().typography
+    );
+    assert_eq!(baseline.get_config().lines, themed.get_config().lines);
+}
+
+#[test]
+fn test_new_plot_preserves_established_default_grid_color() {
+    assert_eq!(Plot::new().layout.grid_style, GridStyle::default());
+}
+
+#[test]
+fn test_invalid_theme_base_font_does_not_poison_resolved_typography() {
+    for invalid in [0.0, f32::NAN, f32::INFINITY] {
+        let theme = Theme {
+            font_size: invalid,
+            ..Theme::default()
+        };
+        let plot = Plot::new().theme(theme);
+        let typography = &plot.get_config().typography;
+        assert!(typography.base_size.is_finite() && typography.base_size > 0.0);
+        assert!(typography.title_size().is_finite());
+        assert!(typography.label_size().is_finite());
+        assert!(typography.tick_size().is_finite());
+        assert!(typography.legend_size().is_finite());
+        plot.render()
+            .expect("sanitized theme typography should render");
+    }
+}
+
+#[test]
+fn test_later_theme_and_plot_config_clear_legacy_legend_font_override() {
+    let themed_plot = Plot::new()
+        .legend_font_size(22.0)
+        .theme(Theme::publication());
+    let themed = themed_plot
+        .resolve_frame(0.0)
+        .expect("frame should resolve");
+    assert_eq!(
+        themed.style.legend.font_size,
+        themed.style.config.typography.legend_size()
+    );
+
+    let config = PlotConfig::builder().font_size(16.0).build();
+    let configured_plot = Plot::new().legend_font_size(22.0).plot_config(config);
+    let configured = configured_plot
+        .resolve_frame(0.0)
+        .expect("frame should resolve");
+    assert_eq!(
+        configured.style.legend.font_size,
+        configured.style.config.typography.legend_size()
+    );
+
+    let explicit_last_plot = Plot::new()
+        .theme(Theme::publication())
+        .legend_font_size(22.0);
+    let explicit_last = explicit_last_plot
+        .resolve_frame(0.0)
+        .expect("frame should resolve");
+    assert_eq!(explicit_last.style.legend.font_size, 22.0);
+
+    let font_size_plot = Plot::new().legend_font_size(22.0).font_size(20.0);
+    let font_size_last = font_size_plot
+        .resolve_frame(0.0)
+        .expect("frame should resolve");
+    assert_eq!(font_size_last.style.legend.font_size, 18.0);
+
+    let scaled_plot = Plot::new().legend_font_size(22.0).scale_typography(2.0);
+    let scaled_last = scaled_plot
+        .resolve_frame(0.0)
+        .expect("frame should resolve");
+    assert_eq!(scaled_last.style.legend.font_size, 18.0);
+}
+
+#[test]
+fn test_absent_series_metrics_preserve_established_fallbacks() {
+    let mut plot = Plot::new();
+    plot.add_line(&[0.0, 1.0], &[0.0, 1.0])
+        .expect("line should be added");
+    plot.series_mgr.series[0].marker_style = Some(MarkerStyle::Circle);
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    assert_eq!(frame.style.series[0].line_width, None);
+    assert_eq!(frame.style.series[0].marker_size, None);
+
+    let shell = plot.resolved_style_shell(&frame.style);
+    assert_eq!(shell.series_mgr.series[0].line_width, None);
+    assert_eq!(shell.series_mgr.series[0].marker_size, None);
+
+    let line: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .marker(MarkerStyle::Circle)
+        .into();
+    let line_frame = line.resolve_frame(0.0).expect("line frame should resolve");
+    assert_eq!(line_frame.style.series[0].line_width, None);
+    assert_eq!(line_frame.style.series[0].marker_size, None);
+
+    let scatter: Plot = Plot::new().scatter(&[0.0, 1.0], &[0.0, 1.0]).into();
+    let scatter_frame = scatter
+        .resolve_frame(0.0)
+        .expect("scatter frame should resolve");
+    assert_eq!(scatter_frame.style.series[0].line_width, None);
+    assert_eq!(scatter_frame.style.series[0].marker_size, None);
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn test_parallel_marker_size_uses_resolved_points_and_dpi() {
+    let mut plot: Plot = Plot::new()
+        .dpi(200)
+        .scatter(&[0.0, 1.0], &[0.0, 1.0])
+        .into();
+    plot.series_mgr.series[0].marker_size = Some(9.0);
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    let shell = plot.resolved_style_shell(&frame.style);
+    let series = &shell.series_mgr.series[0];
+    assert_eq!(
+        shell.parallel_marker_size_px(series, 10.0),
+        shell.render_scale().points_to_pixels(9.0)
+    );
+
+    let fallback_plot: Plot = Plot::new()
+        .dpi(200)
+        .scatter(&[0.0, 1.0], &[0.0, 1.0])
+        .into();
+    let fallback_frame = fallback_plot
+        .resolve_frame(0.0)
+        .expect("frame should resolve");
+    let fallback_shell = fallback_plot.resolved_style_shell(&fallback_frame.style);
+    assert_eq!(
+        fallback_shell.parallel_marker_size_px(&fallback_shell.series_mgr.series[0], 10.0),
+        fallback_shell.render_scale().points_to_pixels(10.0)
+    );
+}
+
+#[test]
+fn test_resolved_alpha_reaches_svg_and_legend_once() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .color(Color::RED)
+        .alpha(0.5)
+        .label("alpha")
+        .into();
+    let svg = plot.render_to_svg().expect("SVG should render");
+    assert!(svg.contains("rgba(255,0,0,0.498)"));
+
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    let shell = plot.resolved_style_shell(&frame.style);
+    let items = shell.collect_legend_items();
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0].color.a, 127);
+}
+
+#[test]
+fn test_specialized_kde_svg_uses_resolved_width_and_alpha() {
+    let samples = [0.0, 0.5, 1.0, 1.5, 2.0];
+    let plot: Plot = Plot::new()
+        .kde(&samples)
+        .color(Color::RED)
+        .line_width(4.0)
+        .alpha(0.5)
+        .into();
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    assert_eq!(frame.style.series[0].line_width, Some(4.0));
+    assert_eq!(frame.style.series[0].alpha, 0.5);
+
+    let svg = plot.render_to_svg().expect("KDE SVG should render");
+    let curve = svg
+        .lines()
+        .find(|line| line.contains("<polyline ") && line.contains("rgba(255,0,0,0.498)"))
+        .expect("resolved KDE curve should be present in SVG");
+    let width = parse_svg_attr(curve, "stroke-width");
+    let expected = plot.render_scale().points_to_pixels(4.0);
+    assert!(
+        (width - expected).abs() < 0.01,
+        "width={width}, expected={expected}"
+    );
+}
+
+#[test]
+fn test_shared_f32_style_source_is_sampled_once_across_properties() {
+    use crate::data::Signal;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_signal = Arc::clone(&calls);
+    let value = Signal::new(move |_| {
+        calls_for_signal.fetch_add(1, Ordering::Relaxed);
+        0.5_f32
+    });
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .line_width_source(value.clone())
+        .marker_size_source(value.clone())
+        .alpha_source(value)
+        .into();
+
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    assert_eq!(frame.style.series[0].line_width, Some(0.5));
+    assert_eq!(frame.style.series[0].marker_size, Some(0.5));
+    assert_eq!(frame.style.series[0].alpha, 0.5);
+}
+
+#[test]
+fn test_auto_palette_color_is_resolved_after_late_theme_change() {
+    let x = vec![0.0, 1.0];
+    let y = vec![1.0, 2.0];
+    let plot: Plot = Plot::new().line(&x, &y).into();
+    assert_eq!(plot.series_mgr.series[0].color, None);
+
+    let mut theme = Theme::dark();
+    theme.color_palette = vec![Color::RED, Color::BLUE];
+    let plot = plot.theme(theme);
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+
+    assert_eq!(frame.style.series[0].color, Color::RED);
+}
+
+#[test]
+fn test_resolved_series_metrics_stay_in_points_across_backend_shells() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 0.0])
+        .line_width(3.5)
+        .marker(MarkerStyle::Diamond)
+        .marker_size(9.0)
+        .into();
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    let resolved = &frame.style.series[0];
+    let style_shell = plot.resolved_style_shell(&frame.style);
+    let prepared_shell = plot.prepared_frame_shell_with_style((800, 600), 1.0, &frame.style);
+
+    for backend_shell in [&style_shell, &prepared_shell] {
+        let series = &backend_shell.series_mgr.series[0];
+        assert_eq!(series.line_width, resolved.line_width);
+        assert_eq!(series.marker_size, resolved.marker_size);
+        assert_eq!(series.marker_style, resolved.marker_style);
+    }
+
+    let svg = plot.render_to_svg().expect("SVG should render");
+    let series_polyline = svg
+        .lines()
+        .find(|line| line.contains("<polyline "))
+        .expect("line series should render as a polyline");
+    let svg_width_px = parse_svg_attr(series_polyline, "stroke-width");
+    let expected_width_px =
+        style_shell.dpi_scaled_line_width(resolved.line_width.expect("explicit line width"));
+    assert!(
+        (svg_width_px - expected_width_px).abs() < 0.01,
+        "SVG width {svg_width_px} should match raster width {expected_width_px}"
+    );
+}
+
+#[test]
+fn test_dark_theme_resolves_legend_semantic_colors() {
+    let theme = Theme::dark();
+    let plot: Plot = Plot::new()
+        .theme(theme.clone())
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .label("series")
+        .into();
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+
+    assert_eq!(frame.style.legend.text_color, theme.foreground);
+    assert_eq!(frame.style.legend.style.face_color, theme.background);
+    assert_eq!(frame.style.legend.style.edge_color, Some(theme.grid_color));
+}
+
+#[test]
+fn test_shared_reactive_series_style_is_sampled_once_per_frame() {
+    use crate::data::Signal;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_signal = Arc::clone(&calls);
+    let color = Signal::new(move |_| {
+        calls_for_signal.fetch_add(1, Ordering::Relaxed);
+        Color::BLUE
+    });
+    let x = vec![0.0, 1.0];
+    let y1 = vec![1.0, 2.0];
+    let y2 = vec![2.0, 3.0];
+    let plot = Plot::new().group(|group| group.color_source(color).line(&x, &y1).line(&x, &y2));
+
+    let frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+    assert_eq!(frame.style.series[0].color, Color::BLUE);
+    assert_eq!(frame.style.series[1].color, Color::BLUE);
+
+    let style_shell = plot.resolved_style_shell(&frame.style);
+    let _ = style_shell.collect_legend_items();
+    assert_eq!(calls.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn test_backend_getter_does_not_sample_reactive_style() {
+    use crate::data::Signal;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let calls_for_signal = Arc::clone(&calls);
+    let color = Signal::new(move |_| {
+        calls_for_signal.fetch_add(1, Ordering::Relaxed);
+        Color::RED
+    });
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .color_source(color)
+        .into();
+
+    assert_eq!(plot.resolved_backend_name(), "skia");
+    assert_eq!(calls.load(Ordering::Relaxed), 0);
 }
 
 #[cfg(feature = "typst-math")]

--- a/src/core/plot/types.rs
+++ b/src/core/plot/types.rs
@@ -313,6 +313,8 @@ pub(crate) struct PlotSeries {
     pub(super) inset_layout: Option<InsetLayout>,
     /// Optional group ID if this series was created inside `Plot::group(...)`.
     pub(super) group_id: Option<usize>,
+    /// Frame-resolved colors for multi-series radar payloads.
+    pub(super) resolved_radar_colors: Option<Arc<[Color]>>,
 }
 
 impl PlotSeries {
@@ -421,11 +423,11 @@ impl PlotSeries {
         default_color: Color,
         theme: &Theme,
     ) -> Option<LegendItem> {
-        let color = self.resolved_color(default_color, 0.0);
-        let line_width = self.resolved_line_width(theme.line_width, 0.0);
-        let line_style = self.resolved_line_style(LineStyle::Solid, 0.0);
-        let marker_style = self.resolved_marker_style(MarkerStyle::Circle, 0.0);
-        let marker_size = self.resolved_marker_size(6.0, 0.0);
+        let color = self.color_with_alpha(default_color);
+        let line_width = self.line_width.unwrap_or(theme.line_width);
+        let line_style = self.line_style.clone().unwrap_or(LineStyle::Solid);
+        let marker_style = self.marker_style.unwrap_or(MarkerStyle::Circle);
+        let marker_size = self.marker_size.unwrap_or(6.0);
 
         let item_type = match &self.series_type {
             SeriesType::Line { .. } => {
@@ -484,9 +486,6 @@ impl PlotSeries {
     ///
     /// Returns a Vec of legend items, expanding radar series into individual entries per data series.
     pub(super) fn to_legend_items(&self, base_color_idx: usize, theme: &Theme) -> Vec<LegendItem> {
-        let line_width = self.resolved_line_width(theme.line_width, 0.0);
-        let line_style = self.resolved_line_style(LineStyle::Solid, 0.0);
-
         match &self.series_type {
             SeriesType::Radar { data } => {
                 // For radar charts, create a legend item for each internal series
@@ -495,20 +494,29 @@ impl PlotSeries {
                     .iter()
                     .enumerate()
                     .map(|(idx, radar_series)| {
-                        let color = data
-                            .config
-                            .colors
+                        let color = self
+                            .resolved_radar_colors
                             .as_ref()
                             .and_then(|colors| colors.get(idx).copied())
+                            .or_else(|| {
+                                data.config
+                                    .colors
+                                    .as_ref()
+                                    .and_then(|colors| colors.get(idx).copied())
+                                    .filter(|color| *color != Color::TRANSPARENT)
+                            })
                             .unwrap_or_else(|| theme.get_color(base_color_idx + idx));
                         // Use a more visible alpha for legend swatches (0.6 instead of fill_alpha)
                         // This ensures legend items are clearly visible while still showing fill style
-                        let fill_color = color.with_alpha(0.6);
+                        let series_alpha = self.alpha.unwrap_or(1.0);
+                        let color_alpha = f32::from(color.a) / 255.0;
+                        let edge_color = color.with_alpha(color_alpha * series_alpha);
+                        let fill_color = color.with_alpha(color_alpha * 0.6 * series_alpha);
                         LegendItem {
                             label: radar_series.label.clone(),
                             color: fill_color,
                             item_type: LegendItemType::Area {
-                                edge_color: Some(color), // Use full-opacity color for edge
+                                edge_color: Some(edge_color),
                             },
                             has_error_bars: false,
                         }
@@ -682,6 +690,7 @@ impl PlotSeries {
             error_config: self.error_config.clone(),
             inset_layout: self.inset_layout,
             group_id: self.group_id,
+            resolved_radar_colors: self.resolved_radar_colors.clone(),
         }
     }
 
@@ -793,86 +802,10 @@ impl PlotSeries {
         }
     }
 
-    pub(super) fn resolved_color(&self, default_color: Color, time: f64) -> Color {
-        self.color_source
-            .as_ref()
-            .map(|source| source.resolve(time))
-            .or(self.color)
-            .unwrap_or(default_color)
-    }
-
-    pub(super) fn resolved_line_width(&self, default_width: f32, time: f64) -> f32 {
-        self.line_width_source
-            .as_ref()
-            .map(|source| source.resolve(time))
-            .or(self.line_width)
-            .unwrap_or(default_width)
-            .max(0.1)
-    }
-
-    pub(super) fn resolved_line_style(&self, default_style: LineStyle, time: f64) -> LineStyle {
-        self.line_style_source
-            .as_ref()
-            .map(|source| source.resolve(time))
-            .or_else(|| self.line_style.clone())
-            .unwrap_or(default_style)
-    }
-
-    pub(super) fn resolved_marker_style(
-        &self,
-        default_style: MarkerStyle,
-        time: f64,
-    ) -> MarkerStyle {
-        self.marker_style_source
-            .as_ref()
-            .map(|source| source.resolve(time))
-            .or(self.marker_style)
-            .unwrap_or(default_style)
-    }
-
-    pub(super) fn resolved_marker_size(&self, default_size: f32, time: f64) -> f32 {
-        self.marker_size_source
-            .as_ref()
-            .map(|source| source.resolve(time))
-            .or(self.marker_size)
-            .unwrap_or(default_size)
-            .max(0.1)
-    }
-
-    pub(super) fn resolved_alpha(&self, default_alpha: f32, time: f64) -> f32 {
-        self.alpha_source
-            .as_ref()
-            .map(|source| source.resolve(time))
-            .or(self.alpha)
-            .unwrap_or(default_alpha)
-            .clamp(0.0, 1.0)
-    }
-
-    pub(super) fn resolve_style_sources(&mut self, time: f64) {
-        if let Some(color_source) = &self.color_source {
-            self.color = Some(color_source.resolve(time));
-        }
-        self.color_source = None;
-        if let Some(line_width_source) = &self.line_width_source {
-            self.line_width = Some(line_width_source.resolve(time).max(0.1));
-        }
-        self.line_width_source = None;
-        if let Some(line_style_source) = &self.line_style_source {
-            self.line_style = Some(line_style_source.resolve(time));
-        }
-        self.line_style_source = None;
-        if let Some(marker_style_source) = &self.marker_style_source {
-            self.marker_style = Some(marker_style_source.resolve(time));
-        }
-        self.marker_style_source = None;
-        if let Some(marker_size_source) = &self.marker_size_source {
-            self.marker_size = Some(marker_size_source.resolve(time).max(0.1));
-        }
-        self.marker_size_source = None;
-        if let Some(alpha_source) = &self.alpha_source {
-            self.alpha = Some(alpha_source.resolve(time).clamp(0.0, 1.0));
-        }
-        self.alpha_source = None;
+    pub(super) fn color_with_alpha(&self, default_color: Color) -> Color {
+        let color = self.color.unwrap_or(default_color);
+        let alpha = self.alpha.unwrap_or(1.0).clamp(0.0, 1.0);
+        color.with_alpha((f32::from(color.a) / 255.0) * alpha)
     }
 }
 
@@ -912,43 +845,43 @@ pub(crate) enum SeriesType {
         config: crate::plots::boxplot::BoxPlotConfig,
     },
     Heatmap {
-        data: crate::plots::heatmap::HeatmapData,
+        data: Arc<crate::plots::heatmap::HeatmapData>,
     },
     /// KDE (Kernel Density Estimation) plot
     Kde {
-        data: crate::plots::KdeData,
+        data: Arc<crate::plots::KdeData>,
     },
     /// ECDF (Empirical Cumulative Distribution Function) plot
     Ecdf {
-        data: crate::plots::EcdfData,
+        data: Arc<crate::plots::EcdfData>,
     },
     /// Violin plot
     Violin {
-        data: crate::plots::ViolinData,
+        data: Arc<crate::plots::ViolinData>,
     },
     /// Boxen (Letter-Value) plot
     Boxen {
-        data: crate::plots::BoxenData,
+        data: Arc<crate::plots::BoxenData>,
     },
     /// Contour plot
     Contour {
-        data: crate::plots::continuous::contour::ContourPlotData,
+        data: Arc<crate::plots::continuous::contour::ContourPlotData>,
     },
     /// Pie chart
     Pie {
-        data: crate::plots::composition::pie::PieData,
+        data: Arc<crate::plots::composition::pie::PieData>,
     },
     /// Radar chart
     Radar {
-        data: crate::plots::polar::radar::RadarPlotData,
+        data: Arc<crate::plots::polar::radar::RadarPlotData>,
     },
     /// Polar plot
     Polar {
-        data: crate::plots::polar::polar_plot::PolarPlotData,
+        data: Arc<crate::plots::polar::polar_plot::PolarPlotData>,
     },
     /// Quiver vector field plot
     Quiver {
-        data: crate::plots::QuiverPlotData,
+        data: Arc<crate::plots::QuiverPlotData>,
     },
 }
 
@@ -1408,8 +1341,29 @@ pub(crate) struct ResolvedStreamingPair {
     pub(super) render_state: crate::data::StreamingRenderState,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedSeriesStyle {
+    pub(super) color: Color,
+    pub(super) line_width: Option<f32>,
+    pub(super) line_style: LineStyle,
+    pub(super) marker_style: Option<MarkerStyle>,
+    pub(super) marker_size: Option<f32>,
+    pub(super) alpha: f32,
+    pub(super) radar_colors: Option<Arc<[Color]>>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ResolvedStyle {
+    pub(super) theme: Theme,
+    pub(super) config: PlotConfig,
+    pub(super) grid_style: GridStyle,
+    pub(super) legend: Legend,
+    pub(super) series: Vec<ResolvedSeriesStyle>,
+}
+
 pub(crate) struct ResolvedFrame<'a> {
     pub(super) series: Vec<ResolvedSeries<'a>>,
+    pub(super) style: ResolvedStyle,
     pub(super) title: Option<String>,
     pub(super) xlabel: Option<String>,
     pub(super) ylabel: Option<String>,

--- a/src/data/observable.rs
+++ b/src/data/observable.rs
@@ -385,6 +385,10 @@ impl<T> Observable<T> {
         Arc::ptr_eq(&self.data, &other.data)
     }
 
+    pub(crate) fn source_id(&self) -> usize {
+        Arc::as_ptr(&self.data) as usize
+    }
+
     /// Increment the version and notify all subscribers
     fn bump_version(&self) {
         self.version.fetch_add(1, Ordering::Release);

--- a/src/data/signal.rs
+++ b/src/data/signal.rs
@@ -95,6 +95,10 @@ impl<T> Signal<T> {
         Arc::ptr_eq(&self.eval, &other.eval)
     }
 
+    pub(crate) fn source_id(&self) -> usize {
+        Arc::as_ptr(&self.eval) as *const () as usize
+    }
+
     /// Transform the signal's output using a mapping function.
     ///
     /// # Arguments

--- a/src/plots/composition/pie.rs
+++ b/src/plots/composition/pie.rs
@@ -409,7 +409,19 @@ impl PlotRender for PieData {
         renderer: &mut SkiaRenderer,
         area: &PlotArea,
         theme: &Theme,
+        color: Color,
+    ) -> Result<()> {
+        self.render_styled(renderer, area, theme, color, 1.0, None)
+    }
+
+    fn render_styled(
+        &self,
+        renderer: &mut SkiaRenderer,
+        area: &PlotArea,
+        theme: &Theme,
         _color: Color,
+        alpha: f32,
+        line_width: Option<f32>,
     ) -> Result<()> {
         if self.wedges.is_empty() {
             return Ok(());
@@ -435,18 +447,21 @@ impl PlotRender for PieData {
             (0..screen_data.wedges.len())
                 .map(|i| palette[i % palette.len()])
                 .collect()
-        };
+        }
+        .into_iter()
+        .map(|color| color.with_alpha((f32::from(color.a) / 255.0) * alpha.clamp(0.0, 1.0)))
+        .collect::<Vec<_>>();
 
         // Number of segments per arc for smooth curves
         let segments = 64;
         let render_scale = renderer.render_scale();
-        let edge_width_px = render_scale.points_to_pixels(config.edge_width);
+        let edge_width_px = render_scale.points_to_pixels(line_width.unwrap_or(config.edge_width));
         let label_font_size_px = render_scale.points_to_pixels(config.label_font_size);
         let shadow_offset_px = render_scale.points_to_pixels(config.shadow as f32) as f64;
 
         // Draw shadow if configured
         if config.shadow > 0.0 {
-            let shadow_color = Color::new(100, 100, 100).with_alpha(0.3);
+            let shadow_color = Color::new(100, 100, 100).with_alpha(0.3 * alpha);
             for wedge in &screen_data.wedges {
                 let polygon = wedge.as_polygon(segments);
                 let shadow_polygon: Vec<(f32, f32)> = polygon
@@ -476,6 +491,8 @@ impl PlotRender for PieData {
 
             // Draw edge if configured
             if let Some(edge_color) = config.edge_color {
+                let edge_color = edge_color
+                    .with_alpha((f32::from(edge_color.a) / 255.0) * alpha.clamp(0.0, 1.0));
                 renderer.draw_polygon_outline(&polygon_f32, edge_color, edge_width_px)?;
             }
         }

--- a/src/plots/continuous/contour.rs
+++ b/src/plots/continuous/contour.rs
@@ -591,8 +591,7 @@ impl PlotRender for ContourPlotData {
         // Get colormap for level coloring
         let cmap = ColorMap::by_name(&config.cmap).unwrap_or_else(ColorMap::viridis);
 
-        // Use provided alpha or config alpha
-        let effective_alpha = if alpha != 1.0 { alpha } else { config.alpha };
+        let effective_alpha = config.alpha * alpha.clamp(0.0, 1.0);
         let effective_line_width = renderer.render_scale().points_to_pixels(
             line_width.unwrap_or_else(|| resolver.line_width(Some(config.line_width))),
         );
@@ -631,6 +630,8 @@ impl PlotRender for ContourPlotData {
                         color
                     }
                 });
+                let line_color =
+                    line_color.with_alpha((f32::from(line_color.a) / 255.0) * effective_alpha);
 
                 // Draw each contour segment (each segment is (x1, y1, x2, y2))
                 for &(x1, y1, x2, y2) in &level.segments {

--- a/src/plots/distribution/boxen.rs
+++ b/src/plots/distribution/boxen.rs
@@ -319,23 +319,38 @@ impl PlotRender for BoxenData {
         _theme: &Theme,
         color: Color,
     ) -> Result<()> {
+        self.render_styled(renderer, area, _theme, color, 1.0, None)
+    }
+
+    fn render_styled(
+        &self,
+        renderer: &mut SkiaRenderer,
+        area: &PlotArea,
+        _theme: &Theme,
+        color: Color,
+        alpha: f32,
+        line_width: Option<f32>,
+    ) -> Result<()> {
         if self.boxes.is_empty() {
             return Ok(());
         }
 
         let config = &self.config;
         let render_scale = renderer.render_scale();
-        let line_width_px = render_scale.points_to_pixels(config.line_width);
+        let line_width_points = line_width.unwrap_or(config.line_width);
+        let line_width_px = render_scale.points_to_pixels(line_width_points);
         let median_line_width_px = render_scale.points_to_pixels(2.0);
         let outlier_size_px = render_scale.points_to_pixels(config.outlier_size);
         let center = 0.5; // Centered position for single boxen
+        let base_color = config.color.unwrap_or(color);
+        let base_color =
+            base_color.with_alpha((f32::from(base_color.a) / 255.0) * alpha.clamp(0.0, 1.0));
 
         // Draw boxes from outermost to innermost (so inner boxes overlay outer)
         for (i, boxen_box) in self.boxes.iter().enumerate() {
             // Generate saturation gradient (lighter toward outside)
             let saturation_factor = 1.0 - (i as f32 / self.boxes.len() as f32) * config.saturation;
-            let box_color = config.color.unwrap_or(color);
-            let adjusted_color = adjust_saturation(box_color, saturation_factor);
+            let adjusted_color = adjust_saturation(base_color, saturation_factor);
 
             // Get rectangle vertices
             let rect = boxen_rect(boxen_box, center, config.orient);
@@ -352,10 +367,10 @@ impl PlotRender for BoxenData {
             }
 
             // Draw outline
-            if config.line_width > 0.0 {
+            if line_width_points > 0.0 {
                 let mut outline = screen_points.clone();
                 outline.push(screen_points[0]); // Close the path
-                renderer.draw_polyline(&outline, color, line_width_px, LineStyle::Solid)?;
+                renderer.draw_polyline(&outline, base_color, line_width_px, LineStyle::Solid)?;
             }
         }
 
@@ -370,7 +385,7 @@ impl PlotRender for BoxenData {
                     y,
                     x2,
                     y,
-                    Color::new(255, 255, 255),
+                    Color::new(255, 255, 255).with_alpha(alpha),
                     median_line_width_px,
                     LineStyle::Solid,
                 )?;
@@ -383,7 +398,7 @@ impl PlotRender for BoxenData {
                     y1,
                     x,
                     y2,
-                    Color::new(255, 255, 255),
+                    Color::new(255, 255, 255).with_alpha(alpha),
                     median_line_width_px,
                     LineStyle::Solid,
                 )?;
@@ -402,7 +417,7 @@ impl PlotRender for BoxenData {
                     py,
                     outlier_size_px,
                     crate::render::MarkerStyle::Circle,
-                    color,
+                    base_color,
                 )?;
             }
         }

--- a/src/plots/distribution/ecdf.rs
+++ b/src/plots/distribution/ecdf.rs
@@ -310,6 +310,18 @@ impl PlotRender for EcdfData {
         _theme: &Theme,
         color: Color,
     ) -> Result<()> {
+        self.render_styled(renderer, area, _theme, color, 1.0, None)
+    }
+
+    fn render_styled(
+        &self,
+        renderer: &mut SkiaRenderer,
+        area: &PlotArea,
+        _theme: &Theme,
+        color: Color,
+        alpha: f32,
+        line_width: Option<f32>,
+    ) -> Result<()> {
         use crate::render::LineStyle;
 
         if self.step_vertices.is_empty() {
@@ -318,7 +330,7 @@ impl PlotRender for EcdfData {
 
         // Draw confidence interval band if present
         if let (Some(ci_lower), Some(ci_upper)) = (&self.ci_lower, &self.ci_upper) {
-            let fill_color = color.with_alpha(0.2);
+            let fill_color = color.with_alpha((f32::from(color.a) / 255.0) * 0.2 * alpha);
 
             // Create polygon for CI band
             let mut polygon_points: Vec<(f32, f32)> = Vec::new();
@@ -346,12 +358,13 @@ impl PlotRender for EcdfData {
             .iter()
             .map(|(x, y)| area.data_to_screen(*x, *y))
             .collect();
+        let line_color = color.with_alpha((f32::from(color.a) / 255.0) * alpha);
 
         if line_points.len() >= 2 {
             let line_width = renderer
                 .render_scale()
-                .points_to_pixels(self.config.line_width);
-            renderer.draw_polyline(&line_points, color, line_width, LineStyle::Solid)?;
+                .points_to_pixels(line_width.unwrap_or(self.config.line_width));
+            renderer.draw_polyline(&line_points, line_color, line_width, LineStyle::Solid)?;
         }
 
         // Draw markers at data points if enabled
@@ -366,7 +379,7 @@ impl PlotRender for EcdfData {
                     py,
                     marker_size,
                     crate::render::MarkerStyle::Circle,
-                    color,
+                    line_color,
                 )?;
             }
         }

--- a/src/plots/distribution/kde.rs
+++ b/src/plots/distribution/kde.rs
@@ -433,13 +433,14 @@ impl PlotRender for KdeData {
             polygon.extend_from_slice(&points);
             polygon.push((points[points.len() - 1].0, baseline_y));
 
-            let fill_alpha = self.config.fill_alpha * alpha.clamp(0.0, 1.0);
+            let fill_alpha =
+                (f32::from(color.a) / 255.0) * self.config.fill_alpha * alpha.clamp(0.0, 1.0);
             let fill_color = color.with_alpha(fill_alpha);
             renderer.draw_filled_polygon(&polygon, fill_color)?;
         }
 
         // Draw the line
-        let actual_color = color.with_alpha(alpha.clamp(0.0, 1.0));
+        let actual_color = color.with_alpha((f32::from(color.a) / 255.0) * alpha.clamp(0.0, 1.0));
         renderer.draw_polyline(&points, actual_color, actual_line_width, LineStyle::Solid)?;
 
         Ok(())

--- a/src/plots/distribution/violin.rs
+++ b/src/plots/distribution/violin.rs
@@ -600,12 +600,10 @@ impl PlotRender for ViolinData {
         let clip_rect = (area.x, area.y, area.width, area.height);
 
         // Use StyleResolver for fill color
-        let fill_alpha = if config.fill_alpha != 0.7 {
-            config.fill_alpha // User override
-        } else {
-            alpha.clamp(0.0, 1.0) // Theme/caller provided
-        };
-        let fill_color = config.fill_color.unwrap_or(color).with_alpha(fill_alpha);
+        let fill_base = config.fill_color.unwrap_or(color);
+        let fill_alpha =
+            (f32::from(fill_base.a) / 255.0) * config.fill_alpha * alpha.clamp(0.0, 1.0);
+        let fill_color = fill_base.with_alpha(fill_alpha);
 
         // Draw filled violin with clipping to plot area
         if screen_points.len() >= 3 {
@@ -617,6 +615,8 @@ impl PlotRender for ViolinData {
             line_width.unwrap_or_else(|| resolver.line_width(Some(config.line_width))),
         );
         let line_color = resolver.edge_color(color, config.line_color);
+        let line_color =
+            line_color.with_alpha((f32::from(line_color.a) / 255.0) * alpha.clamp(0.0, 1.0));
 
         // Draw outline with clipping
         if screen_points.len() >= 2 && actual_line_width > 0.0 {

--- a/src/plots/error/errorbar.rs
+++ b/src/plots/error/errorbar.rs
@@ -427,7 +427,8 @@ impl PlotRender for ErrorBarData {
         }
 
         let config = &self.config;
-        let bar_color = config.color.unwrap_or(color).with_alpha(config.alpha);
+        let bar_color = config.color.unwrap_or(color);
+        let bar_color = bar_color.with_alpha((f32::from(bar_color.a) / 255.0) * config.alpha);
 
         // Convert ErrorLineStyle to LineStyle (using a helper fn to avoid move issues)
         let get_line_style = || match config.line_style {

--- a/src/plots/heatmap.rs
+++ b/src/plots/heatmap.rs
@@ -688,8 +688,7 @@ impl PlotRender for HeatmapData {
         let config = &self.config;
         let _resolver = StyleResolver::new(theme);
 
-        // Use provided alpha or config alpha
-        let effective_alpha = if alpha != 1.0 { alpha } else { config.alpha };
+        let effective_alpha = config.alpha * alpha.clamp(0.0, 1.0);
 
         self.draw_cells_batch(renderer, area, effective_alpha)
     }

--- a/src/plots/polar/polar_plot.rs
+++ b/src/plots/polar/polar_plot.rs
@@ -426,20 +426,36 @@ impl PlotRender for PolarPlotData {
         theme: &Theme,
         color: Color,
     ) -> Result<()> {
+        self.render_styled(renderer, area, theme, color, 1.0, None)
+    }
+
+    fn render_styled(
+        &self,
+        renderer: &mut SkiaRenderer,
+        area: &PlotArea,
+        theme: &Theme,
+        color: Color,
+        alpha: f32,
+        line_width: Option<f32>,
+    ) -> Result<()> {
         if self.points.is_empty() {
             return Ok(());
         }
 
         let config = &self.config;
-        let line_color = config.color.unwrap_or(color);
+        let base_color = config.color.unwrap_or(color);
+        let line_color =
+            base_color.with_alpha((f32::from(base_color.a) / 255.0) * alpha.clamp(0.0, 1.0));
         let render_scale = renderer.render_scale();
-        let line_width_px = render_scale.points_to_pixels(config.line_width);
+        let line_width_px = render_scale.points_to_pixels(line_width.unwrap_or(config.line_width));
         let marker_size_px = render_scale.points_to_pixels(config.marker_size);
         let label_font_size_px = render_scale.points_to_pixels(config.label_font_size);
 
         // Draw fill if enabled
         if config.fill && !self.fill_polygon.is_empty() {
-            let fill_color = line_color.with_alpha(config.fill_alpha);
+            let fill_color = base_color.with_alpha(
+                (f32::from(base_color.a) / 255.0) * config.fill_alpha * alpha.clamp(0.0, 1.0),
+            );
             let screen_polygon: Vec<(f32, f32)> = self
                 .fill_polygon
                 .iter()

--- a/src/plots/polar/radar.rs
+++ b/src/plots/polar/radar.rs
@@ -470,6 +470,7 @@ impl PlotRender for RadarPlotData {
                 .colors
                 .as_ref()
                 .and_then(|colors| colors.get(series_idx).copied())
+                .filter(|color| *color != Color::TRANSPARENT)
                 .unwrap_or_else(|| theme.get_color(series_idx));
 
             // Draw fill if enabled
@@ -530,6 +531,19 @@ impl PlotRender for RadarPlotData {
         alpha: f32,
         line_width: Option<f32>,
     ) -> Result<()> {
+        self.render_styled_with_grid(renderer, area, theme, color, alpha, line_width, None)
+    }
+
+    fn render_styled_with_grid(
+        &self,
+        renderer: &mut SkiaRenderer,
+        area: &PlotArea,
+        theme: &Theme,
+        _color: Color,
+        alpha: f32,
+        line_width: Option<f32>,
+        grid_style: Option<&crate::core::GridStyle>,
+    ) -> Result<()> {
         if self.series.is_empty() {
             return Ok(());
         }
@@ -545,9 +559,15 @@ impl PlotRender for RadarPlotData {
         let scaled_marker_size = render_scale.points_to_pixels(config.marker_size);
 
         // Draw grid rings
-        if config.show_grid {
-            let grid_color = theme.grid_color;
-            let grid_line_width = render_scale.logical_pixels_to_pixels(0.5);
+        if config.show_grid && grid_style.is_none_or(|style| style.visible) {
+            let grid_color = grid_style.map_or(theme.grid_color, |style| {
+                style.color.with_alpha(style.alpha)
+            });
+            let grid_line_width =
+                render_scale.points_to_pixels(grid_style.map_or(0.5, |style| style.line_width));
+            let grid_line_style = grid_style
+                .map(|style| style.line_style.clone())
+                .unwrap_or(LineStyle::Solid);
             for ring in &self.grid_rings {
                 if ring.len() < 2 {
                     continue;
@@ -565,7 +585,7 @@ impl PlotRender for RadarPlotData {
                         sy2,
                         grid_color,
                         grid_line_width,
-                        LineStyle::Solid,
+                        grid_line_style.clone(),
                     )?;
                 }
             }
@@ -581,7 +601,7 @@ impl PlotRender for RadarPlotData {
                     sy2,
                     grid_color,
                     grid_line_width,
-                    LineStyle::Solid,
+                    grid_line_style.clone(),
                 )?;
             }
         }
@@ -602,15 +622,14 @@ impl PlotRender for RadarPlotData {
                 .colors
                 .as_ref()
                 .and_then(|colors| colors.get(series_idx).copied())
+                .filter(|color| *color != Color::TRANSPARENT)
                 .unwrap_or_else(|| theme.get_color(series_idx));
+            let series_alpha = (f32::from(series_color.a) / 255.0) * alpha.clamp(0.0, 1.0);
+            let stroke_color = series_color.with_alpha(series_alpha);
 
             // Draw fill if enabled - use provided alpha
             if config.fill && !series.polygon.is_empty() {
-                let fill_alpha = if alpha != 1.0 {
-                    alpha * config.fill_alpha
-                } else {
-                    config.fill_alpha
-                };
+                let fill_alpha = series_alpha * config.fill_alpha;
                 let fill_color = series_color.with_alpha(fill_alpha);
                 let screen_polygon: Vec<(f32, f32)> = series
                     .polygon
@@ -633,7 +652,7 @@ impl PlotRender for RadarPlotData {
                         sy1,
                         sx2,
                         sy2,
-                        series_color,
+                        stroke_color,
                         effective_line_width,
                         LineStyle::Solid,
                     )?;
@@ -649,7 +668,7 @@ impl PlotRender for RadarPlotData {
                         sy,
                         scaled_marker_size,
                         MarkerStyle::Circle,
-                        series_color,
+                        stroke_color,
                     )?;
                 }
             }

--- a/src/plots/traits.rs
+++ b/src/plots/traits.rs
@@ -318,6 +318,20 @@ pub trait PlotRender: PlotData {
     ) -> Result<()> {
         self.render(renderer, area, theme, color)
     }
+
+    /// Render with resolved plot-level grid styling when the plot type owns its axes.
+    fn render_styled_with_grid(
+        &self,
+        renderer: &mut SkiaRenderer,
+        area: &PlotArea,
+        theme: &Theme,
+        color: Color,
+        alpha: f32,
+        line_width: Option<f32>,
+        _grid_style: Option<&crate::core::GridStyle>,
+    ) -> Result<()> {
+        self.render_styled(renderer, area, theme, color, alpha, line_width)
+    }
 }
 
 /// Trait for filled shapes with optional edge styling

--- a/src/render/theme.rs
+++ b/src/render/theme.rs
@@ -502,16 +502,30 @@ impl Theme {
         use super::FontFamily;
         use crate::core::config::TypographyConfig;
 
+        let defaults = TypographyConfig::default();
+        let base_size = if self.font_size.is_finite() && self.font_size > 0.0 {
+            self.font_size
+        } else {
+            defaults.base_size
+        };
+        let scale = |size: f32, fallback: f32| {
+            if size.is_finite() && size > 0.0 {
+                size / base_size
+            } else {
+                fallback
+            }
+        };
+
         // Preserve exact font family names while keeping generic CSS family
         // names mapped to their corresponding portable family.
         let family = FontFamily::from(self.font_family.as_str());
 
         TypographyConfig {
-            base_size: self.font_size,
-            title_scale: self.title_font_size / self.font_size,
-            label_scale: self.axis_label_font_size / self.font_size,
-            tick_scale: self.tick_label_font_size / self.font_size,
-            legend_scale: self.legend_font_size / self.font_size,
+            base_size,
+            title_scale: scale(self.title_font_size, defaults.title_scale),
+            label_scale: scale(self.axis_label_font_size, defaults.label_scale),
+            tick_scale: scale(self.tick_label_font_size, defaults.tick_scale),
+            legend_scale: scale(self.legend_font_size, defaults.legend_scale),
             family,
             title_weight: super::FontWeight::Normal,
         }
@@ -524,11 +538,12 @@ impl Theme {
     pub fn to_line_config(&self) -> crate::core::config::LineConfig {
         use crate::core::config::LineConfig;
 
+        let scale = self.line_width / 1.5;
         LineConfig {
             data_width: self.line_width,
-            axis_width: self.line_width * 0.5,
-            grid_width: self.line_width * 0.3,
-            tick_width: self.line_width * 0.4,
+            axis_width: 0.8 * scale,
+            grid_width: 0.5 * scale,
+            tick_width: 0.6 * scale,
             tick_length: 4.0, // Standard tick length
         }
     }


### PR DESCRIPTION
## Summary

- resolve plot and series styling once per frame
- keep raster, SVG, legends, specialized plots, and interactive rendering on one style contract
- preserve theme/config last-call precedence and reactive style sampling

## Validation

- focused theme, resolved-style, SVG, and interactive tests
- Rustfmt and all-target/all-feature Clippy
