### PR TITLE
Report truthful backend execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ SVG export is available without enabling the legacy `svg` feature.
 ## Backend Notes
 
 `.backend(...)`, `.auto_optimize()`, and `.get_backend_name()` store or report
-backend preference metadata. Use `.resolved_backend_name()` to inspect the
-backend that the public PNG render/save path will use for the current plot.
-Unsupported optimized backend preferences fall back to the Skia reference raster
-path for output parity. `auto_optimize()` keeps public PNG output on the normal
-visual path; supported large scatter workloads resolve to DataShader only when
-that backend is explicitly configured.
+backend preference metadata. `auto_optimize()` conservatively selects Skia rather
+than advertising a backend that cannot execute across every public raster path.
+Use `.resolved_backend_name()` for the native `Plot` PNG path, or
+`.backend_resolution(...)` to inspect the requested backend, actual backend, and
+any explicit Skia fallback reason for a raster operation. Supported scatter
+workloads resolve to DataShader only when that backend is explicitly configured.
 
 Use release builds and benchmark your actual workload before adding optional
 performance features. See [Backend Selection](docs/guide/07_backends.md) and

--- a/docs/guide/07_backends.md
+++ b/docs/guide/07_backends.md
@@ -33,10 +33,13 @@ There are two separate concepts in the current implementation:
    - `.resolved_backend_name()`
 
 The stored backend preference is visible through `get_backend_name()`.
-`resolved_backend_name()` reports the backend that the public PNG path will use
-for the current plot. `auto_optimize()` preserves the normal visual path for
-public PNG output; explicit DataShader remains available for density-rendered
-scatter output.
+`resolved_backend_name()` reports the backend that the native `Plot` PNG path
+will use for the current plot. `backend_resolution(BackendOperation::...)`
+separates the requested and actual backends and exposes an explicit Skia
+fallback reason. Prepared plots and embedded frames use
+`BackendOperation::RasterImage`; interactive base frames use
+`BackendOperation::Interactive`. Explicit DataShader remains available for
+compatible native `Plot` PNG output.
 
 ## GPUI Embedded Interactive Backend
 
@@ -69,13 +72,14 @@ Host applications can also trigger the same built-in actions directly from the
 
 ### What `.auto_optimize()` does today
 
-`.auto_optimize()` stores a backend choice based on total point count:
-
-- `< 1_000` points: `Skia`
-- `1_000..100_000`: `Parallel` if the `parallel` feature is enabled, otherwise `Skia`
-- `>= 100_000`: `GPU` if the `gpu` feature is enabled, otherwise `DataShader`
+`.auto_optimize()` conservatively stores `Skia`, because it is the only backend
+that can execute across every current public raster operation, target, feature
+set, and series mix. It does not advertise Parallel, GPU, or DataShader solely
+from point count.
 
 If you set `.backend(...)` first, `.auto_optimize()` keeps that explicit choice.
+Use `backend_resolution(...)` when you need the actual backend and any fallback
+reason for a specific raster operation.
 
 ```rust
 use ruviz::core::plot::BackendType;
@@ -158,11 +162,11 @@ Two important details:
 
 ## DataShader
 
-DataShader support exists in the crate, and `.auto_optimize()` may store
-`BackendType::DataShader` metadata for large datasets. Public PNG output keeps
-the normal visual path for `.auto_optimize()`. The DataShader PNG path is an
-explicit opt-in for supported scatter-only workloads. Mixed coordinate plots,
-lines, histograms, heatmaps, and other unsupported series fall back to Skia.
+DataShader support exists in the crate, but `.auto_optimize()` does not select
+it from point count. The DataShader PNG path is an explicit opt-in for supported
+scatter-only workloads. Mixed coordinate plots, lines, histograms, heatmaps,
+non-linear axes, and other unsupported cases fall back to Skia with an
+inspectable `BackendFallbackReason`.
 
 ```rust
 use ruviz::prelude::*;

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -34,10 +34,11 @@ The public static-output APIs are conservative today:
 
 For PNG/image output, the current public path uses the reference raster pipeline
 for output parity unless `BackendType::DataShader` is explicitly configured for
-a supported scatter workload. `.backend(...)` and `.auto_optimize()` store
-backend preference metadata; `.resolved_backend_name()` reports the backend that
-public PNG render/save will actually use for the current plot. `auto_optimize()`
-keeps public PNG output on the normal visual path.
+a supported native `Plot` PNG scatter workload. `.backend(...)` stores an
+explicit preference; `.auto_optimize()` conservatively stores Skia instead of
+advertising a backend that cannot execute across all public raster operations.
+`.resolved_backend_name()` reports the backend that native `Plot` PNG
+render/save will actually use for the current plot.
 
 Reactive plots are resolved to a static snapshot first. Plain `render()` and
 `save()` sample temporal `Signal` sources at `0.0`; `render_at(t)` samples them
@@ -79,8 +80,8 @@ Plot::new()
 For dense plots where many data points map to the same pixels, downsampling or
 aggregating before plotting is often more useful than enabling a backend flag.
 
