### PR TITLE
Complete TextStyle annotation contract

### DIFF
--- a/src/core/annotation.rs
+++ b/src/core/annotation.rs
@@ -678,6 +678,21 @@ mod tests {
     }
 
     #[test]
+    fn text_style_remains_constructible_with_the_public_fields() {
+        let _style = TextStyle {
+            font_size: 11.0,
+            color: Color::BLUE,
+            align: TextAlign::Right,
+            valign: TextVAlign::Bottom,
+            rotation: 17.5,
+            background: Some(Color::WHITE),
+            padding: 3.0,
+            border_color: Some(Color::BLACK),
+            border_width: 0.75,
+        };
+    }
+
+    #[test]
     fn test_arrow_style_builder() {
         let style = ArrowStyle::new()
             .color(Color::BLUE)

--- a/src/core/plot/parallel_render.rs
+++ b/src/core/plot/parallel_render.rs
@@ -1303,7 +1303,12 @@ impl Plot {
         // Draw title if present
         if let Some(ref pos) = layout.title_pos {
             if let Some(title) = frame.title.as_deref() {
-                renderer.draw_title_at(pos, title, self.display.theme.foreground)?;
+                renderer.draw_title_at_with_weight(
+                    pos,
+                    title,
+                    self.display.theme.foreground,
+                    self.display.config.typography.title_weight,
+                )?;
             }
         }
 

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -500,7 +500,12 @@ impl Plot {
 
         if let Some(ref pos) = layout.title_pos {
             if let Some(title) = frame.title.as_deref() {
-                renderer.draw_title_at(pos, title, self.display.theme.foreground)?;
+                renderer.draw_title_at_with_weight(
+                    pos,
+                    title,
+                    self.display.theme.foreground,
+                    self.display.config.typography.title_weight,
+                )?;
             }
         }
 
@@ -1274,7 +1279,11 @@ impl Plot {
         let mut measurements = MeasuredDimensions::default();
 
         if let Some(title) = content.title.as_deref() {
-            measurements.title = Some(renderer.measure_text(title, title_size_px)?);
+            measurements.title = Some(renderer.measure_text_with_weight(
+                title,
+                title_size_px,
+                self.display.config.typography.title_weight,
+            )?);
         }
         if let Some(xlabel) = content.xlabel.as_deref() {
             measurements.xlabel = Some(renderer.measure_text(xlabel, label_size_px)?);
@@ -1986,8 +1995,7 @@ impl Plot {
             Annotation::Text { x, y, text, style } => {
                 let (px, py) =
                     self.svg_annotation_point(*x, *y, plot_area, x_min, x_max, y_min, y_max);
-                let font_size = pt_to_px(style.font_size, self.display.config.figure.dpi);
-                svg.draw_text(text, px, py, font_size, style.color)?;
+                svg.draw_styled_text(text, px, py, &self.display.config.typography.family, style)?;
             }
             Annotation::Arrow {
                 x1,
@@ -2739,12 +2747,13 @@ impl Plot {
         // Draw title/xlabel/ylabel using layout-computed positions.
         if let Some(ref pos) = layout.title_pos {
             if let Some(title) = frame.title.as_deref() {
-                svg.draw_text_centered(
+                svg.draw_text_centered_with_weight(
                     title,
                     pos.x,
                     pos.y,
                     pos.size,
                     self.display.theme.foreground,
+                    self.display.config.typography.title_weight,
                 )?;
             }
         }

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -5441,6 +5441,197 @@ fn test_render_to_svg_propagates_named_font_family() {
     assert!(svg.contains(r#"font-family="&quot;serif&quot;""#));
 }
 
+fn plot_with_weighted_title(weight: crate::render::FontWeight) -> Plot {
+    let config = PlotConfig::builder()
+        .typography(|typography| typography.title_weight(weight))
+        .build();
+    Plot::new()
+        .plot_config(config)
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .color(Color::RED)
+        .title("Weighted raster title")
+        .text_styled(
+            0.5,
+            0.5,
+            "Normal annotation",
+            crate::core::TextStyle::default()
+                .font_size(18.0)
+                .color(Color::BLUE),
+        )
+        .end_series()
+        .set_output_pixels(360, 280)
+}
+
+fn blue_dominant_pixel_indices(image: &Image) -> Vec<usize> {
+    image
+        .pixels
+        .chunks_exact(4)
+        .enumerate()
+        .filter_map(|(index, pixel)| {
+            (pixel[3] > 0
+                && pixel[2] > 80
+                && pixel[2] > pixel[0].saturating_add(40)
+                && pixel[2] > pixel[1].saturating_add(40))
+            .then_some(index)
+        })
+        .collect()
+}
+
+fn differing_pixel_count(left: &Image, right: &Image) -> usize {
+    left.pixels
+        .chunks_exact(4)
+        .zip(right.pixels.chunks_exact(4))
+        .filter(|(left, right)| left != right)
+        .count()
+}
+
+#[test]
+fn plain_svg_multiline_title_uses_weighted_measurement_and_reserves_each_line() {
+    let build = |title: &str| {
+        let config = PlotConfig::builder()
+            .typography(|typography| {
+                typography
+                    .family(crate::render::FontFamily::Monospace)
+                    .title_weight(crate::render::FontWeight::Bold)
+            })
+            .build();
+        Plot::new()
+            .plot_config(config)
+            .line(&[0.0, 1.0], &[0.0, 1.0])
+            .title(title)
+            .end_series()
+            .set_output_pixels(360, 280)
+    };
+    let inspect = |plot: &Plot| {
+        let (_, _, y_min, y_max) = plot.calculate_data_bounds().unwrap();
+        let content = plot.create_plot_content(y_min, y_max);
+        let mut renderer = crate::render::SkiaRenderer::with_font_family(
+            plot.display.dimensions.0,
+            plot.display.dimensions.1,
+            plot.display.theme.clone(),
+            plot.display.config.typography.family.clone(),
+        )
+        .unwrap();
+        renderer.set_render_scale(plot.render_scale());
+        let measured = plot
+            .measure_layout_text(&renderer, &content, plot.display.config.figure.dpi)
+            .unwrap()
+            .unwrap();
+        let layout = plot.compute_layout_from_measurements(
+            plot.display.dimensions,
+            &content,
+            plot.display.config.figure.dpi,
+            Some(&measured),
+        );
+        (measured.title.unwrap(), layout.plot_area.top)
+    };
+
+    let single = build("wide title");
+    let multiline = build("wide title\nshort");
+    let (single_measurement, single_top) = inspect(&single);
+    let (multiline_measurement, multiline_top) = inspect(&multiline);
+    assert!(multiline_measurement.1 > single_measurement.1 * 1.8);
+    assert!(multiline_top > single_top + single_measurement.1 * 0.8);
+
+    let svg = multiline.render_to_svg().unwrap();
+    let title = svg
+        .lines()
+        .find(|line| line.contains("wide title"))
+        .expect("multiline plain-SVG title");
+    assert!(title.contains(r#"font-family="monospace""#));
+    assert!(title.contains(r#"font-weight="700""#));
+    assert!(title.contains(r#"text-anchor="middle""#));
+    assert_eq!(title.matches("<tspan ").count(), 2);
+}
+
+#[test]
+fn serial_raster_title_honors_weight_without_changing_annotation_weight() {
+    let normal = plot_with_weighted_title(crate::render::FontWeight::Normal)
+        .render()
+        .expect("normal-weight serial raster");
+    let bold = plot_with_weighted_title(crate::render::FontWeight::Bold)
+        .render()
+        .expect("bold serial raster");
+
+    assert!(differing_pixel_count(&normal, &bold) > 20);
+    assert_eq!(
+        blue_dominant_pixel_indices(&normal),
+        blue_dominant_pixel_indices(&bold),
+        "title weight must not leak into annotation text"
+    );
+}
+
+#[cfg(feature = "parallel")]
+#[test]
+fn parallel_raster_title_honors_weight_without_changing_annotation_weight() {
+    let normal = plot_with_weighted_title(crate::render::FontWeight::Normal)
+        .render_with_parallel()
+        .expect("normal-weight parallel raster");
+    let bold = plot_with_weighted_title(crate::render::FontWeight::Bold)
+        .render_with_parallel()
+        .expect("bold parallel raster");
+
+    assert!(differing_pixel_count(&normal, &bold) > 20);
+    assert_eq!(
+        blue_dominant_pixel_indices(&normal),
+        blue_dominant_pixel_indices(&bold),
+        "title weight must not leak into parallel annotation text"
+    );
+}
+
+#[test]
+fn test_svg_text_annotation_uses_resolved_typography_and_full_text_style() {
+    let x = vec![0.0, 1.0];
+    let y = vec![0.0, 1.0];
+    let config = PlotConfig::builder()
+        .figure(2.0, 2.0)
+        .dpi(144.0)
+        .typography(|typography| {
+            typography
+                .family(crate::render::FontFamily::Name(
+                    "Annotation Font".to_string(),
+                ))
+                .title_weight(crate::render::FontWeight::Bold)
+        })
+        .build();
+    let style = crate::core::TextStyle {
+        font_size: 10.0,
+        color: Color::new_rgba(20, 30, 40, 200),
+        align: crate::core::TextAlign::Right,
+        valign: crate::core::TextVAlign::Bottom,
+        rotation: 25.0,
+        background: Some(Color::new_rgba(240, 230, 220, 128)),
+        padding: 3.0,
+        border_color: Some(Color::BLUE),
+        border_width: 2.0,
+    };
+
+    let svg = Plot::new()
+        .plot_config(config)
+        .line(&x, &y)
+        .title("Weighted title")
+        .text_styled(0.5, 0.5, "Styled annotation", style)
+        .render_to_svg()
+        .expect("SVG render should succeed");
+
+    assert!(svg.contains(r#"data-ruviz-text-style="annotation""#));
+    assert!(svg.contains("rotate(-25.00)"));
+    assert!(svg.contains(r#"font-family="&quot;Annotation Font&quot;""#));
+    let annotation_line = svg
+        .lines()
+        .find(|line| line.contains(">Styled annotation</text>"))
+        .expect("annotation text should be present");
+    let title_line = svg
+        .lines()
+        .find(|line| line.contains(">Weighted title</text>"))
+        .expect("title text should be present");
+    assert!(annotation_line.contains(r#"font-weight="400""#));
+    assert!(title_line.contains(r#"font-weight="700""#));
+    assert!(svg.contains(r#"text-anchor="end""#));
+    assert!(svg.contains(r#"fill="rgba(240,230,220,0.502)""#));
+    assert!(svg.contains(r#"stroke-width="4.00""#));
+}
+
 #[test]
 fn test_theme_sets_plot_typography_font_family() {
     let themed = Plot::new().theme(crate::render::Theme::publication());

--- a/src/core/plot/tests/typst.rs
+++ b/src/core/plot/tests/typst.rs
@@ -75,3 +75,156 @@ fn test_plot_to_typst_svg_applies_font_family() {
     assert!(mono.contains(r#"data-ruviz-text-engine="typst""#));
     assert_ne!(serif, mono);
 }
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn test_typst_title_honors_resolved_title_weight() {
+    let x = vec![0.0, 1.0];
+    let y = vec![0.0, 1.0];
+    let render = |weight| {
+        let config = PlotConfig::builder()
+            .typography(|typography| typography.title_weight(weight))
+            .build();
+        Plot::new()
+            .plot_config(config)
+            .line(&x, &y)
+            .title("Weighted title")
+            .typst(true)
+            .render_to_svg()
+            .expect("Typst SVG plot render should succeed")
+    };
+
+    let normal = render(crate::render::FontWeight::Normal);
+    let bold = render(crate::render::FontWeight::Bold);
+    assert_ne!(normal, bold);
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn test_typst_annotation_ignores_title_weight() {
+    let render = |weight| {
+        let config = PlotConfig::builder()
+            .typography(|typography| typography.title_weight(weight))
+            .build();
+        Plot::new()
+            .plot_config(config)
+            .line(&[0.0, 1.0], &[0.0, 1.0])
+            .color(Color::RED)
+            .text_styled(
+                0.5,
+                0.5,
+                "Normal annotation",
+                crate::core::TextStyle::default().color(Color::BLUE),
+            )
+            .typst(true)
+            .render_to_svg()
+            .expect("Typst SVG annotation render should succeed")
+    };
+
+    assert_eq!(
+        render(crate::render::FontWeight::Normal),
+        render(crate::render::FontWeight::Bold)
+    );
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn test_typst_raster_title_honors_weight_without_changing_annotation_weight() {
+    let normal = plot_with_weighted_title(crate::render::FontWeight::Normal)
+        .typst(true)
+        .render()
+        .expect("normal-weight Typst raster");
+    let bold = plot_with_weighted_title(crate::render::FontWeight::Bold)
+        .typst(true)
+        .render()
+        .expect("bold Typst raster");
+
+    assert!(differing_pixel_count(&normal, &bold) > 20);
+    assert_eq!(
+        blue_dominant_pixel_indices(&normal),
+        blue_dominant_pixel_indices(&bold),
+        "title weight must not leak into Typst annotation text"
+    );
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn public_typst_title_plain_newline_renders_as_multiline_in_svg_and_raster() {
+    let make_plot = |title: &str| {
+        Plot::new()
+            .line(&[0.0, 1.0], &[0.0, 1.0])
+            .title(title)
+            .end_series()
+            .set_output_pixels(360, 280)
+            .typst(true)
+    };
+
+    let multiline_plot = make_plot("Bold Title\nShort");
+    let single_line_plot = make_plot("Bold Title Short");
+    let multiline_svg = multiline_plot.render_to_svg().unwrap();
+    let single_line_svg = single_line_plot.render_to_svg().unwrap();
+    let multiline_title = extract_typst_group_boxes(&multiline_svg)
+        .last()
+        .copied()
+        .expect("multiline Typst title group");
+    let single_line_title = extract_typst_group_boxes(&single_line_svg)
+        .last()
+        .copied()
+        .expect("single-line Typst title group");
+    assert!(
+        multiline_title.3 > single_line_title.3 * 1.5,
+        "authored title newline must increase rendered height: multiline={multiline_title:?}, single={single_line_title:?}"
+    );
+
+    let multiline = multiline_plot.render().unwrap();
+    let single_line = single_line_plot.render().unwrap();
+    assert!(
+        differing_pixel_count(&multiline, &single_line) > 100,
+        "public Typst raster title must not collapse an authored newline to a space"
+    );
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn public_typst_annotation_plain_newline_renders_multiline_with_alignment_and_rotation() {
+    let render = |text: &str, align, rotation| {
+        let style = crate::core::TextStyle::default()
+            .font_size(16.0)
+            .align(align)
+            .rotation(rotation)
+            .background(Color::new(240, 200, 180))
+            .padding(3.0);
+        Plot::new()
+            .line(&[0.0, 1.0], &[0.0, 1.0])
+            .color(Color::BLUE)
+            .text_styled(0.5, 0.5, text, style)
+            .end_series()
+            .set_output_pixels(360, 280)
+            .typst(true)
+            .render()
+            .unwrap()
+    };
+
+    for (align, rotation) in [
+        (crate::core::TextAlign::Center, 0.0),
+        (crate::core::TextAlign::Right, 27.0),
+    ] {
+        let multiline = render("WIDE CENTER\nx", align, rotation);
+        let single_line = render("WIDE CENTER x", align, rotation);
+        assert!(
+            differing_pixel_count(&multiline, &single_line) > 100,
+            "public Typst annotation newline collapsed for {align:?} at {rotation} degrees"
+        );
+    }
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn public_typst_multiline_title_preserves_inline_markup() {
+    Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .title("#emph[wide]\n$ x + 1 $")
+        .typst(true)
+        .render()
+        .expect("multiline Typst markup should remain compilable");
+}

--- a/src/export/svg.rs
+++ b/src/export/svg.rs
@@ -5,12 +5,15 @@
 
 use crate::core::{
     Legend, LegendItem, LegendItemType, LegendPosition, LegendSpacingPixels, LegendStyle,
-    PlottingError, RenderScale, Result, SpineConfig, find_best_position,
+    PlottingError, RenderScale, Result, SpineConfig, TextAlign, TextStyle, find_best_position,
     plot::{TextEngineMode, TickDirection, TickSides},
 };
 use crate::render::{
-    Color, FontConfig, FontFamily, LineStyle, MarkerStyle, TextRenderer,
-    text_anchor::{TextPlacementMetrics, center_anchor_to_baseline, top_anchor_to_baseline},
+    Color, FontConfig, FontFamily, FontWeight, LineStyle, MarkerStyle, TextRenderer,
+    text_anchor::{
+        TextPlacementMetrics, annotation_text_layout, center_anchor_to_baseline,
+        top_anchor_to_baseline,
+    },
     typst_text::{self, TypstBackendKind, TypstTextAnchor},
 };
 use std::borrow::Cow;
@@ -202,6 +205,29 @@ impl SvgRenderer {
         }
     }
 
+    fn embedded_typst_svg(&self, rendered: &typst_text::TypstSvgOutput) -> String {
+        let mut svg = self.strip_xml_declaration(&rendered.svg).to_string();
+        Self::set_root_svg_dimension(&mut svg, "width", rendered.width);
+        Self::set_root_svg_dimension(&mut svg, "height", rendered.height);
+        svg
+    }
+
+    fn set_root_svg_dimension(svg: &mut String, attribute: &str, value: f32) {
+        let Some(tag_end) = svg.find('>') else {
+            return;
+        };
+        let marker = format!(r#"{attribute}=""#);
+        let Some(relative_start) = svg[..tag_end].find(&marker) else {
+            return;
+        };
+        let value_start = relative_start + marker.len();
+        let Some(relative_end) = svg[value_start..tag_end].find('"') else {
+            return;
+        };
+        let value_end = value_start + relative_end;
+        svg.replace_range(value_start..value_end, &format!("{value:.2}"));
+    }
+
     fn generated_label<'a>(&self, text: &'a str) -> Cow<'a, str> {
         #[cfg(feature = "typst-math")]
         if self.text_engine_mode.uses_typst() {
@@ -213,7 +239,15 @@ impl SvgRenderer {
 
     fn plain_text_metrics(&self, text: &str, font_size: f32) -> Result<TextPlacementMetrics> {
         let config = FontConfig::new(self.font_family.clone(), font_size);
-        self.text_renderer.measure_text_placement(text, &config)
+        self.plain_text_metrics_with_config(text, &config)
+    }
+
+    fn plain_text_metrics_with_config(
+        &self,
+        text: &str,
+        config: &FontConfig,
+    ) -> Result<TextPlacementMetrics> {
+        self.text_renderer.measure_text_placement(text, config)
     }
 
     fn escape_css_string(value: &str) -> String {
@@ -236,15 +270,27 @@ impl SvgRenderer {
     }
 
     fn escaped_font_family(&self) -> String {
-        let css_value = match &self.font_family {
+        self.escaped_font_family_for(&self.font_family)
+    }
+
+    fn escaped_font_family_for(&self, family: &FontFamily) -> String {
+        let css_value = match family {
             FontFamily::Serif
             | FontFamily::SansSerif
             | FontFamily::Monospace
             | FontFamily::Cursive
-            | FontFamily::Fantasy => self.font_family.as_str().to_string(),
+            | FontFamily::Fantasy => family.as_str().to_string(),
             FontFamily::Name(name) => format!("\"{}\"", Self::escape_css_string(name)),
         };
         self.escape_xml(&css_value)
+    }
+
+    fn svg_text_anchor(align: TextAlign) -> &'static str {
+        match align {
+            TextAlign::Left => "start",
+            TextAlign::Center => "middle",
+            TextAlign::Right => "end",
+        }
     }
 
     fn measure_text_for_layout(&self, text: &str, font_size: f32) -> Result<(f32, f32)> {
@@ -591,6 +637,156 @@ impl SvgRenderer {
         }
     }
 
+    pub(crate) fn draw_styled_text(
+        &mut self,
+        text: &str,
+        x: f32,
+        y: f32,
+        family: &FontFamily,
+        style: &TextStyle,
+    ) -> Result<()> {
+        let font_size = self.points_to_pixels(style.font_size.max(0.1));
+        let padding = self.points_to_pixels(style.padding.max(0.0));
+        let border_width = self.points_to_pixels(style.border_width.max(0.0));
+        let text_visible = style.color.a > 0 && !text.trim().is_empty();
+        let background_visible = style.background.is_some_and(|color| color.a > 0);
+        let border_visible =
+            border_width > 0.0 && style.border_color.is_some_and(|color| color.a > 0);
+        if !text_visible && !background_visible && !border_visible {
+            return Ok(());
+        }
+
+        let weight = FontWeight::Normal;
+        let config = FontConfig::new(family.clone(), font_size).weight(weight);
+        #[cfg(feature = "typst-math")]
+        let mut typst_rendered = None;
+        let metrics = if text.trim().is_empty() {
+            TextPlacementMetrics::new(0.0, font_size, font_size)
+        } else {
+            match self.text_engine_mode {
+                TextEngineMode::Plain => self.plain_text_metrics_with_config(text, &config)?,
+                #[cfg(feature = "typst-math")]
+                TextEngineMode::Typst => {
+                    let multiline_text = typst_text::with_explicit_line_breaks(text);
+                    let weighted_text = typst_text::with_font_weight(&multiline_text, weight);
+                    let aligned_text =
+                        typst_text::with_horizontal_alignment(&weighted_text, style.align);
+                    let rendered = typst_text::render_svg_with_font_family(
+                        &aligned_text,
+                        self.typst_size_pt(font_size),
+                        style.color,
+                        0.0,
+                        family,
+                        "SVG annotation text rendering",
+                    )?;
+                    let metrics =
+                        TextPlacementMetrics::new(rendered.width, rendered.height, rendered.height);
+                    typst_rendered = Some(rendered);
+                    metrics
+                }
+            }
+        };
+        let layout =
+            annotation_text_layout(metrics, style.align, style.valign, padding, style.rotation);
+
+        writeln!(
+            self.content,
+            r#"  <g data-ruviz-text-style="annotation" transform="translate({:.2},{:.2}) rotate({:.2})">"#,
+            x, y, layout.rotation
+        )
+        .unwrap();
+
+        if background_visible || border_visible {
+            let fill = style
+                .background
+                .filter(|_| background_visible)
+                .map(|color| self.color_to_svg(color))
+                .unwrap_or_else(|| "none".to_string());
+            let stroke = style
+                .border_color
+                .filter(|_| border_visible)
+                .map(|color| self.color_to_svg(color))
+                .unwrap_or_else(|| "none".to_string());
+            writeln!(
+                self.content,
+                r#"    <rect x="{:.2}" y="{:.2}" width="{:.2}" height="{:.2}" fill="{}" stroke="{}" stroke-width="{:.2}"/>"#,
+                layout.box_x,
+                layout.box_y,
+                layout.box_width,
+                layout.box_height,
+                fill,
+                stroke,
+                border_width
+            )
+            .unwrap();
+        }
+
+        if text_visible {
+            match self.text_engine_mode {
+                TextEngineMode::Plain => {
+                    let font_family = self.escaped_font_family_for(family);
+                    let color = self.color_to_svg(style.color);
+                    let text_anchor = Self::svg_text_anchor(style.align);
+                    let baseline_y = layout.text_y + metrics.baseline_from_top;
+                    if text.contains('\n') {
+                        write!(
+                            self.content,
+                            r#"    <text x="0" font-family="{}" font-size="{:.1}" font-weight="{}" fill="{}" text-anchor="{}" xml:space="preserve">"#,
+                            font_family,
+                            font_size,
+                            weight.numeric(),
+                            color,
+                            text_anchor
+                        )
+                        .unwrap();
+                        let line_height = font_size * 1.2;
+                        for (line_index, line) in text.split('\n').enumerate() {
+                            let line = line.strip_suffix('\r').unwrap_or(line);
+                            let line_y = baseline_y + line_index as f32 * line_height;
+                            write!(
+                                self.content,
+                                r#"<tspan x="0" y="{:.2}">{}</tspan>"#,
+                                line_y,
+                                self.escape_xml(line)
+                            )
+                            .unwrap();
+                        }
+                        writeln!(self.content, "</text>").unwrap();
+                    } else {
+                        writeln!(
+                            self.content,
+                            r#"    <text x="0" y="{:.2}" font-family="{}" font-size="{:.1}" font-weight="{}" fill="{}" text-anchor="{}" xml:space="preserve">{}</text>"#,
+                            baseline_y,
+                            font_family,
+                            font_size,
+                            weight.numeric(),
+                            color,
+                            text_anchor,
+                            self.escape_xml(text)
+                        )
+                        .unwrap();
+                    }
+                }
+                #[cfg(feature = "typst-math")]
+                TextEngineMode::Typst => {
+                    let rendered = typst_rendered
+                        .take()
+                        .expect("Typst annotation rendering must produce SVG output");
+                    let embedded_svg = self.embedded_typst_svg(&rendered);
+                    writeln!(
+                        self.content,
+                        r#"    <g data-ruviz-text-engine="typst" transform="translate({:.2},{:.2})">{}</g>"#,
+                        layout.text_x, layout.text_y, embedded_svg
+                    )
+                    .unwrap();
+                }
+            }
+        }
+
+        writeln!(self.content, "  </g>").unwrap();
+        Ok(())
+    }
+
     /// Draw text at specified position.
     /// `y` is interpreted as the top of the text rendering area.
     pub fn draw_text(&mut self, text: &str, x: f32, y: f32, size: f32, color: Color) -> Result<()> {
@@ -627,7 +823,7 @@ impl SvgRenderer {
                     rendered.height,
                     TypstTextAnchor::TopLeft,
                 );
-                let embedded_svg = self.strip_xml_declaration(&rendered.svg);
+                let embedded_svg = self.embedded_typst_svg(&rendered);
                 writeln!(
                     self.content,
                     r#"  <g data-ruviz-text-engine="typst" transform="translate({:.2},{:.2})">{}</g>"#,
@@ -649,26 +845,91 @@ impl SvgRenderer {
         size: f32,
         color: Color,
     ) -> Result<()> {
+        self.draw_text_centered_impl(text, x, y, size, color, None)
+    }
+
+    pub(crate) fn draw_text_centered_with_weight(
+        &mut self,
+        text: &str,
+        x: f32,
+        y: f32,
+        size: f32,
+        color: Color,
+        weight: FontWeight,
+    ) -> Result<()> {
+        self.draw_text_centered_impl(text, x, y, size, color, Some(weight))
+    }
+
+    fn draw_text_centered_impl(
+        &mut self,
+        text: &str,
+        x: f32,
+        y: f32,
+        size: f32,
+        color: Color,
+        weight: Option<FontWeight>,
+    ) -> Result<()> {
         match self.text_engine_mode {
             TextEngineMode::Plain => {
                 let color_str = self.color_to_svg(color);
-                let escaped_text = self.escape_xml(text);
-                let metrics = self.plain_text_metrics(text, size)?;
+                let resolved_weight = weight.unwrap_or(FontWeight::Normal);
+                let config =
+                    FontConfig::new(self.font_family.clone(), size).weight(resolved_weight);
+                let metrics = self.plain_text_metrics_with_config(text, &config)?;
                 let baseline_y = top_anchor_to_baseline(y, metrics);
                 let font_family = self.escaped_font_family();
-                writeln!(
-                    self.content,
-                    r#"  <text x="{:.2}" y="{:.2}" font-family="{}" font-size="{:.1}" fill="{}" text-anchor="middle">{}</text>"#,
-                    x, baseline_y, font_family, size, color_str, escaped_text
-                )
-                .unwrap();
+                let weight_attr = weight
+                    .map(|weight| format!(r#" font-weight="{}""#, weight.numeric()))
+                    .unwrap_or_default();
+                if text.contains('\n') {
+                    write!(
+                        self.content,
+                        r#"  <text x="{:.2}" font-family="{}" font-size="{:.1}"{} fill="{}" text-anchor="middle" xml:space="preserve">"#,
+                        x, font_family, size, weight_attr, color_str
+                    )
+                    .unwrap();
+                    let line_height = size * 1.2;
+                    for (line_index, line) in text.split('\n').enumerate() {
+                        let line = line.strip_suffix('\r').unwrap_or(line);
+                        let line_y = baseline_y + line_index as f32 * line_height;
+                        write!(
+                            self.content,
+                            r#"<tspan x="{:.2}" y="{:.2}">{}</tspan>"#,
+                            x,
+                            line_y,
+                            self.escape_xml(line)
+                        )
+                        .unwrap();
+                    }
+                    writeln!(self.content, "</text>").unwrap();
+                } else {
+                    writeln!(
+                        self.content,
+                        r#"  <text x="{:.2}" y="{:.2}" font-family="{}" font-size="{:.1}"{} fill="{}" text-anchor="middle" xml:space="preserve">{}</text>"#,
+                        x,
+                        baseline_y,
+                        font_family,
+                        size,
+                        weight_attr,
+                        color_str,
+                        self.escape_xml(text)
+                    )
+                    .unwrap();
+                }
                 Ok(())
             }
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
+                let multiline_text = typst_text::with_explicit_line_breaks(text);
+                let weighted_text =
+                    weight.map(|weight| typst_text::with_font_weight(&multiline_text, weight));
+                let aligned_text = typst_text::with_horizontal_alignment(
+                    weighted_text.as_deref().unwrap_or(&multiline_text),
+                    TextAlign::Center,
+                );
                 let rendered = typst_text::render_svg_with_font_family(
-                    text,
+                    &aligned_text,
                     size_pt,
                     color,
                     0.0,
@@ -682,7 +943,7 @@ impl SvgRenderer {
                     rendered.height,
                     TypstTextAnchor::TopCenter,
                 );
-                let embedded_svg = self.strip_xml_declaration(&rendered.svg);
+                let embedded_svg = self.embedded_typst_svg(&rendered);
                 writeln!(
                     self.content,
                     r#"  <g data-ruviz-text-engine="typst" transform="translate({:.2},{:.2})">{}</g>"#,
@@ -737,7 +998,7 @@ impl SvgRenderer {
                     rendered.height,
                     TypstTextAnchor::Center,
                 );
-                let embedded_svg = self.strip_xml_declaration(&rendered.svg);
+                let embedded_svg = self.embedded_typst_svg(&rendered);
                 writeln!(
                     self.content,
                     r#"  <g data-ruviz-text-engine="typst" transform="translate({:.2},{:.2})">{}</g>"#,

--- a/src/export/svg/tests.rs
+++ b/src/export/svg/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::core::TextVAlign;
 
 fn svg_attr_value<'a>(line: &'a str, attr: &str) -> &'a str {
     let marker = format!(r#"{}=""#, attr);
@@ -687,6 +688,291 @@ fn test_typst_tick_labels_follow_plain_anchor_math() {
         (translates[1].0 - expected_y).abs() <= 0.6
             && (translates[1].1 - expected_y_top).abs() <= 0.6
     );
+}
+
+#[test]
+fn styled_text_defaults_to_center_middle_and_scales_decoration() {
+    let render = |dpi| {
+        let mut renderer = SvgRenderer::new(240.0, 160.0);
+        renderer.set_render_scale(RenderScale::new(dpi));
+        let style = TextStyle {
+            font_size: 12.0,
+            color: Color::BLACK,
+            align: TextAlign::Center,
+            valign: TextVAlign::Middle,
+            rotation: 0.0,
+            background: Some(Color::new_rgba(255, 0, 0, 128)),
+            padding: 3.0,
+            border_color: Some(Color::BLUE),
+            border_width: 1.5,
+        };
+        renderer
+            .draw_styled_text("Anchor", 120.0, 80.0, &FontFamily::SansSerif, &style)
+            .unwrap();
+        renderer.to_svg_string()
+    };
+
+    let low = render(72.0);
+    let high = render(144.0);
+    let low_rect = svg_element_lines(&low, "rect")
+        .into_iter()
+        .find(|line| line.contains("rgba(255,0,0,0.502)"))
+        .unwrap();
+    let high_rect = svg_element_lines(&high, "rect")
+        .into_iter()
+        .find(|line| line.contains("rgba(255,0,0,0.502)"))
+        .unwrap();
+
+    let low_x = parse_svg_attr(low_rect, "x");
+    let low_y = parse_svg_attr(low_rect, "y");
+    let low_width = parse_svg_attr(low_rect, "width");
+    let low_height = parse_svg_attr(low_rect, "height");
+    let high_width = parse_svg_attr(high_rect, "width");
+    let high_height = parse_svg_attr(high_rect, "height");
+    assert_approx_eq(low_x + low_width / 2.0, 0.0);
+    assert_approx_eq(low_y + low_height / 2.0, 0.0);
+    assert!(high_width > low_width * 1.8);
+    assert!(high_height > low_height * 1.8);
+    assert_eq!(svg_attr_value(low_rect, "stroke-width"), "1.50");
+    assert_eq!(svg_attr_value(high_rect, "stroke-width"), "3.00");
+    assert!(low.contains(r#"text-anchor="middle""#));
+}
+
+#[test]
+fn styled_text_honors_alignment_counter_clockwise_rotation_and_font_family() {
+    let mut renderer = SvgRenderer::new(240.0, 160.0);
+    renderer.set_render_scale(RenderScale::new(144.0));
+    let style = TextStyle {
+        font_size: 10.0,
+        color: Color::new_rgba(10, 20, 30, 200),
+        align: TextAlign::Right,
+        valign: TextVAlign::Bottom,
+        rotation: 30.0,
+        background: Some(Color::new(240, 230, 220)),
+        padding: 2.0,
+        border_color: Some(Color::new_rgba(40, 50, 60, 128)),
+        border_width: 2.0,
+    };
+    renderer
+        .draw_styled_text(
+            "Styled",
+            100.0,
+            70.0,
+            &FontFamily::Name("New Computer Modern Sans".to_string()),
+            &style,
+        )
+        .unwrap();
+
+    let svg = renderer.to_svg_string();
+    assert!(svg.contains(r#"transform="translate(100.00,70.00) rotate(-30.00)""#));
+    assert!(svg.contains(r#"text-anchor="end""#));
+    assert!(svg.contains(r#"font-family="&quot;New Computer Modern Sans&quot;""#));
+    assert!(svg.contains(r#"font-weight="400""#));
+    assert!(svg.contains(r#"fill="rgba(10,20,30,0.784)""#));
+
+    let rect = svg_element_lines(&svg, "rect")
+        .into_iter()
+        .find(|line| line.contains("rgb(240,230,220)"))
+        .unwrap();
+    let rect_x = parse_svg_attr(rect, "x");
+    let rect_y = parse_svg_attr(rect, "y");
+    let rect_width = parse_svg_attr(rect, "width");
+    let rect_height = parse_svg_attr(rect, "height");
+    assert_approx_eq(rect_x + rect_width, 4.0);
+    assert_approx_eq(rect_y + rect_height, 4.0);
+    assert_eq!(svg_attr_value(rect, "stroke-width"), "4.00");
+}
+
+#[test]
+fn styled_multiline_text_uses_explicit_tspans_and_block_decoration() {
+    let mut renderer = SvgRenderer::new(240.0, 160.0);
+    renderer.set_render_scale(RenderScale::new(72.0));
+    let style = TextStyle::default()
+        .font_size(12.0)
+        .color(Color::BLACK)
+        .background(Color::new(240, 230, 220))
+        .padding(2.0)
+        .rotation(20.0);
+    renderer
+        .draw_styled_text(
+            "first\nsecond\nthird",
+            120.0,
+            80.0,
+            &FontFamily::SansSerif,
+            &style,
+        )
+        .unwrap();
+
+    let svg = renderer.to_svg_string();
+    assert_eq!(svg.matches("<tspan ").count(), 3);
+    assert!(svg.contains(r#"rotate(-20.00)"#));
+    let rect = svg_element_lines(&svg, "rect")
+        .into_iter()
+        .find(|line| line.contains("rgb(240,230,220)"))
+        .unwrap();
+    assert!(parse_svg_attr(rect, "height") > 40.0);
+}
+
+#[test]
+fn styled_multiline_text_preserves_per_line_center_and_right_alignment() {
+    for (align, anchor) in [(TextAlign::Center, "middle"), (TextAlign::Right, "end")] {
+        let mut renderer = SvgRenderer::new(240.0, 160.0);
+        let style = TextStyle::default().align(align).font_size(12.0);
+        renderer
+            .draw_styled_text(
+                "a much wider line\nshort",
+                120.0,
+                80.0,
+                &FontFamily::SansSerif,
+                &style,
+            )
+            .unwrap();
+
+        let svg = renderer.to_svg_string();
+        let text = svg
+            .lines()
+            .find(|line| line.contains("a much wider line"))
+            .expect("multiline text element");
+        assert!(text.contains(&format!(r#"text-anchor="{anchor}""#)));
+        assert_eq!(text.matches(r#"<tspan x="0""#).count(), 2);
+    }
+}
+
+#[test]
+fn decorated_empty_and_whitespace_annotations_use_one_line_geometry_without_glyphs() {
+    let render = |text: &str| {
+        let mut renderer = SvgRenderer::new(200.0, 120.0);
+        renderer.set_render_scale(RenderScale::new(72.0));
+        let style = TextStyle::default()
+            .font_size(12.0)
+            .background(Color::RED)
+            .padding(2.0)
+            .border(Color::BLUE, 1.0);
+        renderer
+            .draw_styled_text(text, 100.0, 60.0, &FontFamily::SansSerif, &style)
+            .unwrap();
+        renderer.to_svg_string()
+    };
+
+    let empty = render("");
+    let whitespace = render(" \t\n  ");
+    assert_eq!(empty, whitespace);
+    let rect = svg_element_lines(&empty, "rect")
+        .into_iter()
+        .find(|line| line.contains("rgb(255,0,0)"))
+        .expect("decoration rectangle");
+    assert_approx_eq(parse_svg_attr(rect, "width"), 4.0);
+    assert_approx_eq(parse_svg_attr(rect, "height"), 16.0);
+    assert!(!empty.contains("<text "));
+    assert!(!empty.contains(r#"data-ruviz-text-engine="typst""#));
+}
+
+#[test]
+fn styled_annotation_preserves_authored_svg_whitespace_without_formatting_text_nodes() {
+    let mut renderer = SvgRenderer::new(200.0, 120.0);
+    let style = TextStyle::default().align(TextAlign::Right);
+    renderer
+        .draw_styled_text(
+            "  lead\t  gap\n \tsecond",
+            100.0,
+            60.0,
+            &FontFamily::SansSerif,
+            &style,
+        )
+        .unwrap();
+
+    let svg = renderer.to_svg_string();
+    let text = svg
+        .lines()
+        .find(|line| line.contains("lead\t  gap"))
+        .expect("whitespace-preserving annotation text");
+    assert!(text.contains(r#"xml:space="preserve""#));
+    assert!(text.contains(">  lead\t  gap</tspan><tspan"));
+    assert!(text.ends_with("> \tsecond</tspan></text>"));
+    assert!(!text.contains("</tspan>      <tspan"));
+}
+
+#[test]
+fn weighted_multiline_title_uses_matching_metrics_tspans_and_svg_whitespace() {
+    let mut renderer = SvgRenderer::with_font_family(240.0, 160.0, FontFamily::Monospace);
+    let text = "  wide\tgap\n  x";
+    renderer
+        .draw_text_centered_with_weight(text, 120.0, 20.0, 12.0, Color::BLACK, FontWeight::Bold)
+        .unwrap();
+
+    let config = FontConfig::new(FontFamily::Monospace, 12.0).weight(FontWeight::Bold);
+    let metrics = renderer
+        .plain_text_metrics_with_config(text, &config)
+        .unwrap();
+    let svg = renderer.to_svg_string();
+    let title = svg
+        .lines()
+        .find(|line| line.contains("wide\tgap"))
+        .expect("multiline title element");
+    assert!(title.contains(r#"font-family="monospace""#));
+    assert!(title.contains(r#"font-weight="700""#));
+    assert!(title.contains(r#"text-anchor="middle""#));
+    assert!(title.contains(r#"xml:space="preserve""#));
+    assert!(title.contains(r#"><tspan x="120.00" y="#));
+    assert!(title.contains(">  wide\tgap</tspan><tspan"));
+    assert!(title.ends_with(">  x</tspan></text>"));
+    assert_eq!(title.matches("<tspan ").count(), 2);
+
+    let first_tspan = title.find("<tspan ").unwrap();
+    let first_y = parse_svg_attr(&title[first_tspan..], "y");
+    assert_approx_eq(first_y, top_anchor_to_baseline(20.0, metrics));
+    assert!(metrics.height >= 24.0);
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn typst_decorated_whitespace_annotation_uses_plain_one_line_geometry() {
+    let mut renderer = SvgRenderer::new(200.0, 120.0);
+    renderer.set_render_scale(RenderScale::new(72.0));
+    renderer.set_text_engine_mode(TextEngineMode::Typst);
+    let style = TextStyle::default()
+        .font_size(12.0)
+        .background(Color::RED)
+        .padding(2.0);
+    renderer
+        .draw_styled_text(" \t\n ", 100.0, 60.0, &FontFamily::SansSerif, &style)
+        .unwrap();
+
+    let svg = renderer.to_svg_string();
+    let rect = svg_element_lines(&svg, "rect")
+        .into_iter()
+        .find(|line| line.contains("rgb(255,0,0)"))
+        .expect("Typst-mode decoration rectangle");
+    assert_approx_eq(parse_svg_attr(rect, "width"), 4.0);
+    assert_approx_eq(parse_svg_attr(rect, "height"), 16.0);
+    assert!(!svg.contains(r#"data-ruviz-text-engine="typst""#));
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn embedded_typst_svg_uses_outer_unitless_dimensions() {
+    let renderer = SvgRenderer::new(200.0, 150.0);
+    let rendered = typst_text::render_svg_with_font_family(
+        "Frame",
+        12.0,
+        Color::BLACK,
+        0.0,
+        &FontFamily::SansSerif,
+        "Typst SVG framing test",
+    )
+    .unwrap();
+    let embedded = renderer.embedded_typst_svg(&rendered);
+    let root = embedded
+        .lines()
+        .find(|line| line.contains("<svg"))
+        .expect("embedded Typst SVG root");
+    let width = svg_attr_value(root, "width");
+    let height = svg_attr_value(root, "height");
+
+    assert!(!width.ends_with("pt"));
+    assert!(!height.ends_with("pt"));
+    assert_approx_eq(width.parse().unwrap(), rendered.width);
+    assert_approx_eq(height.parse().unwrap(), rendered.height);
 }
 
 #[cfg(feature = "typst-math")]

--- a/src/render/skia.rs
+++ b/src/render/skia.rs
@@ -7,7 +7,7 @@ use crate::{
         pt_to_px,
     },
     render::{
-        Color, FontConfig, FontFamily, LineStyle, MarkerStyle, TextRenderer, Theme,
+        Color, FontConfig, FontFamily, FontWeight, LineStyle, MarkerStyle, TextRenderer, Theme,
         typst_text::{self, TypstBackendKind, TypstTextAnchor},
     },
 };
@@ -1324,9 +1324,21 @@ impl SkiaRenderer {
         size: f32,
         color: Color,
     ) -> Result<()> {
+        self.draw_text_centered_with_weight(text, center_x, y, size, color, FontWeight::Normal)
+    }
+
+    pub(crate) fn draw_text_centered_with_weight(
+        &mut self,
+        text: &str,
+        center_x: f32,
+        y: f32,
+        size: f32,
+        color: Color,
+        weight: FontWeight,
+    ) -> Result<()> {
         match self.text_engine_mode {
             TextEngineMode::Plain => {
-                let config = FontConfig::new(self.font_config.family.clone(), size);
+                let config = FontConfig::new(self.font_config.family.clone(), size).weight(weight);
                 self.text_renderer.render_text_centered(
                     &mut self.pixmap,
                     text,
@@ -1339,8 +1351,14 @@ impl SkiaRenderer {
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
+                let multiline_text = typst_text::with_explicit_line_breaks(text);
+                let weighted_text = typst_text::with_font_weight(&multiline_text, weight);
+                let aligned_text = typst_text::with_horizontal_alignment(
+                    &weighted_text,
+                    crate::core::TextAlign::Center,
+                );
                 let rendered = typst_text::render_raster_with_font_family(
-                    text,
+                    &aligned_text,
                     size_pt,
                     color,
                     0.0,
@@ -1362,16 +1380,31 @@ impl SkiaRenderer {
 
     /// Measure text dimensions
     pub fn measure_text(&self, text: &str, size: f32) -> Result<(f32, f32)> {
+        self.measure_text_with_weight(text, size, FontWeight::Normal)
+    }
+
+    pub(crate) fn measure_text_with_weight(
+        &self,
+        text: &str,
+        size: f32,
+        weight: FontWeight,
+    ) -> Result<(f32, f32)> {
         match self.text_engine_mode {
             TextEngineMode::Plain => {
-                let config = FontConfig::new(self.font_config.family.clone(), size);
+                let config = FontConfig::new(self.font_config.family.clone(), size).weight(weight);
                 self.text_renderer.measure_text(text, &config)
             }
             #[cfg(feature = "typst-math")]
             TextEngineMode::Typst => {
                 let size_pt = self.typst_size_pt(size);
+                let multiline_text = typst_text::with_explicit_line_breaks(text);
+                let weighted_text = typst_text::with_font_weight(&multiline_text, weight);
+                let aligned_text = typst_text::with_horizontal_alignment(
+                    &weighted_text,
+                    crate::core::TextAlign::Center,
+                );
                 typst_text::measure_text_with_font_family(
-                    text,
+                    &aligned_text,
                     size_pt,
                     self.theme.foreground,
                     0.0,
@@ -1806,7 +1839,17 @@ impl SkiaRenderer {
     ///
     /// This is the preferred method for content-driven layout.
     pub fn draw_title_at(&mut self, pos: &TextPosition, text: &str, color: Color) -> Result<()> {
-        self.draw_text_centered(text, pos.x, pos.y, pos.size, color)
+        self.draw_title_at_with_weight(pos, text, color, FontWeight::Normal)
+    }
+
+    pub(crate) fn draw_title_at_with_weight(
+        &mut self,
+        pos: &TextPosition,
+        text: &str,
+        color: Color,
+        weight: FontWeight,
+    ) -> Result<()> {
+        self.draw_text_centered_with_weight(text, pos.x, pos.y, pos.size, color, weight)
     }
 
     /// Draw X-axis label at a computed position from LayoutCalculator

--- a/src/render/skia/annotations.rs
+++ b/src/render/skia/annotations.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::axes::AxisScale;
+use crate::{axes::AxisScale, render::text_anchor::annotation_text_layout};
 
 struct AnnotationTransform<'a> {
     plot_area: Rect,
@@ -134,11 +134,13 @@ impl SkiaRenderer {
         dpi: f32,
         x_scale: &AxisScale,
         y_scale: &AxisScale,
-        mut should_draw: F,
+        should_draw: F,
     ) -> Result<()>
     where
         F: FnMut(&crate::core::Annotation) -> bool,
     {
+        let mut should_draw = should_draw;
+
         let transform = AnnotationTransform {
             plot_area,
             x_min,
@@ -214,7 +216,7 @@ impl SkiaRenderer {
         }
     }
 
-    /// Draw a text annotation at data coordinates
+    /// Draw a text annotation at data coordinates.
     fn draw_annotation_text(
         &mut self,
         x: f64,
@@ -225,12 +227,177 @@ impl SkiaRenderer {
         dpi: f32,
     ) -> Result<()> {
         let (px, py) = transform.point(x, y);
+        let render_scale = RenderScale::new(dpi);
+        let font_size_px = render_scale.points_to_pixels(style.font_size.max(0.1));
+        let padding_px = render_scale.points_to_pixels(style.padding.max(0.0));
+        let border_width_px = render_scale.points_to_pixels(style.border_width.max(0.0));
+        let text_visible = style.color.a > 0 && !text.trim().is_empty();
+        let background_visible = style.background.is_some_and(|color| color.a > 0);
+        let border_visible =
+            border_width_px > 0.0 && style.border_color.is_some_and(|color| color.a > 0);
+        if !text_visible && !background_visible && !border_visible {
+            return Ok(());
+        }
+        let font = FontConfig::new(self.font_config.family.clone(), font_size_px)
+            .weight(FontWeight::Normal);
 
-        // Convert font size from points to pixels
-        let font_size_px = pt_to_px(style.font_size, dpi);
+        #[cfg(feature = "typst-math")]
+        let mut typst_rendered = None;
+        let metrics = if text.trim().is_empty() {
+            crate::render::text_anchor::TextPlacementMetrics::new(0.0, font_size_px, font_size_px)
+        } else {
+            match self.text_engine_mode {
+                TextEngineMode::Plain => self.text_renderer.measure_text_placement(text, &font)?,
+                #[cfg(feature = "typst-math")]
+                TextEngineMode::Typst => {
+                    let multiline_text = typst_text::with_explicit_line_breaks(text);
+                    let weighted_text = typst_text::with_font_weight(&multiline_text, font.weight);
+                    let aligned_text =
+                        typst_text::with_horizontal_alignment(&weighted_text, style.align);
+                    let rendered = typst_text::render_raster_with_font_family(
+                        &aligned_text,
+                        self.typst_size_pt(font_size_px),
+                        style.color,
+                        0.0,
+                        &font.family,
+                        "Skia annotation text rendering",
+                    )?;
+                    let metrics = crate::render::text_anchor::TextPlacementMetrics::new(
+                        rendered.width,
+                        rendered.height,
+                        rendered.height,
+                    );
+                    typst_rendered = Some(rendered);
+                    metrics
+                }
+            }
+        };
+        let layout = annotation_text_layout(
+            metrics,
+            style.align,
+            style.valign,
+            padding_px,
+            style.rotation,
+        );
+        let local_to_canvas = Transform::from_rotate(layout.rotation).post_translate(px, py);
 
-        // Draw text at the position (could add background box and rotation in future)
-        self.draw_text(text, px, py, font_size_px, style.color)
+        if (background_visible || border_visible)
+            && let Some(rect) = Rect::from_xywh(
+                layout.box_x,
+                layout.box_y,
+                layout.box_width,
+                layout.box_height,
+            )
+        {
+            let mut path = PathBuilder::new();
+            path.push_rect(rect);
+            if let Some(path) = path.finish() {
+                if background_visible && let Some(background) = style.background {
+                    let mut paint = Paint::default();
+                    paint.set_color(background.to_tiny_skia_color());
+                    paint.anti_alias = true;
+                    self.fill_path_masked(&path, &paint, FillRule::Winding, local_to_canvas, None)?;
+                }
+                if border_visible && let Some(border_color) = style.border_color {
+                    let mut paint = Paint::default();
+                    paint.set_color(border_color.to_tiny_skia_color());
+                    paint.anti_alias = true;
+                    let stroke = Stroke {
+                        width: border_width_px,
+                        ..Stroke::default()
+                    };
+                    self.stroke_path_masked(&path, &paint, &stroke, local_to_canvas, None)?;
+                }
+            }
+        }
+
+        if !text_visible {
+            return Ok(());
+        }
+
+        match self.text_engine_mode {
+            TextEngineMode::Plain => {
+                if layout.rotation.abs() <= f32::EPSILON {
+                    return self.text_renderer.render_text_aligned(
+                        &mut self.pixmap,
+                        text,
+                        px + layout.text_x,
+                        py + layout.text_y,
+                        metrics.width,
+                        style.align,
+                        &font,
+                        style.color,
+                    );
+                }
+
+                let glyph_guard = font_size_px.ceil().max(2.0);
+                let layer_width = (metrics.width + 2.0 * glyph_guard).ceil().max(1.0) as u32;
+                let layer_height = (metrics.height + 2.0 * glyph_guard).ceil().max(1.0) as u32;
+                crate::render::text::validate_text_raster_size(
+                    layer_width,
+                    layer_height,
+                    "Rotated annotation text",
+                )?;
+                let mut layer =
+                    Pixmap::new(layer_width, layer_height).ok_or(PlottingError::RenderError(
+                        "Failed to allocate rotated annotation text layer".to_string(),
+                    ))?;
+                layer.fill(tiny_skia::Color::TRANSPARENT);
+                self.text_renderer.render_text_aligned(
+                    &mut layer,
+                    text,
+                    glyph_guard,
+                    glyph_guard,
+                    metrics.width,
+                    style.align,
+                    &font,
+                    style.color,
+                )?;
+                let text_transform = Transform::from_translate(
+                    layout.text_x - glyph_guard,
+                    layout.text_y - glyph_guard,
+                )
+                .post_rotate(layout.rotation)
+                .post_translate(px, py);
+                let paint = PixmapPaint {
+                    quality: FilterQuality::Bilinear,
+                    ..PixmapPaint::default()
+                };
+                self.pixmap
+                    .draw_pixmap(0, 0, layer.as_ref(), &paint, text_transform, None);
+                Ok(())
+            }
+            #[cfg(feature = "typst-math")]
+            TextEngineMode::Typst => {
+                let rendered = typst_rendered
+                    .take()
+                    .expect("Typst annotation rendering must produce a raster");
+                if layout.rotation.abs() <= f32::EPSILON {
+                    self.draw_typst_raster(&rendered, px + layout.text_x, py + layout.text_y);
+                    return Ok(());
+                }
+
+                let scale_x = rendered.pixmap.width().max(1) as f32 / rendered.width.max(1e-6);
+                let scale_y = rendered.pixmap.height().max(1) as f32 / rendered.height.max(1e-6);
+                let text_transform = Transform::from_scale(1.0 / scale_x, 1.0 / scale_y)
+                    .post_translate(layout.text_x, layout.text_y)
+                    .post_rotate(layout.rotation)
+                    .post_translate(px, py);
+                let paint = PixmapPaint {
+                    quality: FilterQuality::Bilinear,
+                    ..PixmapPaint::default()
+                };
+                self.pixmap.draw_pixmap(
+                    0,
+                    0,
+                    rendered.pixmap.as_ref(),
+                    &paint,
+                    text_transform,
+                    None,
+                );
+                Ok(())
+            }
+        }
     }
 
     /// Draw an arrow annotation

--- a/src/render/skia/primitives.rs
+++ b/src/render/skia/primitives.rs
@@ -266,7 +266,7 @@ impl SkiaRenderer {
         Ok(mask)
     }
 
-    fn fill_path_masked(
+    pub(super) fn fill_path_masked(
         &mut self,
         path: &tiny_skia::Path,
         paint: &Paint,
@@ -280,7 +280,7 @@ impl SkiaRenderer {
         Ok(())
     }
 
-    fn stroke_path_masked(
+    pub(super) fn stroke_path_masked(
         &mut self,
         path: &tiny_skia::Path,
         paint: &Paint,

--- a/src/render/skia/tests.rs
+++ b/src/render/skia/tests.rs
@@ -47,6 +47,50 @@ fn dark_pixel_bounds(image: &Image) -> Option<(u32, u32, u32, u32)> {
     found.then_some((min_x, min_y, max_x, max_y))
 }
 
+fn red_pixel_positions(image: &Image) -> Vec<(f32, f32)> {
+    let mut positions = Vec::new();
+    for y in 0..image.height {
+        for x in 0..image.width {
+            let pixel = image_pixel_rgba(image, x, y);
+            if pixel[0] > 200 && pixel[1] < 80 && pixel[2] < 80 && pixel[3] > 0 {
+                positions.push((x as f32, y as f32));
+            }
+        }
+    }
+    positions
+}
+
+fn red_dominant_pixel_positions(image: &Image) -> Vec<(f32, f32)> {
+    let mut positions = Vec::new();
+    for y in 0..image.height {
+        for x in 0..image.width {
+            let pixel = image_pixel_rgba(image, x, y);
+            if pixel[3] > 0
+                && pixel[0] > 80
+                && pixel[0] > pixel[1].saturating_add(40)
+                && pixel[0] > pixel[2].saturating_add(40)
+            {
+                positions.push((x as f32, y as f32));
+            }
+        }
+    }
+    positions
+}
+
+fn position_bounds(positions: &[(f32, f32)]) -> (f32, f32, f32, f32) {
+    positions.iter().copied().fold(
+        (
+            f32::INFINITY,
+            f32::INFINITY,
+            f32::NEG_INFINITY,
+            f32::NEG_INFINITY,
+        ),
+        |(min_x, min_y, max_x, max_y), (x, y)| {
+            (min_x.min(x), min_y.min(y), max_x.max(x), max_y.max(y))
+        },
+    )
+}
+
 fn assert_exact_rgba_pixels(name: &str, reference: &Image, candidate: &Image) {
     assert_eq!(reference.width, candidate.width, "{name} width changed");
     assert_eq!(reference.height, candidate.height, "{name} height changed");
@@ -1041,6 +1085,272 @@ fn test_draw_colorbar_scales_border_width_with_render_dpi() {
         high_darkness > low_darkness * 1.2,
         "colorbar border width should scale with DPI: low_darkness={low_darkness}, high_darkness={high_darkness}"
     );
+}
+
+fn render_text_annotation(text: &str, style: crate::core::TextStyle, dpi: f32) -> Image {
+    render_text_annotation_with_mode(text, style, dpi, TextEngineMode::Plain)
+}
+
+fn render_text_annotation_with_mode(
+    text: &str,
+    style: crate::core::TextStyle,
+    dpi: f32,
+    mode: TextEngineMode,
+) -> Image {
+    let mut renderer = SkiaRenderer::new(320, 320, Theme::light()).unwrap();
+    renderer.set_text_engine_mode(mode);
+    let plot_area = Rect::from_xywh(40.0, 40.0, 240.0, 240.0).unwrap();
+    let annotation = crate::core::Annotation::text_styled(0.5, 0.5, text, style);
+    renderer
+        .draw_annotations_where_scaled(
+            &[annotation],
+            plot_area,
+            0.0,
+            1.0,
+            0.0,
+            1.0,
+            dpi,
+            &crate::axes::AxisScale::Linear,
+            &crate::axes::AxisScale::Linear,
+            |_| true,
+        )
+        .unwrap();
+    renderer.into_image()
+}
+
+fn multiline_local_x_bounds(image: &Image, rotation: f32) -> [(f32, f32); 2] {
+    let angle = rotation.to_radians();
+    let local: Vec<(f32, f32)> = red_dominant_pixel_positions(image)
+        .into_iter()
+        .map(|(x, y)| {
+            let dx = x - 160.0;
+            let dy = y - 160.0;
+            (
+                dx * angle.cos() - dy * angle.sin(),
+                dx * angle.sin() + dy * angle.cos(),
+            )
+        })
+        .collect();
+    assert!(
+        local.len() > 20,
+        "multiline annotation should render glyphs"
+    );
+    let (min_y, max_y) = local.iter().fold(
+        (f32::INFINITY, f32::NEG_INFINITY),
+        |(min_y, max_y), (_, y)| (min_y.min(*y), max_y.max(*y)),
+    );
+    let split_y = (min_y + max_y) / 2.0;
+    let bounds = |upper: bool| {
+        local.iter().filter(|(_, y)| (*y <= split_y) == upper).fold(
+            (f32::INFINITY, f32::NEG_INFINITY),
+            |(min_x, max_x), (x, _)| (min_x.min(*x), max_x.max(*x)),
+        )
+    };
+    [bounds(true), bounds(false)]
+}
+
+fn assert_multiline_annotation_alignment(
+    mode: TextEngineMode,
+    text: &str,
+    align: crate::core::TextAlign,
+    rotation: f32,
+) {
+    let style = crate::core::TextStyle::default()
+        .font_size(18.0)
+        .color(Color::RED)
+        .padding(0.0)
+        .align(align)
+        .rotation(rotation);
+    let image = render_text_annotation_with_mode(text, style, 72.0, mode);
+    let [wide, short] = multiline_local_x_bounds(&image, rotation);
+    match align {
+        crate::core::TextAlign::Center => assert!(
+            ((wide.0 + wide.1) / 2.0 - (short.0 + short.1) / 2.0).abs() <= 3.0,
+            "center-aligned line centers differ: wide={wide:?}, short={short:?}"
+        ),
+        crate::core::TextAlign::Right => assert!(
+            (wide.1 - short.1).abs() <= 3.0,
+            "right-aligned line edges differ: wide={wide:?}, short={short:?}"
+        ),
+        crate::core::TextAlign::Left => unreachable!("focused helper tests center/right only"),
+    }
+}
+
+#[test]
+fn text_annotation_default_anchor_is_center_middle_and_scales_with_dpi() {
+    let style = crate::core::TextStyle::default()
+        .font_size(12.0)
+        .color(Color::TRANSPARENT)
+        .background(Color::RED)
+        .padding(3.0);
+    let low = render_text_annotation("MMMMMMMM", style.clone(), 72.0);
+    let high = render_text_annotation("MMMMMMMM", style, 144.0);
+    let low_positions = red_pixel_positions(&low);
+    let high_positions = red_pixel_positions(&high);
+    assert!(!low_positions.is_empty());
+    assert!(!high_positions.is_empty());
+    let low_bounds = position_bounds(&low_positions);
+    let high_bounds = position_bounds(&high_positions);
+    let low_width = low_bounds.2 - low_bounds.0 + 1.0;
+    let low_height = low_bounds.3 - low_bounds.1 + 1.0;
+    let high_width = high_bounds.2 - high_bounds.0 + 1.0;
+    let high_height = high_bounds.3 - high_bounds.1 + 1.0;
+
+    assert!(((low_bounds.0 + low_bounds.2) / 2.0 - 160.0).abs() <= 1.0);
+    assert!(((low_bounds.1 + low_bounds.3) / 2.0 - 160.0).abs() <= 1.0);
+    assert!(high_width > low_width * 1.8);
+    assert!(high_height > low_height * 1.8);
+}
+
+#[test]
+fn positive_text_annotation_rotation_is_counter_clockwise() {
+    let style = crate::core::TextStyle::default()
+        .font_size(12.0)
+        .color(Color::TRANSPARENT)
+        .background(Color::RED)
+        .padding(0.0)
+        .rotation(35.0);
+    let image = render_text_annotation("MMMMMMMM", style, 72.0);
+    let positions = red_pixel_positions(&image);
+    assert!(positions.len() > 20);
+    let mean_x = positions.iter().map(|(x, _)| *x).sum::<f32>() / positions.len() as f32;
+    let mean_y = positions.iter().map(|(_, y)| *y).sum::<f32>() / positions.len() as f32;
+    let covariance = positions
+        .iter()
+        .map(|(x, y)| (*x - mean_x) * (*y - mean_y))
+        .sum::<f32>()
+        / positions.len() as f32;
+
+    assert!(
+        covariance < -20.0,
+        "positive counter-clockwise rotation should rise to the right: covariance={covariance}"
+    );
+}
+
+#[test]
+fn rotated_multiline_text_keeps_all_lines_and_decoration() {
+    let text = "first line\nsecond line\nthird line";
+    let base_style = crate::core::TextStyle::default()
+        .font_size(14.0)
+        .color(Color::RED)
+        .background(Color::GREEN)
+        .padding(2.0)
+        .border(Color::BLUE, 1.5);
+    let unrotated = render_text_annotation(text, base_style.clone(), 72.0);
+    let rotated = render_text_annotation(text, base_style.rotation(30.0), 72.0);
+    let unrotated_red = red_dominant_pixel_positions(&unrotated);
+    let rotated_red = red_dominant_pixel_positions(&rotated);
+    let unrotated_bounds = position_bounds(&unrotated_red);
+    let angle = 30.0_f32.to_radians();
+    let (rotated_min_y, rotated_max_y) = rotated_red.iter().fold(
+        (f32::INFINITY, f32::NEG_INFINITY),
+        |(min_y, max_y), (x, y)| {
+            let dx = *x - 160.0;
+            let dy = *y - 160.0;
+            let local_y = dx * angle.sin() + dy * angle.cos();
+            (min_y.min(local_y), max_y.max(local_y))
+        },
+    );
+    let rotated_green = rotated
+        .pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[1] > 120 && pixel[0] < 100 && pixel[2] < 100)
+        .count();
+    let rotated_blue = rotated
+        .pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[2] > 150 && pixel[0] < 100 && pixel[1] < 100)
+        .count();
+
+    assert!(unrotated_red.len() > 100);
+    assert!(rotated_red.len() > 100);
+    assert!(
+        rotated_max_y - rotated_min_y > (unrotated_bounds.3 - unrotated_bounds.1) * 0.8,
+        "rotated multiline text lost later lines"
+    );
+    assert!(rotated_green > 100);
+    assert!(rotated_blue > 20);
+}
+
+#[test]
+fn plain_multiline_annotation_aligns_each_unequal_width_line_when_rotated_or_unrotated() {
+    for rotation in [0.0, 27.0] {
+        for align in [
+            crate::core::TextAlign::Center,
+            crate::core::TextAlign::Right,
+        ] {
+            assert_multiline_annotation_alignment(
+                TextEngineMode::Plain,
+                "MMMMMMMM\nI",
+                align,
+                rotation,
+            );
+        }
+    }
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn typst_multiline_annotation_aligns_each_unequal_width_line_when_rotated_or_unrotated() {
+    for rotation in [0.0, 27.0] {
+        for align in [
+            crate::core::TextAlign::Center,
+            crate::core::TextAlign::Right,
+        ] {
+            assert_multiline_annotation_alignment(
+                TextEngineMode::Typst,
+                "MMMMMMMM\nI",
+                align,
+                rotation,
+            );
+        }
+    }
+}
+
+#[test]
+fn decorated_empty_and_whitespace_annotations_share_one_line_geometry_without_glyphs() {
+    let style = crate::core::TextStyle::default()
+        .font_size(12.0)
+        .color(Color::TRANSPARENT)
+        .background(Color::RED)
+        .padding(2.0);
+    let empty = render_text_annotation("", style.clone(), 72.0);
+    let whitespace = render_text_annotation(" \t\n ", style, 72.0);
+    assert_exact_rgba_pixels("empty and whitespace decoration", &empty, &whitespace);
+
+    let bounds = position_bounds(&red_pixel_positions(&empty));
+    assert!((bounds.2 - bounds.0 + 1.0 - 4.0).abs() <= 1.0);
+    assert!((bounds.3 - bounds.1 + 1.0 - 16.0).abs() <= 1.0);
+}
+
+#[cfg(feature = "typst-math")]
+#[test]
+fn typst_whitespace_annotation_skips_glyphs_and_matches_plain_decoration() {
+    let style = crate::core::TextStyle::default()
+        .font_size(12.0)
+        .color(Color::BLACK)
+        .background(Color::RED)
+        .padding(2.0);
+    let plain =
+        render_text_annotation_with_mode(" \t\n ", style.clone(), 72.0, TextEngineMode::Plain);
+    let typst = render_text_annotation_with_mode(" \t\n ", style, 72.0, TextEngineMode::Typst);
+    assert_exact_rgba_pixels("plain and Typst whitespace decoration", &plain, &typst);
+}
+
+#[test]
+fn translucent_text_annotation_background_uses_source_over_compositing() {
+    let style = crate::core::TextStyle::default()
+        .font_size(12.0)
+        .color(Color::TRANSPARENT)
+        .background(Color::new_rgba(255, 0, 0, 128))
+        .padding(4.0);
+    let image = render_text_annotation("MMMMMMMM", style, 72.0);
+    let pixel = image_pixel_rgba(&image, 160, 160);
+
+    assert!(pixel[0] >= 250);
+    assert!((120..=135).contains(&pixel[1]));
+    assert!((120..=135).contains(&pixel[2]));
+    assert_eq!(pixel[3], 255);
 }
 
 #[test]

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -74,7 +74,7 @@ impl PixmapTarget for PixmapMut<'_> {
     }
 }
 
-fn validate_text_raster_size(width: u32, height: u32, context: &str) -> Result<()> {
+pub(crate) fn validate_text_raster_size(width: u32, height: u32, context: &str) -> Result<()> {
     if width > MAX_TEXT_RASTER_DIMENSION || height > MAX_TEXT_RASTER_DIMENSION {
         return Err(PlottingError::PerformanceLimit {
             limit_type: format!("{context} raster dimension"),
@@ -197,10 +197,24 @@ fn is_renderable_text(text: &str) -> bool {
     !text.trim().is_empty()
 }
 
+fn text_line_count(text: &str) -> usize {
+    text.split('\n').count().max(1)
+}
+
+fn text_buffer_height(text: &str, size: f32, minimum: f32) -> f32 {
+    let line_height = size * 1.2;
+    (text_line_count(text) as f32 * line_height + size * 2.0).max(minimum)
+}
+
 fn estimate_text_metrics(text: &str, config: &FontConfig) -> TextPlacementMetrics {
-    let char_count = text.chars().count() as f32;
-    let height = (config.size * 1.2).max(config.size);
-    let width = char_count * config.size * 0.6;
+    let max_char_count = text
+        .split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line).chars().count())
+        .max()
+        .unwrap_or(0) as f32;
+    let line_height = (config.size * 1.2).max(config.size);
+    let height = text_line_count(text) as f32 * line_height;
+    let width = max_char_count * config.size * 0.6;
     TextPlacementMetrics::new(width, height, config.size)
 }
 
@@ -421,6 +435,21 @@ pub enum FontWeight {
 }
 
 impl FontWeight {
+    /// Numeric CSS/OpenType weight value.
+    pub(crate) const fn numeric(self) -> u16 {
+        match self {
+            FontWeight::Thin => 100,
+            FontWeight::ExtraLight => 200,
+            FontWeight::Light => 300,
+            FontWeight::Normal => 400,
+            FontWeight::Medium => 500,
+            FontWeight::SemiBold => 600,
+            FontWeight::Bold => 700,
+            FontWeight::ExtraBold => 800,
+            FontWeight::Black => 900,
+        }
+    }
+
     /// Convert to cosmic-text Weight type
     pub fn to_cosmic_weight(self) -> CosmicWeight {
         match self {
@@ -629,7 +658,7 @@ impl TextRenderer {
 
         // Calculate buffer dimensions
         let buffer_width = (text.len() as f32 * config.size * 2.0).max(800.0);
-        let buffer_height = (config.size * 4.0).max(100.0);
+        let buffer_height = text_buffer_height(text, config.size, 100.0);
         buffer.set_size(&mut font_system, Some(buffer_width), Some(buffer_height));
 
         // Set text with font attributes
@@ -698,9 +727,54 @@ impl TextRenderer {
             return Ok(());
         }
 
-        let (width, _) = self.measure_text(text, config)?;
-        let x = center_x - width / 2.0;
-        self.render_text(pixmap, text, x, y, config, color)
+        let metrics = self.measure_text_placement(text, config)?;
+        self.render_text_aligned(
+            pixmap,
+            text,
+            center_x - metrics.width / 2.0,
+            y,
+            metrics.width,
+            crate::core::TextAlign::Center,
+            config,
+            color,
+        )
+    }
+
+    /// Render each line within a fixed-width block using the requested alignment.
+    pub(crate) fn render_text_aligned(
+        &self,
+        pixmap: &mut Pixmap,
+        text: &str,
+        block_x: f32,
+        y: f32,
+        block_width: f32,
+        align: crate::core::TextAlign,
+        config: &FontConfig,
+        color: Color,
+    ) -> Result<()> {
+        if !is_renderable_text(text) || color.a == 0 {
+            return Ok(());
+        }
+
+        let line_height = config.size * 1.2;
+        for (line_index, line) in text.split('\n').enumerate() {
+            let line = line.strip_suffix('\r').unwrap_or(line);
+            let line_width = self.measure_text_placement(line, config)?.width;
+            let offset = match align {
+                crate::core::TextAlign::Left => 0.0,
+                crate::core::TextAlign::Center => (block_width - line_width) / 2.0,
+                crate::core::TextAlign::Right => block_width - line_width,
+            };
+            self.render_text(
+                pixmap,
+                line,
+                block_x + offset,
+                y + line_index as f32 * line_height,
+                config,
+                color,
+            )?;
+        }
+        Ok(())
     }
 
     /// Render text rotated 90 degrees counterclockwise
@@ -741,7 +815,7 @@ impl TextRenderer {
         // Use a generous shaping buffer. Tight placement bounds are computed from
         // rasterized glyph pixels rather than heuristic constants.
         let buffer_width = (text.len() as f32 * config.size * 3.0).max(800.0);
-        let buffer_height = (config.size * 6.0).max(180.0);
+        let buffer_height = text_buffer_height(text, config.size, 180.0);
 
         buffer.set_size(&mut font_system, Some(buffer_width), Some(buffer_height));
 
@@ -904,7 +978,7 @@ impl TextRenderer {
         let mut buffer = Buffer::new(&mut font_system, metrics);
 
         let buffer_width = (text.len() as f32 * config.size * 2.0).max(800.0);
-        let buffer_height = (config.size * 4.0).max(100.0);
+        let buffer_height = text_buffer_height(text, config.size, 100.0);
         buffer.set_size(&mut font_system, Some(buffer_width), Some(buffer_height));
 
         let attrs = config.to_cosmic_attrs();
@@ -917,7 +991,7 @@ impl TextRenderer {
 
         for run in buffer.layout_runs() {
             width = width.max(run.line_w);
-            height = height.max(run.line_height);
+            height = height.max(run.line_top + run.line_height);
             if baseline_from_top.is_none() {
                 baseline_from_top = Some(run.line_y);
             }
@@ -961,7 +1035,7 @@ impl TextRenderer {
         let mut buffer = Buffer::new(&mut font_system, metrics);
 
         let buffer_width = (text.len() as f32 * config.size * 2.0).max(800.0);
-        let buffer_height = (config.size * 4.0).max(100.0);
+        let buffer_height = text_buffer_height(text, config.size, 100.0);
         buffer.set_size(&mut font_system, Some(buffer_width), Some(buffer_height));
 
         let attrs = config.to_cosmic_attrs();
@@ -1255,6 +1329,22 @@ mod tests {
         // Non-empty string should have positive width
         let (w, _h) = renderer.measure_text("Hello", &config).unwrap();
         assert!(w > 0.0);
+    }
+
+    #[test]
+    fn multiline_placement_height_includes_every_line() {
+        let renderer = TextRenderer::new();
+        let config = FontConfig::new(FontFamily::SansSerif, 12.0);
+        let single = renderer.measure_text_placement("first", &config).unwrap();
+        let multiline = renderer
+            .measure_text_placement(
+                "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven\ntwelve",
+                &config,
+            )
+            .unwrap();
+
+        assert!(multiline.height > single.height * 10.0);
+        assert_eq!(multiline.baseline_from_top, single.baseline_from_top);
     }
 
     #[test]

--- a/src/render/text_anchor.rs
+++ b/src/render/text_anchor.rs
@@ -30,7 +30,74 @@ impl TextPlacementMetrics {
 pub enum TextAnchorKind {
     TopLeft,
     TopCenter,
+    TopRight,
+    CenterLeft,
     Center,
+    CenterRight,
+    BottomLeft,
+    BottomCenter,
+    BottomRight,
+}
+
+pub(crate) fn aligned_text_anchor(
+    align: crate::core::TextAlign,
+    valign: crate::core::TextVAlign,
+) -> TextAnchorKind {
+    use crate::core::{TextAlign, TextVAlign};
+
+    match (align, valign) {
+        (TextAlign::Left, TextVAlign::Top) => TextAnchorKind::TopLeft,
+        (TextAlign::Center, TextVAlign::Top) => TextAnchorKind::TopCenter,
+        (TextAlign::Right, TextVAlign::Top) => TextAnchorKind::TopRight,
+        (TextAlign::Left, TextVAlign::Middle) => TextAnchorKind::CenterLeft,
+        (TextAlign::Center, TextVAlign::Middle) => TextAnchorKind::Center,
+        (TextAlign::Right, TextVAlign::Middle) => TextAnchorKind::CenterRight,
+        (TextAlign::Left, TextVAlign::Bottom) => TextAnchorKind::BottomLeft,
+        (TextAlign::Center, TextVAlign::Bottom) => TextAnchorKind::BottomCenter,
+        (TextAlign::Right, TextVAlign::Bottom) => TextAnchorKind::BottomRight,
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct AnnotationTextLayout {
+    pub text_x: f32,
+    pub text_y: f32,
+    pub box_x: f32,
+    pub box_y: f32,
+    pub box_width: f32,
+    pub box_height: f32,
+    /// Screen-coordinate rotation in degrees. Negative is visual counter-clockwise.
+    pub rotation: f32,
+}
+
+pub(crate) fn annotation_text_layout(
+    metrics: TextPlacementMetrics,
+    align: crate::core::TextAlign,
+    valign: crate::core::TextVAlign,
+    padding: f32,
+    counter_clockwise_rotation: f32,
+) -> AnnotationTextLayout {
+    let padding = padding.max(0.0);
+    let (text_x, text_y) = anchor_to_top_left(
+        0.0,
+        0.0,
+        metrics.width,
+        metrics.height,
+        aligned_text_anchor(align, valign),
+    );
+    AnnotationTextLayout {
+        text_x,
+        text_y,
+        box_x: text_x - padding,
+        box_y: text_y - padding,
+        box_width: metrics.width + 2.0 * padding,
+        box_height: metrics.height + 2.0 * padding,
+        rotation: if counter_clockwise_rotation.is_finite() {
+            -counter_clockwise_rotation
+        } else {
+            0.0
+        },
+    }
 }
 
 /// Convert an anchor coordinate and rendered bounds into top-left draw coordinates.
@@ -41,14 +108,27 @@ pub fn anchor_to_top_left(
     rendered_height: f32,
     anchor: TextAnchorKind,
 ) -> (f32, f32) {
-    match anchor {
-        TextAnchorKind::TopLeft => (anchor_x, anchor_y),
-        TextAnchorKind::TopCenter => (anchor_x - rendered_width / 2.0, anchor_y),
-        TextAnchorKind::Center => (
-            anchor_x - rendered_width / 2.0,
-            anchor_y - rendered_height / 2.0,
-        ),
-    }
+    let x = match anchor {
+        TextAnchorKind::TopLeft | TextAnchorKind::CenterLeft | TextAnchorKind::BottomLeft => {
+            anchor_x
+        }
+        TextAnchorKind::TopCenter | TextAnchorKind::Center | TextAnchorKind::BottomCenter => {
+            anchor_x - rendered_width / 2.0
+        }
+        TextAnchorKind::TopRight | TextAnchorKind::CenterRight | TextAnchorKind::BottomRight => {
+            anchor_x - rendered_width
+        }
+    };
+    let y = match anchor {
+        TextAnchorKind::TopLeft | TextAnchorKind::TopCenter | TextAnchorKind::TopRight => anchor_y,
+        TextAnchorKind::CenterLeft | TextAnchorKind::Center | TextAnchorKind::CenterRight => {
+            anchor_y - rendered_height / 2.0
+        }
+        TextAnchorKind::BottomLeft | TextAnchorKind::BottomCenter | TextAnchorKind::BottomRight => {
+            anchor_y - rendered_height
+        }
+    };
+    (x, y)
 }
 
 /// Convert a top-origin anchor y to baseline y.
@@ -59,4 +139,44 @@ pub fn top_anchor_to_baseline(anchor_top_y: f32, metrics: TextPlacementMetrics) 
 /// Convert a center-origin anchor y to baseline y.
 pub fn center_anchor_to_baseline(anchor_center_y: f32, metrics: TextPlacementMetrics) -> f32 {
     anchor_center_y - metrics.height / 2.0 + metrics.baseline_from_top
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_anchor_kinds_map_to_expected_top_left() {
+        let cases = [
+            (TextAnchorKind::TopLeft, (20.0, 30.0)),
+            (TextAnchorKind::TopCenter, (15.0, 30.0)),
+            (TextAnchorKind::TopRight, (10.0, 30.0)),
+            (TextAnchorKind::CenterLeft, (20.0, 28.0)),
+            (TextAnchorKind::Center, (15.0, 28.0)),
+            (TextAnchorKind::CenterRight, (10.0, 28.0)),
+            (TextAnchorKind::BottomLeft, (20.0, 26.0)),
+            (TextAnchorKind::BottomCenter, (15.0, 26.0)),
+            (TextAnchorKind::BottomRight, (10.0, 26.0)),
+        ];
+
+        for (anchor, expected) in cases {
+            assert_eq!(anchor_to_top_left(20.0, 30.0, 10.0, 4.0, anchor), expected);
+        }
+    }
+
+    #[test]
+    fn annotation_layout_expands_padding_without_moving_text_anchor() {
+        let layout = annotation_text_layout(
+            TextPlacementMetrics::new(10.0, 4.0, 3.0),
+            crate::core::TextAlign::Center,
+            crate::core::TextVAlign::Middle,
+            2.0,
+            30.0,
+        );
+
+        assert_eq!((layout.text_x, layout.text_y), (-5.0, -2.0));
+        assert_eq!((layout.box_x, layout.box_y), (-7.0, -4.0));
+        assert_eq!((layout.box_width, layout.box_height), (14.0, 8.0));
+        assert_eq!(layout.rotation, -30.0);
+    }
 }

--- a/src/render/typst_text.rs
+++ b/src/render/typst_text.rs
@@ -1,7 +1,7 @@
 use crate::{
-    core::{PlottingError, Result},
+    core::{PlottingError, Result, TextAlign},
     render::{
-        Color, FontFamily,
+        Color, FontFamily, FontWeight,
         text_anchor::{TextAnchorKind, anchor_to_top_left},
     },
 };
@@ -28,13 +28,109 @@ pub struct TypstSvgOutput {
 }
 
 pub fn literal_text_snippet(text: &str) -> String {
-    let escaped = text
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t");
-    format!("#text(\"{}\")", escaped)
+    fn escaped_line(line: &str) -> String {
+        line.replace('\\', "\\\\")
+            .replace('"', "\\\"")
+            .replace('\r', "\\r")
+            .replace('\t', "\\t")
+    }
+
+    if !text.contains('\n') {
+        return format!("#text(\"{}\")", escaped_line(text));
+    }
+
+    text.split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
+        .map(|line| format!("#text(\"{}\")", escaped_line(line)))
+        .collect::<Vec<_>>()
+        .join("\\\n")
+}
+
+pub(crate) fn with_explicit_line_breaks(snippet: &str) -> String {
+    if snippet.trim().is_empty() || !snippet.contains('\n') {
+        return snippet.to_string();
+    }
+
+    let mut explicit = String::with_capacity(snippet.len() + snippet.matches('\n').count());
+    for segment in snippet.split_inclusive('\n') {
+        let has_newline = segment.ends_with('\n');
+        let line = segment.strip_suffix('\n').unwrap_or(segment);
+        let line = line.strip_suffix('\r').unwrap_or(line);
+        explicit.push_str(line);
+        if has_newline {
+            let trailing_backslashes = line.chars().rev().take_while(|ch| *ch == '\\').count();
+            if trailing_backslashes % 2 == 0 {
+                explicit.push('\\');
+            }
+            explicit.push('\n');
+        }
+    }
+    explicit
+}
+
+pub(crate) fn with_font_weight(snippet: &str, weight: FontWeight) -> String {
+    if snippet.trim().is_empty() {
+        return snippet.to_string();
+    }
+    format!("#set text(weight: {})\n{snippet}", weight.numeric())
+}
+
+pub(crate) fn with_horizontal_alignment(snippet: &str, align: TextAlign) -> String {
+    if snippet.trim().is_empty() || align == TextAlign::Left {
+        return snippet.to_string();
+    }
+    let typst_align = match align {
+        TextAlign::Left => unreachable!("left alignment returns before wrapping"),
+        TextAlign::Center => "center",
+        TextAlign::Right => "right",
+    };
+    format!("#align({typst_align})[{snippet}]")
+}
+
+#[cfg(test)]
+mod weight_tests {
+    use super::*;
+
+    #[test]
+    fn font_weight_wrapper_preserves_empty_text_fast_path() {
+        assert_eq!(with_font_weight("", FontWeight::Bold), "");
+        assert_eq!(with_font_weight(" \n\t", FontWeight::Bold), " \n\t");
+    }
+
+    #[test]
+    fn horizontal_alignment_wrapper_preserves_empty_and_left_aligned_text() {
+        assert_eq!(
+            with_horizontal_alignment(" \n\t", TextAlign::Center),
+            " \n\t"
+        );
+        assert_eq!(with_horizontal_alignment("value", TextAlign::Left), "value");
+        assert_eq!(
+            with_horizontal_alignment("wide\nshort", TextAlign::Right),
+            "#align(right)[wide\nshort]"
+        );
+    }
+
+    #[test]
+    fn explicit_line_breaks_convert_authored_newlines_without_escaping_markup() {
+        assert_eq!(with_explicit_line_breaks("wide\nshort"), "wide\\\nshort");
+        assert_eq!(
+            with_explicit_line_breaks("#emph[wide]\n$ x + 1 $"),
+            "#emph[wide]\\\n$ x + 1 $"
+        );
+        assert_eq!(
+            with_explicit_line_breaks("already\\\nexplicit"),
+            "already\\\nexplicit"
+        );
+        assert_eq!(with_explicit_line_breaks(" \n\t"), " \n\t");
+    }
+
+    #[test]
+    fn literal_text_snippet_uses_explicit_breaks_between_escaped_lines() {
+        assert_eq!(
+            literal_text_snippet("a\\\"\n\tb"),
+            "#text(\"a\\\\\\\"\")\\\n#text(\"\\tb\")"
+        );
+    }
 }
 
 /// Text anchor semantics used when positioning rendered Typst output.


### PR DESCRIPTION
## Summary

- carry the full public `TextStyle` contract through SVG and raster annotations
- preserve multiline alignment, rotation, whitespace, decoration, weight, and font selection
- keep plain and Typst text behavior consistent across DPI-scaled output

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib --all-features` (1,404 passed)