-For large scatter plots, `.auto_optimize()` may store DataShader metadata, but
-public PNG output still uses the normal visual path:
+For large scatter plots, `.auto_optimize()` keeps the executable Skia backend
+instead of selecting a backend from point count alone:
 
 ```rust
 use ruviz::prelude::*;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -39,12 +39,13 @@ pub use legend::{
     LegendSpacingPixels, LegendStyle, find_best_position,
 };
 pub use plot::{
-    BackendType, DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, Image, ImageTarget,
-    InsetAnchor, InsetLayout, InteractiveFrame, InteractivePlotSession,
-    InteractiveViewportSnapshot, IntoPlot, LayerRenderState, Plot, PlotBuilder, PlotInput,
-    PlotInputEvent, PlotSource, PreparedPlot, QualityPolicy, ReactiveSubscription, ReactiveValue,
-    RenderTargetKind, SeriesStyle, SurfaceCapability, SurfaceTarget, TextEngineMode, TickDirection,
-    TickSides, ViewportPoint, ViewportRect,
+    BackendFallbackReason, BackendOperation, BackendResolution, BackendType, DirtyDomain,
+    DirtyDomains, FramePacing, FrameStats, HitResult, Image, ImageTarget, InsetAnchor, InsetLayout,
+    InteractiveFrame, InteractivePlotSession, InteractiveViewportSnapshot, IntoPlot,
+    LayerRenderState, Plot, PlotBuilder, PlotInput, PlotInputEvent, PlotSource, PreparedPlot,
+    QualityPolicy, ReactiveSubscription, ReactiveValue, RenderTargetKind, SeriesStyle,
+    SurfaceCapability, SurfaceTarget, TextEngineMode, TickDirection, TickSides, ViewportPoint,
+    ViewportRect,
 };
 pub use position::Position;
 pub use style::PlotStyle;

--- a/src/core/plot/builder.rs
+++ b/src/core/plot/builder.rs
@@ -1023,9 +1023,10 @@ where
         self
     }
 
-    /// Enable GPU acceleration for coordinate transformations
+    /// Store a GPU backend preference.
     ///
-    /// This method forwards to the inner Plot.
+    /// This method forwards to the inner Plot. Public raster operations currently
+    /// resolve the preference to Skia with an inspectable fallback reason.
     #[cfg(feature = "gpu")]
     pub fn gpu(mut self, enabled: bool) -> Self {
         self.plot = self.plot.gpu(enabled);

--- a/src/core/plot/config.rs
+++ b/src/core/plot/config.rs
@@ -1,16 +1,16 @@
 //! Plot configuration types
 
-/// Backend types for rendering
+/// Backend types that may be requested for raster rendering.
 #[allow(clippy::upper_case_acronyms)] // GPU is the standard industry acronym
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BackendType {
-    /// Default Skia backend (CPU-based, good for <1K points)
+    /// Reference CPU raster backend.
     Skia,
-    /// Parallel multi-threaded backend (good for 1K-100K points)
+    /// Parallel CPU backend preference.
     Parallel,
-    /// GPU-accelerated backend (good for >100K points)
+    /// GPU backend preference.
     GPU,
-    /// DataShader aggregation backend (good for >1M points)
+    /// Density-aggregation backend for compatible scatter PNG output.
     DataShader,
 }
 
@@ -23,6 +23,83 @@ impl BackendType {
             Self::GPU => "gpu",
             Self::DataShader => "datashader",
         }
+    }
+}
+
+/// Public raster operation whose backend is being resolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BackendOperation {
+    /// In-memory raster output, including prepared plots, subplot frames, and
+    /// PNG bytes encoded from those images.
+    RasterImage,
+    /// The native `Plot::render_png_bytes` and `Plot::save` routing policy.
+    Png,
+    /// Interactive base-layer rasterization.
+    Interactive,
+}
+
+/// Why a requested raster backend resolved to Skia.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BackendFallbackReason {
+    /// The crate feature required by the requested backend is disabled.
+    FeatureDisabled,
+    /// No parity-approved public execution path exists for this operation.
+    UnsupportedOperation,
+    /// The requested backend is unavailable on the compilation target.
+    UnsupportedTarget,
+    /// The plot contains no series to render with the requested backend.
+    EmptyPlot,
+    /// The plot mixes Cartesian and non-Cartesian coordinate systems.
+    MixedCoordinateSystems,
+    /// At least one series type is unsupported by the requested backend.
+    UnsupportedSeries,
+    /// The requested backend does not support the configured axis scales.
+    UnsupportedAxisScale,
+    /// The requested backend cannot execute descending manual axis limits.
+    ReversedAxisLimits,
+}
+
+/// Deterministic backend decision for a specific public raster operation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendResolution {
+    requested_backend: Option<BackendType>,
+    actual_backend: BackendType,
+    fallback_reason: Option<BackendFallbackReason>,
+}
+
+impl BackendResolution {
+    pub(crate) const fn new(
+        requested_backend: Option<BackendType>,
+        actual_backend: BackendType,
+        fallback_reason: Option<BackendFallbackReason>,
+    ) -> Self {
+        Self {
+            requested_backend,
+            actual_backend,
+            fallback_reason,
+        }
+    }
+
+    /// Explicit or auto-selected backend stored on the plot, if any.
+    pub const fn requested_backend(self) -> Option<BackendType> {
+        self.requested_backend
+    }
+
+    /// Backend that will execute for the selected operation.
+    pub const fn actual_backend(self) -> BackendType {
+        self.actual_backend
+    }
+
+    /// Reason the requested backend resolved to Skia, if it did.
+    pub const fn fallback_reason(self) -> Option<BackendFallbackReason> {
+        self.fallback_reason
+    }
+
+    /// Whether the stored backend choice could not execute.
+    pub const fn used_fallback(self) -> bool {
+        self.fallback_reason.is_some()
     }
 }
 

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -1,5 +1,5 @@
 use super::{
-    Image, Plot, PlotData, PlotSeries, PreparedPlot, ReactiveSubscription, RenderExecutionMode,
+    BackendOperation, Image, Plot, PlotData, PlotSeries, PreparedPlot, ReactiveSubscription,
     ResolvedData, ResolvedFrame, ResolvedSeries, SeriesType,
 };
 use crate::{
@@ -1548,8 +1548,8 @@ impl InteractivePlotSession {
                 plot = plot.gpu(true);
             }
         }
-        let (renderer, _) =
-            plot.render_renderer_with_frame_and_diagnostics(RenderExecutionMode::Reference, frame)?;
+        let mode = plot.render_execution_mode(BackendOperation::Interactive);
+        let (renderer, _) = plot.render_renderer_with_frame_and_diagnostics(mode, frame)?;
         let image = Arc::new(renderer.into_image());
         let displayed_data = DisplayedFrameData::capture(source_plot, frame);
 

--- a/src/core/plot/mixed_render.rs
+++ b/src/core/plot/mixed_render.rs
@@ -84,6 +84,8 @@ impl Plot {
 
     pub(super) fn series_supports_auto_datashader(series: &PlotSeries) -> bool {
         matches!(series.series_type, SeriesType::Scatter { .. })
+            && series.x_errors.is_none()
+            && series.y_errors.is_none()
     }
 
     pub(super) fn is_non_cartesian_series(series: &PlotSeries) -> bool {

--- a/src/core/plot/mod.rs
+++ b/src/core/plot/mod.rs
@@ -127,6 +127,24 @@ pub struct RenderDiagnostics {
     pub rebuilt_prepared_geometry_cache: bool,
 }
 
+impl RenderDiagnostics {
+    /// Backend that actually produced the diagnosed raster frame.
+    pub const fn actual_backend(&self) -> BackendType {
+        if self.used_parallel {
+            BackendType::Parallel
+        } else if self.used_auto_datashader {
+            BackendType::DataShader
+        } else {
+            BackendType::Skia
+        }
+    }
+
+    /// Stable lowercase name of the backend that actually ran.
+    pub const fn actual_backend_name(&self) -> &'static str {
+        self.actual_backend().as_str()
+    }
+}
+
 macro_rules! impl_series_continuation_methods {
     ($self_:ident.$finalize:ident()) => {
         /// Continue with a new line series.
@@ -483,7 +501,10 @@ mod tests;
 mod types;
 
 pub use builder::{IntoPlot, PlotBuilder, PlotInput, SeriesStyle};
-pub use config::{BackendType, GridMode, TickDirection, TickSides};
+pub use config::{
+    BackendFallbackReason, BackendOperation, BackendResolution, BackendType, GridMode,
+    TickDirection, TickSides,
+};
 pub use configuration::{PlotConfiguration, TextEngineMode};
 pub use data::{IntoPlotData, PlotData, PlotSource, PlotText, ReactiveValue};
 pub use image::Image;

--- a/src/core/plot/prepared.rs
+++ b/src/core/plot/prepared.rs
@@ -1,7 +1,8 @@
 //! Prepared plot runtime for repeated frame rendering.
 
 use super::{
-    Image, InteractivePlotSession, Plot, RenderDiagnostics, RenderExecutionMode, ResolvedStyle,
+    BackendOperation, Image, InteractivePlotSession, Plot, RenderDiagnostics, RenderExecutionMode,
+    ResolvedStyle,
     data::{ReactiveTeardown, SharedReactiveCallback},
     raster_batches::SeriesRasterPlan,
 };
@@ -277,9 +278,10 @@ impl PreparedPlot {
         let frame = self.plot.resolve_frame(time)?;
         let prepared_plot = self.prepared_render_plot(&key, size_px, scale_factor, &frame.style)?;
 
+        let mode = prepared_plot.render_execution_mode(BackendOperation::RasterImage);
         let result = prepared_plot
             .render_renderer_with_resolved_frame(
-                RenderExecutionMode::Reference,
+                mode,
                 &frame,
                 |plot,
                  snapshot_series,

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -247,7 +247,7 @@ impl Plot {
         const LARGE_DATASET_THRESHOLD: usize = 1_000_000;
         if total_points > LARGE_DATASET_THRESHOLD {
             log::warn!(
-                "Rendering {} points (>1M). DataShader optimization is available for large datasets.",
+                "Rendering {} points (>1M); consider explicit data reduction or a supported backend for this output path.",
                 total_points
             );
         }
@@ -792,41 +792,118 @@ impl Plot {
         )
     }
 
-    fn public_png_render_mode_for_series(&self, series_list: &[PlotSeries]) -> RenderExecutionMode {
-        let total_points = Self::calculate_total_points_for_series(series_list);
-        if self.should_use_configured_datashader_for_public_png(series_list, total_points) {
-            RenderExecutionMode::Optimized
-        } else {
-            RenderExecutionMode::Reference
+    fn backend_fallback(&self, reason: BackendFallbackReason) -> BackendResolution {
+        BackendResolution::new(self.render.backend, BackendType::Skia, Some(reason))
+    }
+
+    fn backend_resolution_for_series(
+        &self,
+        operation: BackendOperation,
+        series_list: &[PlotSeries],
+    ) -> BackendResolution {
+        let Some(requested_backend) = self.render.backend else {
+            return BackendResolution::new(None, BackendType::Skia, None);
+        };
+
+        if requested_backend == BackendType::Skia {
+            return BackendResolution::new(Some(BackendType::Skia), BackendType::Skia, None);
+        }
+
+        match requested_backend {
+            BackendType::Skia => unreachable!("Skia resolution returned above"),
+            BackendType::Parallel => {
+                #[cfg(not(feature = "parallel"))]
+                {
+                    self.backend_fallback(BackendFallbackReason::FeatureDisabled)
+                }
+                #[cfg(feature = "parallel")]
+                {
+                    self.backend_fallback(BackendFallbackReason::UnsupportedOperation)
+                }
+            }
+            BackendType::GPU => {
+                #[cfg(not(feature = "gpu"))]
+                {
+                    self.backend_fallback(BackendFallbackReason::FeatureDisabled)
+                }
+                #[cfg(feature = "gpu")]
+                {
+                    self.backend_fallback(BackendFallbackReason::UnsupportedOperation)
+                }
+            }
+            BackendType::DataShader => {
+                if operation != BackendOperation::Png {
+                    return self.backend_fallback(BackendFallbackReason::UnsupportedOperation);
+                }
+                #[cfg(target_arch = "wasm32")]
+                {
+                    self.backend_fallback(BackendFallbackReason::UnsupportedTarget)
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    if series_list.is_empty() {
+                        return self.backend_fallback(BackendFallbackReason::EmptyPlot);
+                    }
+                    if Self::has_mixed_coordinate_series(series_list) {
+                        return self
+                            .backend_fallback(BackendFallbackReason::MixedCoordinateSystems);
+                    }
+                    if !series_list
+                        .iter()
+                        .all(Self::series_supports_auto_datashader)
+                    {
+                        return self.backend_fallback(BackendFallbackReason::UnsupportedSeries);
+                    }
+                    if !self.datashader_supports_axis_scales() {
+                        return self.backend_fallback(BackendFallbackReason::UnsupportedAxisScale);
+                    }
+                    if !self.datashader_supports_axis_directions() {
+                        return self.backend_fallback(BackendFallbackReason::ReversedAxisLimits);
+                    }
+                    BackendResolution::new(
+                        Some(BackendType::DataShader),
+                        BackendType::DataShader,
+                        None,
+                    )
+                }
+            }
         }
     }
 
-    fn public_png_render_mode(&self) -> RenderExecutionMode {
-        self.public_png_render_mode_for_series(&self.series_mgr.series)
+    /// Resolve the configured backend for a specific public raster operation.
+    ///
+    /// The result separates the stored preference from the backend that can
+    /// actually execute and provides a deterministic Skia fallback reason.
+    pub fn backend_resolution(&self, operation: BackendOperation) -> BackendResolution {
+        self.backend_resolution_for_series(operation, &self.series_mgr.series)
+    }
+
+    pub(super) fn render_execution_mode_for_series(
+        &self,
+        operation: BackendOperation,
+        series_list: &[PlotSeries],
+    ) -> RenderExecutionMode {
+        match self
+            .backend_resolution_for_series(operation, series_list)
+            .actual_backend()
+        {
+            BackendType::DataShader => RenderExecutionMode::Optimized,
+            BackendType::Skia => RenderExecutionMode::Reference,
+            BackendType::Parallel | BackendType::GPU => {
+                unreachable!("backend resolution only selects executable paths")
+            }
+        }
+    }
+
+    pub(super) fn render_execution_mode(&self, operation: BackendOperation) -> RenderExecutionMode {
+        self.render_execution_mode_for_series(operation, &self.series_mgr.series)
     }
 
     fn public_png_render_mode_from_resolved(
         &self,
-        resolved_series: &[ResolvedSeries<'_>],
+        _resolved_series: &[ResolvedSeries<'_>],
     ) -> RenderExecutionMode {
-        let total_points = Self::calculate_total_points_from_resolved(resolved_series);
-        if self
-            .should_use_configured_datashader_for_public_png(&self.series_mgr.series, total_points)
-        {
-            RenderExecutionMode::Optimized
-        } else {
-            RenderExecutionMode::Reference
-        }
-    }
-
-    fn should_use_configured_datashader_for_public_png(
-        &self,
-        series_list: &[PlotSeries],
-        total_points: usize,
-    ) -> bool {
-        matches!(self.render.backend, Some(BackendType::DataShader))
-            && !self.render.auto_optimized
-            && self.should_use_datashader_for_render(series_list, total_points)
+        self.render_execution_mode(BackendOperation::Png)
     }
 
     pub(crate) fn should_use_datashader_for_render(
@@ -834,7 +911,7 @@ impl Plot {
         series_list: &[PlotSeries],
         total_points: usize,
     ) -> bool {
-        if !self.datashader_supports_axis_scales() {
+        if !self.datashader_supports_axis_scales() || !self.datashader_supports_axis_directions() {
             return false;
         }
 
@@ -858,6 +935,16 @@ impl Plot {
     fn datashader_supports_axis_scales(&self) -> bool {
         matches!(self.layout.x_scale, AxisScale::Linear)
             && matches!(self.layout.y_scale, AxisScale::Linear)
+    }
+
+    fn datashader_supports_axis_directions(&self) -> bool {
+        self.layout
+            .x_limits
+            .is_none_or(|(x_min, x_max)| x_min < x_max)
+            && self
+                .layout
+                .y_limits
+                .is_none_or(|(y_min, y_max)| y_min < y_max)
     }
 
     /// Render the plot to an in-memory image.
@@ -922,12 +1009,13 @@ impl Plot {
     /// ```
     pub fn render_at(&self, time: f64) -> Result<Image> {
         self.validate_before_frame_resolution()?;
+        let mode = self.render_execution_mode(BackendOperation::RasterImage);
         if self.has_dynamic_style_sources() {
             return self
-                .render_dynamic_style_frame(RenderExecutionMode::Reference, time)
+                .render_dynamic_style_frame(mode, time)
                 .map(|(image, _)| image);
         }
-        self.render_image_with_mode_at(RenderExecutionMode::Reference, time)
+        self.render_image_with_mode_at(mode, time)
     }
 
     /// Render the plot and encode it as PNG bytes.
@@ -952,6 +1040,17 @@ impl Plot {
     ) -> Result<(Vec<u8>, RenderDiagnostics)> {
         self.save_png_bytes_with_backend()
             .map(|(png_bytes, _, diagnostics)| (png_bytes, diagnostics))
+    }
+
+    /// Render PNG bytes and include the deterministic backend decision.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn benchmark_render_png_bytes_with_backend_resolution(
+        &self,
+    ) -> Result<(Vec<u8>, RenderDiagnostics, BackendResolution)> {
+        let resolution = self.backend_resolution(BackendOperation::Png);
+        self.save_png_bytes_with_backend()
+            .map(|(png_bytes, _, diagnostics)| (png_bytes, diagnostics, resolution))
     }
 
     /// Check if this plot contains any reactive data (Signal or Observable).
@@ -999,8 +1098,9 @@ impl Plot {
         let mut plot = self.resolved_style_shell(&frame.style);
         plot.display.config.figure.dpi = dpi;
         let plot = plot.set_subplot_output_pixels(renderer.width(), renderer.height());
-        let (subplot_renderer, _) = plot
-            .render_renderer_with_frame_and_diagnostics(RenderExecutionMode::Reference, &frame)?;
+        let mode = plot.render_execution_mode(BackendOperation::RasterImage);
+        let (subplot_renderer, _) =
+            plot.render_renderer_with_frame_and_diagnostics(mode, &frame)?;
         renderer.draw_subplot(subplot_renderer.into_image(), 0, 0)?;
         frame.acknowledge_rendered(self);
         Ok(())
@@ -1658,86 +1758,25 @@ impl Plot {
 
         Ok(image)
     }
-    /// Infer and store a backend label based on data size
+    /// Select a backend that is safe for every public raster output path.
     ///
-    /// Updates [`get_backend_name`](Self::get_backend_name) metadata based on
-    /// dataset characteristics:
-    /// - < 1K points: Skia (simple, fast)
-    /// - 1,000 to 99,999 points: Parallel when available, otherwise Skia
-    /// - 100,000+ points: GPU when available, otherwise DataShader
+    /// Automatic routing remains on the reference Skia backend until another
+    /// backend has a parity-approved path for the requested operation. Explicit
+    /// compatible DataShader PNG output remains available through
+    /// [`backend`](Self::backend).
     ///
     /// If a backend was explicitly set with `.backend()`, that choice is respected.
-    /// Public PNG output keeps the reference visual path for `.auto_optimize()`;
-    /// explicit `BackendType::DataShader` remains available for callers that
-    /// deliberately want density aggregation for compatible scatter plots.
     pub fn auto_optimize(self) -> Self {
         self.auto_optimize_with_extra_points(0)
     }
 
-    /// Auto-optimize with additional pending points from PlotBuilder
-    ///
-    /// This internal method is used by PlotBuilder to include points from
-    /// the current series that hasn't been finalized yet.
-    pub(crate) fn auto_optimize_with_extra_points(mut self, extra_points: usize) -> Self {
-        // If backend already explicitly set, respect that choice
+    /// Apply conservative auto-selection while a builder still owns a pending series.
+    pub(crate) fn auto_optimize_with_extra_points(mut self, _extra_points: usize) -> Self {
         if self.render.backend.is_some() {
             return self;
         }
 
-        // Count total data points across all series
-        let series_points: usize = self
-            .series_mgr
-            .series
-            .iter()
-            .map(|s| match &s.series_type {
-                SeriesType::Line { x_data, .. } => x_data.len(),
-                SeriesType::Scatter { x_data, .. } => x_data.len(),
-                SeriesType::Bar { values, .. } => values.len(),
-                SeriesType::Histogram { data, .. } => data.len(),
-                SeriesType::BoxPlot { data, .. } => data.len(),
-                SeriesType::ErrorBars { x_data, .. } => x_data.len(),
-                SeriesType::ErrorBarsXY { x_data, .. } => x_data.len(),
-                SeriesType::Heatmap { data } => data.n_rows * data.n_cols,
-                SeriesType::Kde { data } => data.x.len(),
-                SeriesType::Ecdf { data } => data.x.len(),
-                SeriesType::Violin { data } => data.data.len(),
-                SeriesType::Boxen { data } => data.boxes.len() * 4,
-                SeriesType::Contour { data } => data.x.len() * data.y.len(),
-                SeriesType::Pie { data } => data.values.len(),
-                SeriesType::Radar { data } => data.series.iter().map(|s| s.values.len()).sum(),
-                SeriesType::Polar { data } => data.points.len(),
-                SeriesType::Quiver { data } => data.arrows.len(),
-            })
-            .sum();
-
-        let total_points = series_points + extra_points;
-
-        // Select backend based on data size
-        let selected_backend =
-            if Self::has_mixed_coordinate_series(&self.series_mgr.series) || total_points < 1000 {
-                BackendType::Skia
-            } else if total_points < 100_000 {
-                #[cfg(feature = "parallel")]
-                {
-                    BackendType::Parallel
-                }
-                #[cfg(not(feature = "parallel"))]
-                {
-                    BackendType::Skia
-                }
-            } else {
-                // For very large datasets, prefer GPU if available, else DataShader
-                #[cfg(feature = "gpu")]
-                {
-                    BackendType::GPU
-                }
-                #[cfg(not(feature = "gpu"))]
-                {
-                    BackendType::DataShader
-                }
-            };
-
-        self.render.backend = Some(selected_backend);
+        self.render.backend = Some(BackendType::Skia);
         self.render.auto_optimized = true;
         self
     }
@@ -1749,11 +1788,10 @@ impl Plot {
         self
     }
 
-    /// Enable GPU acceleration for the PNG export path used by [`save`](Self::save).
+    /// Store a GPU backend preference for APIs that inspect plot configuration.
     ///
-    /// When enabled, [`save`](Self::save) may use GPU-assisted rendering for
-    /// sufficiently large datasets. [`render`](Self::render) continues to use
-    /// the in-memory CPU/DataShader/parallel paths today.
+    /// Public raster operations currently resolve this preference to Skia and
+    /// report the fallback through [`backend_resolution`](Self::backend_resolution).
     ///
     /// # Example
     ///
@@ -1772,13 +1810,13 @@ impl Plot {
     ///
     /// # Requirements
     ///
-    /// - Requires the `gpu` feature to be enabled
-    /// - Falls back to CPU if GPU is not available
+    /// Requires the `gpu` feature to be enabled.
     #[cfg(feature = "gpu")]
     pub fn gpu(mut self, enabled: bool) -> Self {
         self.render.enable_gpu = enabled;
         if enabled {
             self.render.backend = Some(BackendType::GPU);
+            self.render.auto_optimized = false;
         }
         self
     }
@@ -1794,18 +1832,9 @@ impl Plot {
     /// reports the configured backend preference. Unsupported optimized backend
     /// preferences fall back to the reference Skia raster path.
     pub fn resolved_backend_name(&self) -> &'static str {
-        #[cfg(target_arch = "wasm32")]
-        {
-            BackendType::Skia.as_str()
-        }
-
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            match self.public_png_render_mode() {
-                RenderExecutionMode::Optimized => BackendType::DataShader.as_str(),
-                RenderExecutionMode::Reference => BackendType::Skia.as_str(),
-            }
-        }
+        self.backend_resolution(BackendOperation::Png)
+            .actual_backend()
+            .as_str()
     }
 
     /// Save the plot to a PNG file.
@@ -1857,6 +1886,17 @@ impl Plot {
         self.save_png_bytes_with_backend()
     }
 
+    /// Render through the save path and include its backend decision.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[doc(hidden)]
+    pub fn benchmark_save_png_bytes_with_backend_resolution(
+        &self,
+    ) -> Result<(Vec<u8>, &'static str, RenderDiagnostics, BackendResolution)> {
+        let resolution = self.backend_resolution(BackendOperation::Png);
+        self.save_png_bytes_with_backend()
+            .map(|(png_bytes, backend, diagnostics)| (png_bytes, backend, diagnostics, resolution))
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn save_png_bytes_with_backend(&self) -> Result<(Vec<u8>, &'static str, RenderDiagnostics)> {
         self.validate_before_frame_resolution()?;
@@ -1876,11 +1916,14 @@ impl Plot {
         let (renderer, diagnostics) =
             render_plot.render_renderer_with_frame_and_diagnostics(mode, &frame)?;
         let png_bytes = renderer.encode_png_bytes()?;
-        let backend = if diagnostics.used_auto_datashader {
-            BackendType::DataShader.as_str()
-        } else {
-            BackendType::Skia.as_str()
-        };
+        let backend = diagnostics.actual_backend_name();
+        debug_assert_eq!(
+            backend,
+            self.backend_resolution_for_series(BackendOperation::Png, &self.series_mgr.series)
+                .actual_backend()
+                .as_str(),
+            "backend resolution must match the renderer that executed"
+        );
         Ok((png_bytes, backend, diagnostics, frame))
     }
 

--- a/src/core/plot/series_builders.rs
+++ b/src/core/plot/series_builders.rs
@@ -983,10 +983,10 @@ impl PlotSeriesBuilder {
         self.end_series().backend(backend)
     }
 
-    /// Enable GPU acceleration for coordinate transformations
+    /// Store a GPU backend preference.
     ///
-    /// When enabled, large datasets (>5K points) will use GPU compute shaders
-    /// for coordinate transformation, providing significant speedups.
+    /// Public raster operations currently resolve the preference to Skia with an
+    /// inspectable fallback reason.
     #[cfg(feature = "gpu")]
     pub fn gpu(self, enabled: bool) -> Plot {
         self.end_series().gpu(enabled)

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -3117,10 +3117,17 @@ fn test_render_to_svg_preserves_line_width_ratio_across_dpi() {
 
 #[test]
 #[cfg(feature = "gpu")]
-fn test_gpu_method_sets_backend() {
-    let plot = Plot::new().gpu(true);
+fn test_gpu_method_sets_backend_and_reports_skia_fallback() {
+    let plot = Plot::new().auto_optimize().gpu(true);
     assert_eq!(plot.get_backend_name(), "gpu");
     assert!(plot.render.enable_gpu);
+    assert!(!plot.render.auto_optimized);
+    let resolution = plot.backend_resolution(BackendOperation::Png);
+    assert_eq!(resolution.actual_backend(), BackendType::Skia);
+    assert_eq!(
+        resolution.fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedOperation)
+    );
 }
 
 #[test]
@@ -3148,7 +3155,7 @@ fn test_gpu_threshold_constants() {
 #[test]
 #[cfg(feature = "gpu")]
 fn test_gpu_with_small_dataset() {
-    // Small datasets should not trigger GPU even with gpu(true)
+    // Static raster output truthfully falls back even with gpu(true).
     let x_data: Vec<f64> = (0..100).map(|i| i as f64).collect();
     let y_data: Vec<f64> = x_data.iter().map(|x| x * x).collect();
 
@@ -3166,7 +3173,7 @@ fn test_gpu_with_small_dataset() {
 #[test]
 #[cfg(feature = "gpu")]
 fn test_gpu_with_medium_dataset() {
-    // Medium datasets (>5K) should trigger GPU path
+    // Dataset size does not advertise an unavailable static GPU path.
     let x_data: Vec<f64> = (0..6000).map(|i| i as f64 * 0.01).collect();
     let y_data: Vec<f64> = x_data.iter().map(|x| x.sin()).collect();
 
@@ -3176,7 +3183,7 @@ fn test_gpu_with_medium_dataset() {
         .title("Medium Dataset GPU Test")
         .end_series();
 
-    // Should succeed (GPU path if available, otherwise fallback to CPU)
+    // Rendering succeeds through the documented Skia fallback.
     let result = plot.render();
     assert!(result.is_ok());
 }
@@ -3289,14 +3296,19 @@ fn test_public_png_auto_optimize_keeps_large_scatter_on_skia_visual_path() {
         .auto_optimize()
         .into_plot();
 
-    assert_eq!(plot.get_backend_name(), "datashader");
+    assert_eq!(plot.get_backend_name(), "skia");
     assert_eq!(plot.resolved_backend_name(), "skia");
+    let resolution = plot.backend_resolution(BackendOperation::Png);
+    assert_eq!(resolution.requested_backend(), Some(BackendType::Skia));
+    assert_eq!(resolution.actual_backend(), BackendType::Skia);
+    assert_eq!(resolution.fallback_reason(), None);
 
     let (png_bytes, backend, diagnostics) = plot
         .benchmark_save_png_bytes_with_diagnostics()
         .expect("auto-optimized scatter PNG render should preserve Skia visuals");
 
     assert_eq!(backend, "skia");
+    assert_eq!(diagnostics.actual_backend(), BackendType::Skia);
     assert_eq!(diagnostics.render_mode, "reference");
     assert!(!diagnostics.used_auto_datashader);
     assert!(png_bytes.starts_with(b"\x89PNG\r\n\x1a\n"));
@@ -3315,12 +3327,20 @@ fn test_public_png_explicit_datashader_uses_density_path_for_large_scatter() {
 
     assert_eq!(plot.get_backend_name(), "datashader");
     assert_eq!(plot.resolved_backend_name(), "datashader");
+    let resolution = plot.backend_resolution(BackendOperation::Png);
+    assert_eq!(
+        resolution.requested_backend(),
+        Some(BackendType::DataShader)
+    );
+    assert_eq!(resolution.actual_backend(), BackendType::DataShader);
+    assert_eq!(resolution.fallback_reason(), None);
 
     let (png_bytes, backend, diagnostics) = plot
         .benchmark_save_png_bytes_with_diagnostics()
         .expect("explicit DataShader scatter PNG render should use density path");
 
     assert_eq!(backend, "datashader");
+    assert_eq!(diagnostics.actual_backend(), BackendType::DataShader);
     assert_eq!(diagnostics.render_mode, "optimized");
     assert!(diagnostics.used_auto_datashader);
     assert!(png_bytes.starts_with(b"\x89PNG\r\n\x1a\n"));
@@ -3328,7 +3348,7 @@ fn test_public_png_explicit_datashader_uses_density_path_for_large_scatter() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
-fn test_public_png_auto_optimize_falls_back_for_unsupported_large_line() {
+fn test_public_png_auto_optimize_refuses_unroutable_large_line_backend() {
     let x_data: Vec<f64> = (0..100_000).map(|i| i as f64 * 0.00001).collect();
     let y_data: Vec<f64> = x_data.iter().map(|x| x.sin()).collect();
 
@@ -3337,14 +3357,20 @@ fn test_public_png_auto_optimize_falls_back_for_unsupported_large_line() {
         .auto_optimize()
         .into_plot();
 
-    assert_eq!(plot.get_backend_name(), "datashader");
+    assert_eq!(plot.get_backend_name(), "skia");
     assert_eq!(plot.resolved_backend_name(), "skia");
+    assert!(
+        !plot
+            .backend_resolution(BackendOperation::Png)
+            .used_fallback()
+    );
 
     let (_, backend, diagnostics) = plot
         .benchmark_save_png_bytes_with_diagnostics()
-        .expect("unsupported DataShader line PNG render should fall back to Skia");
+        .expect("auto-selected Skia line PNG render should stay on Skia");
 
     assert_eq!(backend, "skia");
+    assert_eq!(diagnostics.actual_backend(), BackendType::Skia);
     assert_eq!(diagnostics.render_mode, "reference");
     assert!(!diagnostics.used_auto_datashader);
 }

--- a/tests/auto_optimization_test.rs
+++ b/tests/auto_optimization_test.rs
@@ -16,19 +16,25 @@ fn test_small_dataset_uses_skia() {
 }
 
 #[test]
-fn test_medium_dataset_uses_parallel() {
-    // GIVEN: Plot with 10K-100K points
+fn test_medium_dataset_keeps_executable_skia_backend() {
     let x: Vec<f64> = (0..50_000).map(|i| i as f64).collect();
     let y: Vec<f64> = x.iter().map(|v| v * 2.0).collect();
 
-    let plot = Plot::new().line(&x, &y).auto_optimize();
+    let plot = Plot::new().line(&x, &y).auto_optimize().into_plot();
 
-    // THEN: Should select Parallel backend (if available) or Skia (fallback)
-    #[cfg(feature = "parallel")]
-    assert_eq!(plot.get_backend_name(), "parallel");
-
-    #[cfg(not(feature = "parallel"))]
     assert_eq!(plot.get_backend_name(), "skia");
+    assert_eq!(plot.resolved_backend_name(), "skia");
+}
+
+#[test]
+fn test_large_dataset_does_not_advertise_an_unroutable_backend() {
+    let x: Vec<f64> = (0..100_000).map(|i| i as f64).collect();
+    let y: Vec<f64> = x.iter().map(|v| v * 2.0).collect();
+
+    let plot = Plot::new().line(&x, &y).auto_optimize().into_plot();
+
+    assert_eq!(plot.get_backend_name(), "skia");
+    assert_eq!(plot.resolved_backend_name(), "skia");
 }
 
 #[test]

--- a/tests/nonbreaking_plot_api_test.rs
+++ b/tests/nonbreaking_plot_api_test.rs
@@ -1,3 +1,4 @@
+use ruviz::core::{BackendFallbackReason, BackendOperation};
 use ruviz::prelude::*;
 
 #[test]
@@ -204,6 +205,18 @@ fn resolved_backend_reports_actual_public_png_path() {
         .into_plot();
     assert_eq!(plot.get_backend_name(), "datashader");
     assert_eq!(plot.resolved_backend_name(), "skia");
+    #[cfg(not(target_arch = "wasm32"))]
+    assert_eq!(
+        plot.backend_resolution(BackendOperation::Png)
+            .fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedSeries)
+    );
+    #[cfg(target_arch = "wasm32")]
+    assert_eq!(
+        plot.backend_resolution(BackendOperation::Png)
+            .fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedTarget)
+    );
 }
 
 #[test]
@@ -219,6 +232,11 @@ fn wasm_resolved_backend_reports_skia_for_explicit_datashader_scatter() {
 
     assert_eq!(plot.get_backend_name(), "datashader");
     assert_eq!(plot.resolved_backend_name(), "skia");
+    assert_eq!(
+        plot.backend_resolution(BackendOperation::Png)
+            .fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedTarget)
+    );
 }
 
 #[test]
@@ -256,4 +274,283 @@ fn explicit_datashader_backend_falls_back_on_non_linear_axes() {
 
     assert_eq!(plot.get_backend_name(), "datashader");
     assert_eq!(plot.resolved_backend_name(), "skia");
+    let resolution = plot.backend_resolution(BackendOperation::Png);
+    assert_eq!(resolution.actual_backend(), BackendType::Skia);
+    assert_eq!(
+        resolution.fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedAxisScale)
+    );
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn explicit_datashader_reversed_manual_limits_fall_back_and_save_png() {
+    let output_dir = tempfile::tempdir().expect("temporary output directory should exist");
+    let output = output_dir.path().join("reversed-datashader.png");
+    let plot = Plot::new()
+        .backend(BackendType::DataShader)
+        .xlim(4.0, 0.0)
+        .ylim(4.0, 0.0)
+        .scatter(&[0.0, 1.0, 2.0, 3.0, 4.0], &[0.0, 1.0, 4.0, 2.0, 3.0])
+        .into_plot();
+
+    let resolution = plot.backend_resolution(BackendOperation::Png);
+    assert_eq!(resolution.actual_backend(), BackendType::Skia);
+    assert_eq!(
+        resolution.fallback_reason(),
+        Some(BackendFallbackReason::ReversedAxisLimits)
+    );
+
+    let (_, backend, diagnostics, executed_resolution) = plot
+        .benchmark_save_png_bytes_with_backend_resolution()
+        .expect("reversed axes should execute through the Skia PNG path");
+    assert_eq!(backend, "skia");
+    assert_eq!(diagnostics.actual_backend(), BackendType::Skia);
+    assert_eq!(diagnostics.render_mode, "reference");
+    assert!(!diagnostics.used_auto_datashader);
+    assert_eq!(executed_resolution, resolution);
+
+    plot.save(&output)
+        .expect("reversed-axis fallback should save a PNG successfully");
+    let png = std::fs::read(output).expect("saved PNG should be readable");
+    assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
+    image::load_from_memory(&png).expect("saved output should decode as PNG");
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn explicit_datashader_scatter_error_variants_fall_back_with_full_skia_output() {
+    let x = [0.0, 1.0, 2.0, 3.0];
+    let y = [1.0, 3.0, 2.0, 4.0];
+    let symmetric_x = [0.1, 0.2, 0.15, 0.25];
+    let symmetric_y = [0.3, 0.4, 0.2, 0.35];
+    let lower = [0.1, 0.2, 0.1, 0.15];
+    let upper = [0.2, 0.3, 0.25, 0.4];
+
+    let cases = [
+        (
+            "symmetric y errors",
+            Plot::new()
+                .backend(BackendType::DataShader)
+                .scatter(&x, &y)
+                .with_yerr(&symmetric_y)
+                .into_plot(),
+            Plot::new()
+                .scatter(&x, &y)
+                .with_yerr(&symmetric_y)
+                .into_plot(),
+        ),
+        (
+            "symmetric x errors",
+            Plot::new()
+                .backend(BackendType::DataShader)
+                .scatter(&x, &y)
+                .with_xerr(&symmetric_x)
+                .into_plot(),
+            Plot::new()
+                .scatter(&x, &y)
+                .with_xerr(&symmetric_x)
+                .into_plot(),
+        ),
+        (
+            "combined x and y errors",
+            Plot::new()
+                .backend(BackendType::DataShader)
+                .scatter(&x, &y)
+                .with_xerr(&symmetric_x)
+                .with_yerr(&symmetric_y)
+                .into_plot(),
+            Plot::new()
+                .scatter(&x, &y)
+                .with_xerr(&symmetric_x)
+                .with_yerr(&symmetric_y)
+                .into_plot(),
+        ),
+        (
+            "asymmetric y errors",
+            Plot::new()
+                .backend(BackendType::DataShader)
+                .scatter(&x, &y)
+                .with_yerr_asymmetric(&lower, &upper)
+                .into_plot(),
+            Plot::new()
+                .scatter(&x, &y)
+                .with_yerr_asymmetric(&lower, &upper)
+                .into_plot(),
+        ),
+        (
+            "asymmetric x errors",
+            Plot::new()
+                .backend(BackendType::DataShader)
+                .scatter(&x, &y)
+                .with_xerr_asymmetric(&lower, &upper)
+                .into_plot(),
+            Plot::new()
+                .scatter(&x, &y)
+                .with_xerr_asymmetric(&lower, &upper)
+                .into_plot(),
+        ),
+    ];
+
+    for (name, fallback_plot, reference_plot) in cases {
+        let resolution = fallback_plot.backend_resolution(BackendOperation::Png);
+        assert_eq!(resolution.actual_backend(), BackendType::Skia, "{name}");
+        assert_eq!(
+            resolution.fallback_reason(),
+            Some(BackendFallbackReason::UnsupportedSeries),
+            "{name}"
+        );
+
+        let (fallback_png, backend, diagnostics, executed_resolution) = fallback_plot
+            .benchmark_save_png_bytes_with_backend_resolution()
+            .unwrap_or_else(|error| panic!("{name} fallback should render: {error}"));
+        let (reference_png, reference_backend, reference_diagnostics) = reference_plot
+            .benchmark_save_png_bytes_with_diagnostics()
+            .unwrap_or_else(|error| panic!("{name} reference should render: {error}"));
+
+        assert_eq!(backend, "skia", "{name}");
+        assert_eq!(reference_backend, "skia", "{name}");
+        assert_eq!(diagnostics.actual_backend(), BackendType::Skia, "{name}");
+        assert_eq!(diagnostics.render_mode, "reference", "{name}");
+        assert!(!diagnostics.used_auto_datashader, "{name}");
+        assert_eq!(executed_resolution, resolution, "{name}");
+        assert_eq!(
+            reference_diagnostics.actual_backend(),
+            BackendType::Skia,
+            "{name}"
+        );
+        assert_eq!(
+            fallback_png, reference_png,
+            "{name} should preserve error bars"
+        );
+    }
+}
+
+#[test]
+fn explicit_parallel_backend_reports_truthful_fallback() {
+    let plot = Plot::new()
+        .backend(BackendType::Parallel)
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .into_plot();
+    let resolution = plot.backend_resolution(BackendOperation::Png);
+
+    assert_eq!(resolution.requested_backend(), Some(BackendType::Parallel));
+    assert_eq!(resolution.actual_backend(), BackendType::Skia);
+    #[cfg(feature = "parallel")]
+    assert_eq!(
+        resolution.fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedOperation)
+    );
+    #[cfg(not(feature = "parallel"))]
+    assert_eq!(
+        resolution.fallback_reason(),
+        Some(BackendFallbackReason::FeatureDisabled)
+    );
+}
+
+#[test]
+fn explicit_gpu_backend_reports_truthful_fallback() {
+    let plot = Plot::new()
+        .backend(BackendType::GPU)
+        .scatter(&[0.0, 1.0], &[0.0, 1.0])
+        .into_plot();
+    for operation in [
+        BackendOperation::RasterImage,
+        BackendOperation::Png,
+        BackendOperation::Interactive,
+    ] {
+        let resolution = plot.backend_resolution(operation);
+        assert_eq!(resolution.requested_backend(), Some(BackendType::GPU));
+        assert_eq!(resolution.actual_backend(), BackendType::Skia);
+        #[cfg(feature = "gpu")]
+        assert_eq!(
+            resolution.fallback_reason(),
+            Some(BackendFallbackReason::UnsupportedOperation)
+        );
+        #[cfg(not(feature = "gpu"))]
+        assert_eq!(
+            resolution.fallback_reason(),
+            Some(BackendFallbackReason::FeatureDisabled)
+        );
+    }
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn explicit_datashader_reports_operation_and_series_fallbacks() {
+    let scatter = Plot::new()
+        .backend(BackendType::DataShader)
+        .scatter(&[0.0, 1.0], &[0.0, 1.0])
+        .into_plot();
+    let raster_resolution = scatter.backend_resolution(BackendOperation::RasterImage);
+    assert_eq!(raster_resolution.actual_backend(), BackendType::Skia);
+    assert_eq!(
+        raster_resolution.fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedOperation)
+    );
+
+    let line = Plot::new()
+        .backend(BackendType::DataShader)
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .into_plot();
+    let png_resolution = line.backend_resolution(BackendOperation::Png);
+    assert_eq!(png_resolution.actual_backend(), BackendType::Skia);
+    assert_eq!(
+        png_resolution.fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedSeries)
+    );
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn explicit_datashader_reports_mixed_coordinate_fallback() {
+    let plot = Plot::new()
+        .backend(BackendType::DataShader)
+        .scatter(&[0.0, 1.0], &[0.0, 1.0])
+        .polar_line(&[1.0, 2.0], &[0.0, std::f64::consts::PI])
+        .into_plot();
+    let resolution = plot.backend_resolution(BackendOperation::Png);
+
+    assert_eq!(resolution.actual_backend(), BackendType::Skia);
+    assert_eq!(
+        resolution.fallback_reason(),
+        Some(BackendFallbackReason::MixedCoordinateSystems)
+    );
+}
+
+#[test]
+fn prepared_plot_diagnostics_match_raster_image_resolution() {
+    let plot = Plot::new()
+        .backend(BackendType::DataShader)
+        .scatter(&[0.0, 1.0], &[0.0, 1.0])
+        .into_plot();
+    let resolution = plot.backend_resolution(BackendOperation::RasterImage);
+    let (_, diagnostics) = plot
+        .prepare()
+        .render_png_bytes_uncached_with_diagnostics()
+        .expect("prepared PNG bytes should use the raster-image policy");
+
+    assert_eq!(resolution.actual_backend(), BackendType::Skia);
+    assert_eq!(
+        resolution.fallback_reason(),
+        Some(BackendFallbackReason::UnsupportedOperation)
+    );
+    assert_eq!(diagnostics.actual_backend(), resolution.actual_backend());
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
+fn backend_resolution_and_diagnostics_agree_on_executed_renderer() {
+    let plot = Plot::new()
+        .backend(BackendType::Parallel)
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .into_plot();
+    let (_, backend, diagnostics, resolution) = plot
+        .benchmark_save_png_bytes_with_backend_resolution()
+        .expect("explicit parallel preference should fall back to a Skia PNG");
+
+    assert_eq!(backend, "skia");
+    assert_eq!(diagnostics.actual_backend(), BackendType::Skia);
+    assert_eq!(resolution.actual_backend(), diagnostics.actual_backend());
+    assert!(resolution.used_fallback());
 }


### PR DESCRIPTION
## Summary

- report requested and actually executed rendering backends separately
- route supported DataShader plots explicitly and explain truthful fallbacks
- keep diagnostics aligned with raster, prepared, and interactive execution

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --test auto_optimization_test --test nonbreaking_plot_api_test --all-features` (28 passed)