### PR TITLE
Add frame-coherent hit-test index

### DIFF
--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -14,9 +14,9 @@ use crate::{
 };
 use std::{
     cell::RefCell,
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     sync::{
-        Arc, Mutex,
+        Arc, Mutex, OnceLock,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
@@ -116,6 +116,8 @@ const MIN_ZOOM_LEVEL: f64 = 0.1;
 const MAX_ZOOM_LEVEL: f64 = 100.0;
 const VIEWPORT_EPSILON: f64 = 1e-9;
 const HIT_TEST_TOLERANCE_LOGICAL_PX: f64 = 8.0;
+const MIN_INDEXED_POINT_COUNT: usize = 256;
+const MAX_INDEX_QUERY_CELLS: u64 = 4096;
 
 #[cfg(not(target_arch = "wasm32"))]
 type FrameTimer = Instant;
@@ -568,12 +570,272 @@ impl DisplayedFrameData {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum AxisScaleIdentity {
+    Linear,
+    Log,
+    SymLog { linthresh_bits: u64 },
+}
+
+impl From<&AxisScale> for AxisScaleIdentity {
+    fn from(scale: &AxisScale) -> Self {
+        match scale {
+            AxisScale::Linear => Self::Linear,
+            AxisScale::Log => Self::Log,
+            AxisScale::SymLog { linthresh } => Self::SymLog {
+                linthresh_bits: linthresh.to_bits(),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct PointHitIndexKey {
+    frame_key: InteractiveFrameKey,
+    plot_area_bits: [u32; 4],
+    x_scale: AxisScaleIdentity,
+    y_scale: AxisScaleIdentity,
+    cell_size_bits: u64,
+}
+
+impl PointHitIndexKey {
+    fn from_geometry(geometry: &GeometrySnapshot, cell_size_px: f64) -> Self {
+        Self {
+            frame_key: geometry.key.clone(),
+            plot_area_bits: [
+                geometry.plot_area.left().to_bits(),
+                geometry.plot_area.top().to_bits(),
+                geometry.plot_area.right().to_bits(),
+                geometry.plot_area.bottom().to_bits(),
+            ],
+            x_scale: AxisScaleIdentity::from(&geometry.x_scale),
+            y_scale: AxisScaleIdentity::from(&geometry.y_scale),
+            cell_size_bits: cell_size_px.to_bits(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct IndexedPoint {
+    point_index: usize,
+    screen_position: ViewportPoint,
+    data_position: ViewportPoint,
+}
+
+#[derive(Clone, Debug)]
+struct ScreenSpacePointGrid {
+    origin: ViewportPoint,
+    cell_size_px: f64,
+    cells: HashMap<(i64, i64), Vec<usize>>,
+    points: Vec<IndexedPoint>,
+}
+
+impl ScreenSpacePointGrid {
+    fn build(x: &[f64], y: &[f64], geometry: &GeometrySnapshot, cell_size_px: f64) -> Option<Self> {
+        if x.len().min(y.len()) < MIN_INDEXED_POINT_COUNT
+            || !cell_size_px.is_finite()
+            || cell_size_px <= 0.0
+            || !geometry.plot_area.width().is_finite()
+            || !geometry.plot_area.height().is_finite()
+            || geometry.plot_area.width() <= 0.0
+            || geometry.plot_area.height() <= 0.0
+        {
+            return None;
+        }
+
+        let origin = ViewportPoint::new(
+            geometry.plot_area.left() as f64,
+            geometry.plot_area.top() as f64,
+        );
+        let mut cells = HashMap::<(i64, i64), Vec<usize>>::new();
+        let mut points = Vec::with_capacity(x.len().min(y.len()));
+        for (point_index, (&x_val, &y_val)) in x.iter().zip(y.iter()).enumerate() {
+            let data_position = ViewportPoint::new(x_val, y_val);
+            if !geometry.contains_transformable_data(data_position) {
+                continue;
+            }
+            let screen_position = geometry.data_to_screen(data_position);
+            if !screen_position.x.is_finite() || !screen_position.y.is_finite() {
+                continue;
+            }
+            let Some(cell) = grid_cell(screen_position, origin, cell_size_px) else {
+                continue;
+            };
+            let indexed_position = points.len();
+            points.push(IndexedPoint {
+                point_index,
+                screen_position,
+                data_position,
+            });
+            cells.entry(cell).or_default().push(indexed_position);
+        }
+
+        (points.len() >= MIN_INDEXED_POINT_COUNT).then_some(Self {
+            origin,
+            cell_size_px,
+            cells,
+            points,
+        })
+    }
+
+    fn nearest(&self, position_px: ViewportPoint, tolerance_px: f64) -> GridQueryResult {
+        let Some((min_col, min_row)) = grid_cell(
+            ViewportPoint::new(position_px.x - tolerance_px, position_px.y - tolerance_px),
+            self.origin,
+            self.cell_size_px,
+        ) else {
+            return GridQueryResult::Fallback;
+        };
+        let Some((max_col, max_row)) = grid_cell(
+            ViewportPoint::new(position_px.x + tolerance_px, position_px.y + tolerance_px),
+            self.origin,
+            self.cell_size_px,
+        ) else {
+            return GridQueryResult::Fallback;
+        };
+        let Some(min_col) = min_col.checked_sub(1) else {
+            return GridQueryResult::Fallback;
+        };
+        let Some(min_row) = min_row.checked_sub(1) else {
+            return GridQueryResult::Fallback;
+        };
+        let Some(max_col) = max_col.checked_add(1) else {
+            return GridQueryResult::Fallback;
+        };
+        let Some(max_row) = max_row.checked_add(1) else {
+            return GridQueryResult::Fallback;
+        };
+        let Some(column_count) = inclusive_cell_count(min_col, max_col) else {
+            return GridQueryResult::Fallback;
+        };
+        let Some(row_count) = inclusive_cell_count(min_row, max_row) else {
+            return GridQueryResult::Fallback;
+        };
+        if column_count.saturating_mul(row_count) > MAX_INDEX_QUERY_CELLS {
+            return GridQueryResult::Fallback;
+        }
+
+        let mut best = None::<PointHitCandidate>;
+        for row in min_row..=max_row {
+            for col in min_col..=max_col {
+                let Some(indexed_positions) = self.cells.get(&(col, row)) else {
+                    continue;
+                };
+                for &indexed_position in indexed_positions {
+                    let point = self.points[indexed_position];
+                    let distance = screen_distance(position_px, point.screen_position);
+                    if distance > tolerance_px {
+                        continue;
+                    }
+                    let should_replace = best.as_ref().is_none_or(|current| {
+                        distance < current.distance_px
+                            || (distance == current.distance_px
+                                && point.point_index < current.point_index)
+                    });
+                    if should_replace {
+                        best = Some(PointHitCandidate {
+                            point_index: point.point_index,
+                            screen_position: point.screen_position,
+                            data_position: point.data_position,
+                            distance_px: distance,
+                        });
+                    }
+                }
+            }
+        }
+        GridQueryResult::Indexed(best)
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PointHitIndex {
+    key: PointHitIndexKey,
+    series: Vec<Option<ScreenSpacePointGrid>>,
+}
+
+type LazyPointHitIndex = Arc<OnceLock<Arc<PointHitIndex>>>;
+
+impl PointHitIndex {
+    fn build(
+        plot: &Plot,
+        displayed_data: &DisplayedFrameData,
+        geometry: &GeometrySnapshot,
+    ) -> Self {
+        let cell_size_px = geometry.logical_pixels_to_pixels(HIT_TEST_TOLERANCE_LOGICAL_PX);
+        let series = plot
+            .series_mgr
+            .series
+            .iter()
+            .enumerate()
+            .map(|(series_index, series)| match &series.series_type {
+                SeriesType::Line { .. }
+                | SeriesType::Scatter { .. }
+                | SeriesType::ErrorBars { .. }
+                | SeriesType::ErrorBarsXY { .. } => displayed_data
+                    .xy(plot, series_index)
+                    .and_then(|(x, y)| ScreenSpacePointGrid::build(x, y, geometry, cell_size_px)),
+                _ => None,
+            })
+            .collect();
+        Self {
+            key: PointHitIndexKey::from_geometry(geometry, cell_size_px),
+            series,
+        }
+    }
+
+    fn matches_geometry(&self, geometry: &GeometrySnapshot) -> bool {
+        self.key
+            == PointHitIndexKey::from_geometry(geometry, f64::from_bits(self.key.cell_size_bits))
+    }
+
+    fn series_grid(&self, series_index: usize) -> Option<&ScreenSpacePointGrid> {
+        self.series.get(series_index)?.as_ref()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PointHitCandidate {
+    point_index: usize,
+    screen_position: ViewportPoint,
+    data_position: ViewportPoint,
+    distance_px: f64,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum GridQueryResult {
+    Indexed(Option<PointHitCandidate>),
+    Fallback,
+}
+
+fn grid_cell(point: ViewportPoint, origin: ViewportPoint, cell_size_px: f64) -> Option<(i64, i64)> {
+    let col = ((point.x - origin.x) / cell_size_px).floor();
+    let row = ((point.y - origin.y) / cell_size_px).floor();
+    if !col.is_finite()
+        || !row.is_finite()
+        || col < i64::MIN as f64
+        || col > i64::MAX as f64
+        || row < i64::MIN as f64
+        || row > i64::MAX as f64
+    {
+        return None;
+    }
+    Some((col as i64, row as i64))
+}
+
+fn inclusive_cell_count(min: i64, max: i64) -> Option<u64> {
+    if min > max {
+        return None;
+    }
+    u64::try_from(i128::from(max) - i128::from(min) + 1).ok()
+}
+
 #[derive(Clone, Debug)]
 struct InteractiveFrameCache {
     key: InteractiveFrameKey,
     image: Arc<Image>,
     geometry: GeometrySnapshot,
     displayed_data: DisplayedFrameData,
+    point_hit_index: LazyPointHitIndex,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -631,6 +893,12 @@ impl GeometrySnapshot {
             && point.y.is_finite()
             && value_in_bounds(point.x, self.x_bounds)
             && value_in_bounds(point.y, self.y_bounds)
+    }
+
+    fn contains_transformable_data(&self, point: ViewportPoint) -> bool {
+        self.contains_data(point)
+            && axis_accepts_value(&self.x_scale, point.x)
+            && axis_accepts_value(&self.y_scale, point.y)
     }
 
     fn screen_to_data(&self, point: ViewportPoint) -> ViewportPoint {
@@ -1223,111 +1491,102 @@ impl InteractivePlotSession {
     }
 
     pub fn hit_test(&self, position_px: ViewportPoint) -> HitResult {
-        let Some((geometry, displayed_data)) = self
-            .inner
+        let Some((geometry, displayed_data, point_hit_index)) = self.displayed_hit_test_data()
+        else {
+            return HitResult::None;
+        };
+        let tolerance_px = geometry.logical_pixels_to_pixels(HIT_TEST_TOLERANCE_LOGICAL_PX);
+        hit_test_displayed_frame(
+            self.inner.prepared.plot(),
+            &displayed_data,
+            &geometry,
+            Some(&point_hit_index),
+            position_px,
+            tolerance_px,
+        )
+    }
+
+    fn displayed_frame_data(
+        &self,
+    ) -> Option<(GeometrySnapshot, DisplayedFrameData, LazyPointHitIndex)> {
+        self.inner
             .state
             .lock()
             .expect("InteractivePlotSession state lock poisoned")
             .base_cache
             .as_ref()
-            .map(|cache| (cache.geometry.clone(), cache.displayed_data.clone()))
+            .map(|cache| {
+                (
+                    cache.geometry.clone(),
+                    cache.displayed_data.clone(),
+                    Arc::clone(&cache.point_hit_index),
+                )
+            })
+    }
+
+    fn displayed_hit_test_data(
+        &self,
+    ) -> Option<(GeometrySnapshot, DisplayedFrameData, Arc<PointHitIndex>)> {
+        let (geometry, displayed_data, point_hit_index) = self.displayed_frame_data()?;
+        let point_hit_index = Arc::clone(point_hit_index.get_or_init(|| {
+            Arc::new(PointHitIndex::build(
+                self.inner.prepared.plot(),
+                &displayed_data,
+                &geometry,
+            ))
+        }));
+        Some((geometry, displayed_data, point_hit_index))
+    }
+
+    #[cfg(test)]
+    fn hit_test_with_tolerance_px(
+        &self,
+        position_px: ViewportPoint,
+        tolerance_px: f64,
+    ) -> HitResult {
+        let Some((geometry, displayed_data, point_hit_index)) = self.displayed_hit_test_data()
         else {
             return HitResult::None;
         };
-        if !geometry.contains_screen(position_px) {
+        hit_test_displayed_frame(
+            self.inner.prepared.plot(),
+            &displayed_data,
+            &geometry,
+            Some(&point_hit_index),
+            position_px,
+            tolerance_px,
+        )
+    }
+
+    #[cfg(test)]
+    fn hit_test_brute_force_with_tolerance_px(
+        &self,
+        position_px: ViewportPoint,
+        tolerance_px: f64,
+    ) -> HitResult {
+        let Some((geometry, displayed_data, _)) = self.displayed_frame_data() else {
             return HitResult::None;
-        }
-        let plot = self.inner.prepared.plot();
-        let hit_tolerance_px = geometry.logical_pixels_to_pixels(HIT_TEST_TOLERANCE_LOGICAL_PX);
-        let mut best_hit = HitResult::None;
-        let mut best_distance = f64::INFINITY;
+        };
+        hit_test_displayed_frame_brute_force(
+            self.inner.prepared.plot(),
+            &displayed_data,
+            &geometry,
+            position_px,
+            tolerance_px,
+        )
+    }
 
-        for (series_index, series) in plot.series_mgr.series.iter().enumerate() {
-            match &series.series_type {
-                SeriesType::Line { .. }
-                | SeriesType::Scatter { .. }
-                | SeriesType::ErrorBars { .. }
-                | SeriesType::ErrorBarsXY { .. } => {
-                    let Some((x, y)) = displayed_data.xy(plot, series_index) else {
-                        continue;
-                    };
-                    for (point_index, (&x_val, &y_val)) in x.iter().zip(y.iter()).enumerate() {
-                        if !x_val.is_finite() || !y_val.is_finite() {
-                            continue;
-                        }
-                        let data_position = ViewportPoint::new(x_val, y_val);
-                        if !geometry.contains_data(data_position) {
-                            continue;
-                        }
-                        let screen_position = geometry.data_to_screen(data_position);
-                        let dx = position_px.x - screen_position.x;
-                        let dy = position_px.y - screen_position.y;
-                        let distance = (dx * dx + dy * dy).sqrt();
-                        if distance <= hit_tolerance_px && distance < best_distance {
-                            best_distance = distance;
-                            best_hit = HitResult::SeriesPoint {
-                                series_index,
-                                point_index,
-                                screen_position,
-                                data_position,
-                                distance_px: distance,
-                            };
-                        }
-                    }
-                }
-                SeriesType::Heatmap { data } => {
-                    let rect = geometry.plot_area;
-                    if position_px.x < rect.left() as f64
-                        || position_px.x > rect.right() as f64
-                        || position_px.y < rect.top() as f64
-                        || position_px.y > rect.bottom() as f64
-                    {
-                        continue;
-                    }
-                    let data_position = geometry.screen_to_data(position_px);
-                    if data_position.x < data.x_extent.0
-                        || data_position.x > data.x_extent.1
-                        || data_position.y < data.y_extent.0
-                        || data_position.y > data.y_extent.1
-                    {
-                        continue;
-                    }
+    #[cfg(test)]
+    fn point_hit_index_initialized(&self) -> bool {
+        self.displayed_frame_data()
+            .is_some_and(|(_, _, index)| index.get().is_some())
+    }
 
-                    let cell_width =
-                        (data.x_extent.1 - data.x_extent.0) / data.n_cols.max(1) as f64;
-                    let cell_height =
-                        (data.y_extent.1 - data.y_extent.0) / data.n_rows.max(1) as f64;
-                    let col = ((data_position.x - data.x_extent.0) / cell_width)
-                        .floor()
-                        .clamp(0.0, data.n_cols.saturating_sub(1) as f64)
-                        as usize;
-                    let row = ((data.y_extent.1 - data_position.y) / cell_height)
-                        .floor()
-                        .clamp(0.0, data.n_rows.saturating_sub(1) as f64)
-                        as usize;
-                    let value = data.values[row][col];
-                    if data.should_mask_value(value) {
-                        continue;
-                    }
-                    let ((x1, x2), (y1, y2)) = data.cell_data_bounds(row, col);
-                    let first = geometry.data_to_screen(ViewportPoint::new(x1, y2));
-                    let second = geometry.data_to_screen(ViewportPoint::new(x2, y1));
-                    best_hit = HitResult::HeatmapCell {
-                        series_index,
-                        row,
-                        col,
-                        value,
-                        screen_rect: ViewportRect {
-                            min: ViewportPoint::new(first.x.min(second.x), first.y.min(second.y)),
-                            max: ViewportPoint::new(first.x.max(second.x), first.y.max(second.y)),
-                        },
-                    };
-                }
-                _ => {}
-            }
-        }
-
-        best_hit
+    #[cfg(test)]
+    fn indexed_point_series_count(&self) -> usize {
+        self.displayed_hit_test_data()
+            .map(|(_, _, index)| index.series.iter().flatten().count())
+            .unwrap_or(0)
     }
 
     /// Converts a displayed-frame screen position to data coordinates.
@@ -1771,6 +2030,7 @@ impl InteractivePlotSession {
         let (renderer, _) = plot.render_renderer_with_frame_and_diagnostics(mode, frame)?;
         let image = Arc::new(renderer.into_image());
         let displayed_data = DisplayedFrameData::capture(source_plot, frame);
+        let point_hit_index = Arc::new(OnceLock::new());
 
         let mut state = self
             .inner
@@ -1782,6 +2042,7 @@ impl InteractivePlotSession {
             image: Arc::clone(&image),
             geometry: geometry.clone(),
             displayed_data,
+            point_hit_index,
         });
         Ok(BaseLayerResult {
             image,
@@ -2095,6 +2356,7 @@ impl InteractivePlotSession {
             &draw_ops,
         )?);
         let displayed_data = DisplayedFrameData::capture(source_plot, frame);
+        let point_hit_index = Arc::new(OnceLock::new());
 
         let mut state = self
             .inner
@@ -2106,6 +2368,7 @@ impl InteractivePlotSession {
             image: Arc::clone(&image),
             geometry: geometry.clone(),
             displayed_data,
+            point_hit_index,
         });
 
         Ok(Some(BaseLayerResult {
@@ -2436,6 +2699,188 @@ fn require_finite_point(point: ViewportPoint, label: &str) -> Result<()> {
             "{label} must contain finite coordinates"
         )))
     }
+}
+
+fn axis_accepts_value(scale: &AxisScale, value: f64) -> bool {
+    match scale {
+        AxisScale::Linear | AxisScale::SymLog { .. } => true,
+        AxisScale::Log => value > 0.0,
+    }
+}
+
+fn screen_distance(first: ViewportPoint, second: ViewportPoint) -> f64 {
+    let dx = first.x - second.x;
+    let dy = first.y - second.y;
+    (dx * dx + dy * dy).sqrt()
+}
+
+fn brute_force_point_candidate(
+    x: &[f64],
+    y: &[f64],
+    geometry: &GeometrySnapshot,
+    position_px: ViewportPoint,
+    tolerance_px: f64,
+) -> Option<PointHitCandidate> {
+    let mut best = None::<PointHitCandidate>;
+    for (point_index, (&x_val, &y_val)) in x.iter().zip(y.iter()).enumerate() {
+        let data_position = ViewportPoint::new(x_val, y_val);
+        if !geometry.contains_transformable_data(data_position) {
+            continue;
+        }
+        let screen_position = geometry.data_to_screen(data_position);
+        if !screen_position.x.is_finite() || !screen_position.y.is_finite() {
+            continue;
+        }
+        let distance = screen_distance(position_px, screen_position);
+        if distance <= tolerance_px
+            && best
+                .as_ref()
+                .is_none_or(|current| distance < current.distance_px)
+        {
+            best = Some(PointHitCandidate {
+                point_index,
+                screen_position,
+                data_position,
+                distance_px: distance,
+            });
+        }
+    }
+    best
+}
+
+fn hit_test_displayed_frame_brute_force(
+    plot: &Plot,
+    displayed_data: &DisplayedFrameData,
+    geometry: &GeometrySnapshot,
+    position_px: ViewportPoint,
+    tolerance_px: f64,
+) -> HitResult {
+    hit_test_displayed_frame(
+        plot,
+        displayed_data,
+        geometry,
+        None,
+        position_px,
+        tolerance_px,
+    )
+}
+
+fn hit_test_displayed_frame(
+    plot: &Plot,
+    displayed_data: &DisplayedFrameData,
+    geometry: &GeometrySnapshot,
+    point_hit_index: Option<&PointHitIndex>,
+    position_px: ViewportPoint,
+    tolerance_px: f64,
+) -> HitResult {
+    if !geometry.contains_screen(position_px) || !tolerance_px.is_finite() || tolerance_px < 0.0 {
+        return HitResult::None;
+    }
+    let point_hit_index = point_hit_index.filter(|index| index.matches_geometry(geometry));
+    let mut best_hit = HitResult::None;
+    let mut best_distance = f64::INFINITY;
+
+    for (series_index, series) in plot.series_mgr.series.iter().enumerate() {
+        match &series.series_type {
+            SeriesType::Line { .. }
+            | SeriesType::Scatter { .. }
+            | SeriesType::ErrorBars { .. }
+            | SeriesType::ErrorBarsXY { .. } => {
+                let Some((x, y)) = displayed_data.xy(plot, series_index) else {
+                    continue;
+                };
+                let candidate = match point_hit_index
+                    .and_then(|index| index.series_grid(series_index))
+                    .map(|grid| grid.nearest(position_px, tolerance_px))
+                {
+                    Some(GridQueryResult::Indexed(candidate)) => candidate,
+                    Some(GridQueryResult::Fallback) | None => {
+                        brute_force_point_candidate(x, y, geometry, position_px, tolerance_px)
+                    }
+                };
+                let Some(candidate) = candidate else {
+                    continue;
+                };
+                if candidate.distance_px < best_distance {
+                    best_distance = candidate.distance_px;
+                    best_hit = HitResult::SeriesPoint {
+                        series_index,
+                        point_index: candidate.point_index,
+                        screen_position: candidate.screen_position,
+                        data_position: candidate.data_position,
+                        distance_px: candidate.distance_px,
+                    };
+                }
+            }
+            SeriesType::Heatmap { data } => {
+                if data.n_rows == 0 || data.n_cols == 0 {
+                    continue;
+                }
+                let data_position = geometry.screen_to_data(position_px);
+                if !data_position.x.is_finite()
+                    || !data_position.y.is_finite()
+                    || data_position.x < data.x_extent.0
+                    || data_position.x > data.x_extent.1
+                    || data_position.y < data.y_extent.0
+                    || data_position.y > data.y_extent.1
+                {
+                    continue;
+                }
+
+                let cell_width = (data.x_extent.1 - data.x_extent.0) / data.n_cols as f64;
+                let cell_height = (data.y_extent.1 - data.y_extent.0) / data.n_rows as f64;
+                if !cell_width.is_finite()
+                    || !cell_height.is_finite()
+                    || cell_width <= 0.0
+                    || cell_height <= 0.0
+                {
+                    continue;
+                }
+                let col = ((data_position.x - data.x_extent.0) / cell_width)
+                    .floor()
+                    .clamp(0.0, data.n_cols.saturating_sub(1) as f64)
+                    as usize;
+                let row = ((data.y_extent.1 - data_position.y) / cell_height)
+                    .floor()
+                    .clamp(0.0, data.n_rows.saturating_sub(1) as f64)
+                    as usize;
+                let Some(value) = data
+                    .values
+                    .get(row)
+                    .and_then(|values| values.get(col))
+                    .copied()
+                else {
+                    continue;
+                };
+                if data.should_mask_value(value) {
+                    continue;
+                }
+                let ((x1, x2), (y1, y2)) = data.cell_data_bounds(row, col);
+                let first = geometry.data_to_screen(ViewportPoint::new(x1, y2));
+                let second = geometry.data_to_screen(ViewportPoint::new(x2, y1));
+                if !first.x.is_finite()
+                    || !first.y.is_finite()
+                    || !second.x.is_finite()
+                    || !second.y.is_finite()
+                {
+                    continue;
+                }
+                best_hit = HitResult::HeatmapCell {
+                    series_index,
+                    row,
+                    col,
+                    value,
+                    screen_rect: ViewportRect {
+                        min: ViewportPoint::new(first.x.min(second.x), first.y.min(second.y)),
+                        max: ViewportPoint::new(first.x.max(second.x), first.y.max(second.y)),
+                    },
+                };
+            }
+            _ => {}
+        }
+    }
+
+    best_hit
 }
 
 fn displayed_geometry_unavailable() -> PlottingError {

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -15,6 +15,76 @@ fn render_target() -> SurfaceTarget {
     }
 }
 
+fn assert_index_matches_brute_force(
+    session: &InteractivePlotSession,
+    data_probes: &[ViewportPoint],
+) {
+    assert!(
+        session.indexed_point_series_count() > 0,
+        "test fixture must exercise the indexed path"
+    );
+    let plot_area = session.viewport_snapshot().unwrap().plot_area;
+    let mut queries = vec![
+        plot_area.min,
+        plot_area.max,
+        ViewportPoint::new(plot_area.min.x, plot_area.max.y),
+        ViewportPoint::new(plot_area.max.x, plot_area.min.y),
+        ViewportPoint::new(
+            (plot_area.min.x + plot_area.max.x) * 0.5,
+            (plot_area.min.y + plot_area.max.y) * 0.5,
+        ),
+    ];
+    queries.extend(
+        data_probes
+            .iter()
+            .filter_map(|&point| session.data_to_screen(point).unwrap()),
+    );
+
+    let mut random_state = 0x9e37_79b9_7f4a_7c15_u64;
+    for _ in 0..64 {
+        random_state = random_state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let x_fraction = (random_state >> 11) as f64 / (1_u64 << 53) as f64;
+        random_state = random_state
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        let y_fraction = (random_state >> 11) as f64 / (1_u64 << 53) as f64;
+        queries.push(ViewportPoint::new(
+            plot_area.min.x + x_fraction * plot_area.width(),
+            plot_area.min.y + y_fraction * plot_area.height(),
+        ));
+    }
+
+    for tolerance_px in [0.0, 0.25, 3.0, 8.0, 17.0, 64.0, 1.0e9] {
+        for &query in &queries {
+            assert_eq!(
+                session.hit_test_with_tolerance_px(query, tolerance_px),
+                session.hit_test_brute_force_with_tolerance_px(query, tolerance_px),
+                "indexed and brute-force hit tests differed at {query:?} with radius {tolerance_px}"
+            );
+        }
+    }
+    for tolerance_px in [f64::NAN, f64::INFINITY, -1.0] {
+        let query = queries[queries.len() / 2];
+        assert_eq!(
+            session.hit_test_with_tolerance_px(query, tolerance_px),
+            session.hit_test_brute_force_with_tolerance_px(query, tolerance_px)
+        );
+    }
+}
+
+fn dense_series(count: usize, x_value: impl Fn(f64) -> f64, phase: f64) -> (Vec<f64>, Vec<f64>) {
+    let mut x = Vec::with_capacity(count);
+    let mut y = Vec::with_capacity(count);
+    for index in 0..count {
+        let fraction = index as f64 / (count.saturating_sub(1).max(1)) as f64;
+        x.push(x_value(fraction));
+        y.push(((fraction * std::f64::consts::TAU) + phase).sin());
+    }
+    (x, y)
+}
+
 fn derived_y_ticks(session: &InteractivePlotSession) -> Vec<f64> {
     let geometry = session
         .geometry_snapshot()
@@ -252,6 +322,7 @@ fn test_high_dpi_conversion_uses_backing_pixels_and_logical_hit_tolerance() {
             time_seconds: 0.0,
         })
         .expect("high-DPI frame should render");
+    assert_eq!(session.indexed_point_series_count(), 0);
 
     let data_position = ViewportPoint::new(10.0, 0.0);
     let screen_position = session
@@ -266,13 +337,365 @@ fn test_high_dpi_conversion_uses_backing_pixels_and_logical_hit_tolerance() {
     assert!((round_trip.y - data_position.y).abs() < 1e-6);
 
     let six_logical_pixels_away = ViewportPoint::new(screen_position.x + 12.0, screen_position.y);
+    let fallback_hit = session.hit_test(six_logical_pixels_away);
+    assert_eq!(
+        fallback_hit,
+        session.hit_test_brute_force_with_tolerance_px(six_logical_pixels_away, 16.0)
+    );
     assert!(matches!(
-        session.hit_test(six_logical_pixels_away),
+        fallback_hit,
         HitResult::SeriesPoint { point_index: 0, .. }
     ));
 
     let nine_logical_pixels_away = ViewportPoint::new(screen_position.x + 18.0, screen_position.y);
     assert_eq!(session.hit_test(nine_logical_pixels_away), HitResult::None);
+}
+
+#[test]
+fn test_indexed_hit_test_matches_brute_force_across_scales_reversal_and_radii() {
+    let (linear_x, linear_y) = dense_series(640, |fraction| fraction * 20.0 - 10.0, 0.0);
+    let (_, linear_y_second) = dense_series(640, |fraction| fraction, 0.7);
+    let linear_plot: Plot = Plot::new()
+        .scatter(&linear_x, &linear_y)
+        .line(&linear_x, &linear_y_second)
+        .xlim(-10.0, 10.0)
+        .ylim(-1.2, 1.2)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let linear_session = linear_plot.prepare_interactive();
+    linear_session
+        .render_to_surface(render_target())
+        .expect("linear indexed frame should render");
+    assert_index_matches_brute_force(
+        &linear_session,
+        &[
+            ViewportPoint::new(-10.0, 0.0),
+            ViewportPoint::new(0.0, 0.0),
+            ViewportPoint::new(10.0, 0.0),
+        ],
+    );
+
+    let (scaled_x, mut scaled_y) = dense_series(640, |fraction| 10_f64.powf(3.0 * fraction), 0.0);
+    let (_, mut scaled_y_second) = dense_series(640, |fraction| fraction, 0.9);
+    for value in &mut scaled_y {
+        *value *= 100.0;
+    }
+    for value in &mut scaled_y_second {
+        *value *= 100.0;
+    }
+    let scaled_plot: Plot = Plot::new()
+        .line(&scaled_x, &scaled_y)
+        .scatter(&scaled_x, &scaled_y_second)
+        .xscale(crate::axes::AxisScale::Log)
+        .yscale(crate::axes::AxisScale::symlog(1.0))
+        .xlim(1000.0, 1.0)
+        .ylim(100.0, -100.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let scaled_session = scaled_plot.prepare_interactive();
+    scaled_session
+        .render_to_surface(SurfaceTarget {
+            size_px: (640, 480),
+            scale_factor: 2.0,
+            time_seconds: 0.0,
+        })
+        .expect("scaled reversed indexed frame should render");
+    assert_index_matches_brute_force(
+        &scaled_session,
+        &[
+            ViewportPoint::new(1.0, -100.0),
+            ViewportPoint::new(10.0, 0.0),
+            ViewportPoint::new(1000.0, 100.0),
+        ],
+    );
+
+    let errors = vec![0.05; linear_x.len()];
+    let error_plot: Plot = Plot::new()
+        .error_bars(&linear_x, &linear_y, &errors)
+        .error_bars_xy(&linear_x, &linear_y_second, &errors, &errors)
+        .into_plot()
+        .xlim(-10.0, 10.0)
+        .ylim(-1.2, 1.2)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let error_session = error_plot.prepare_interactive();
+    error_session
+        .render_to_surface(render_target())
+        .expect("indexed error-bar frame should render");
+    assert_eq!(error_session.indexed_point_series_count(), 2);
+    assert_index_matches_brute_force(
+        &error_session,
+        &[ViewportPoint::new(0.0, 0.0), ViewportPoint::new(5.0, 0.5)],
+    );
+}
+
+#[test]
+fn test_symlog_infinite_linthresh_hits_rendered_center_point() {
+    let x = (0..320)
+        .map(|index| index as f64 / 159.5 - 1.0)
+        .collect::<Vec<_>>();
+    let y = vec![0.0; x.len()];
+    let plot: Plot = Plot::new()
+        .scatter(&x, &y)
+        .xscale(crate::axes::AxisScale::symlog(f64::INFINITY))
+        .xlim(-1.0, 1.0)
+        .ylim(-1.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("infinite-linthresh SymLog frame should render");
+
+    let expected_data_position = ViewportPoint::new(-1.0, 0.0);
+    let expected_screen_position = session
+        .data_to_screen(expected_data_position)
+        .expect("displayed conversion should succeed")
+        .expect("finite SymLog point should map to the displayed plot area");
+    let plot_area = session.viewport_snapshot().unwrap().plot_area;
+    assert!((expected_screen_position.x - (plot_area.min.x + plot_area.max.x) * 0.5).abs() < 1e-5);
+    assert_eq!(session.indexed_point_series_count(), 1);
+
+    for hit in [
+        session.hit_test(expected_screen_position),
+        session.hit_test_brute_force_with_tolerance_px(
+            expected_screen_position,
+            HIT_TEST_TOLERANCE_LOGICAL_PX,
+        ),
+    ] {
+        match hit {
+            HitResult::SeriesPoint {
+                series_index,
+                point_index,
+                screen_position,
+                data_position,
+                distance_px,
+            } => {
+                assert_eq!(series_index, 0);
+                assert_eq!(point_index, 0);
+                assert_eq!(screen_position, expected_screen_position);
+                assert_eq!(data_position, expected_data_position);
+                assert_eq!(distance_px, 0.0);
+            }
+            other => panic!("expected the rendered center point, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn test_screen_space_grid_safely_rejects_invalid_points_and_huge_queries() {
+    let plot: Plot = Plot::new()
+        .scatter(&[0.0, 1.0], &[0.0, 1.0])
+        .xlim(0.0, 1.0)
+        .ylim(0.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("grid edge-case frame should render");
+    let geometry = session.displayed_geometry().unwrap();
+    let mut x = (0..320)
+        .map(|index| index as f64 / 319.0)
+        .collect::<Vec<_>>();
+    let mut y = x.clone();
+    x[3] = f64::NAN;
+    y[4] = f64::INFINITY;
+    let cell_size_px = geometry.logical_pixels_to_pixels(HIT_TEST_TOLERANCE_LOGICAL_PX);
+    let grid = ScreenSpacePointGrid::build(&x, &y, &geometry, cell_size_px)
+        .expect("remaining finite points should still be indexed");
+    let center = session
+        .data_to_screen(ViewportPoint::new(0.5, 0.5))
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        grid.nearest(center, 1.0e300),
+        GridQueryResult::Fallback
+    ));
+    assert!(ScreenSpacePointGrid::build(&[], &[], &geometry, cell_size_px).is_none());
+}
+
+#[test]
+fn test_indexed_hit_test_preserves_point_and_heatmap_tie_ordering() {
+    let mut first_x = vec![0.0; 320];
+    let mut first_y = vec![0.0; 320];
+    let mut second_x = vec![0.0; 320];
+    let mut second_y = vec![0.0; 320];
+    for index in 1..320 {
+        let value = 0.6 + index as f64 / 1000.0;
+        first_x[index] = value;
+        first_y[index] = value;
+        second_x[index] = value;
+        second_y[index] = -value;
+    }
+
+    let point_tie_plot: Plot = Plot::new()
+        .scatter(&first_x, &first_y)
+        .scatter(&second_x, &second_y)
+        .xlim(-1.0, 1.0)
+        .ylim(-1.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let point_tie_session = point_tie_plot.prepare_interactive();
+    point_tie_session
+        .render_to_surface(render_target())
+        .expect("point tie frame should render");
+    assert_eq!(point_tie_session.indexed_point_series_count(), 2);
+    let center = point_tie_session
+        .data_to_screen(ViewportPoint::new(0.0, 0.0))
+        .unwrap()
+        .unwrap();
+    let indexed = point_tie_session.hit_test(center);
+    assert_eq!(
+        indexed,
+        point_tie_session.hit_test_brute_force_with_tolerance_px(center, 8.0)
+    );
+    assert!(matches!(
+        indexed,
+        HitResult::SeriesPoint {
+            series_index: 0,
+            point_index: 0,
+            ..
+        }
+    ));
+
+    let heatmap_values = vec![vec![1.0]];
+    let mixed_plot: Plot = Plot::new()
+        .scatter(&first_x, &first_y)
+        .heatmap(
+            &heatmap_values,
+            Some(
+                crate::plots::heatmap::HeatmapConfig::new()
+                    .extent(-1.0, 1.0, -1.0, 1.0)
+                    .colorbar(false),
+            ),
+        )
+        .scatter(&second_x, &second_y)
+        .xlim(-1.0, 1.0)
+        .ylim(-1.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let mixed_session = mixed_plot.prepare_interactive();
+    mixed_session
+        .render_to_surface(render_target())
+        .expect("mixed tie frame should render");
+    assert_eq!(mixed_session.indexed_point_series_count(), 2);
+    let center = mixed_session
+        .data_to_screen(ViewportPoint::new(0.0, 0.0))
+        .unwrap()
+        .unwrap();
+    let indexed = mixed_session.hit_test(center);
+    assert_eq!(
+        indexed,
+        mixed_session.hit_test_brute_force_with_tolerance_px(center, 8.0)
+    );
+    assert!(matches!(
+        indexed,
+        HitResult::HeatmapCell {
+            series_index: 1,
+            row: 0,
+            col: 0,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn test_indexed_hit_test_tracks_displayed_reactive_viewport_and_time_frames() {
+    let x = (0..640)
+        .map(|index| index as f64 / 639.0)
+        .collect::<Vec<_>>();
+    let y = Observable::new(x.clone());
+    let plot: Plot = Plot::new()
+        .scatter_source(x.clone(), y.clone())
+        .xlim(0.0, 1.0)
+        .ylim(0.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(SurfaceTarget {
+            size_px: (640, 480),
+            scale_factor: 2.0,
+            time_seconds: 0.0,
+        })
+        .expect("initial reactive indexed frame should render");
+    assert_index_matches_brute_force(
+        &session,
+        &[
+            ViewportPoint::new(0.25, 0.25),
+            ViewportPoint::new(0.75, 0.75),
+        ],
+    );
+
+    y.set(x.iter().map(|value| 1.0 - value).collect());
+    assert_index_matches_brute_force(
+        &session,
+        &[
+            ViewportPoint::new(0.25, 0.25),
+            ViewportPoint::new(0.75, 0.75),
+        ],
+    );
+    session.apply_input(PlotInputEvent::Pan {
+        delta_px: ViewportPoint::new(40.0, -20.0),
+    });
+    assert_index_matches_brute_force(
+        &session,
+        &[
+            ViewportPoint::new(0.25, 0.25),
+            ViewportPoint::new(0.75, 0.75),
+        ],
+    );
+    session
+        .render_to_surface(SurfaceTarget {
+            size_px: (640, 480),
+            scale_factor: 2.0,
+            time_seconds: 0.0,
+        })
+        .expect("updated reactive viewport frame should render");
+    assert_index_matches_brute_force(
+        &session,
+        &[
+            ViewportPoint::new(0.25, 0.75),
+            ViewportPoint::new(0.75, 0.25),
+        ],
+    );
+
+    let temporal_y = signal::of(|time| {
+        (0..640)
+            .map(|index| (index as f64 / 639.0 + time).fract())
+            .collect::<Vec<_>>()
+    });
+    let temporal_plot: Plot = Plot::new()
+        .scatter_source(x, temporal_y)
+        .xlim(0.0, 1.0)
+        .ylim(0.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let temporal_session = temporal_plot.prepare_interactive();
+    temporal_session
+        .render_to_surface(SurfaceTarget {
+            time_seconds: 0.0,
+            ..render_target()
+        })
+        .expect("initial temporal indexed frame should render");
+    assert_index_matches_brute_force(&temporal_session, &[ViewportPoint::new(0.25, 0.25)]);
+    temporal_session
+        .render_to_surface(SurfaceTarget {
+            time_seconds: 0.25,
+            ..render_target()
+        })
+        .expect("updated temporal indexed frame should render");
+    assert_index_matches_brute_force(&temporal_session, &[ViewportPoint::new(0.25, 0.5)]);
 }
 
 #[test]
@@ -725,6 +1148,54 @@ fn test_incremental_streaming_uses_scaled_geometry_and_displayed_hit_data() {
     assert!(matches!(
         session.hit_test(screen_position),
         HitResult::SeriesPoint { point_index: 2, .. }
+    ));
+}
+#[test]
+fn test_incremental_streaming_replaces_index_with_displayed_frame_data() {
+    let stream = StreamingXY::new(1024);
+    stream.push_many((0..320).map(|index| {
+        let value = index as f64 / 400.0;
+        (value, value)
+    }));
+    let plot: Plot = Plot::new()
+        .scatter_streaming(&stream)
+        .into_plot()
+        .xlim(0.0, 1.0)
+        .ylim(0.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial indexed streaming frame should render");
+    assert!(!session.point_hit_index_initialized());
+    assert_eq!(session.indexed_point_series_count(), 1);
+    assert!(session.point_hit_index_initialized());
+    assert_index_matches_brute_force(&session, &[ViewportPoint::new(0.5, 0.5)]);
+
+    stream.push(0.9, 0.1);
+    let frame = session
+        .render_to_surface(render_target())
+        .expect("incremental indexed streaming frame should render");
+    assert!(frame.layer_state.used_incremental_data);
+    assert!(!session.point_hit_index_initialized());
+    assert_eq!(session.indexed_point_series_count(), 1);
+    assert!(session.point_hit_index_initialized());
+    assert_index_matches_brute_force(
+        &session,
+        &[ViewportPoint::new(0.5, 0.5), ViewportPoint::new(0.9, 0.1)],
+    );
+    let new_point = session
+        .data_to_screen(ViewportPoint::new(0.9, 0.1))
+        .unwrap()
+        .unwrap();
+    assert!(matches!(
+        session.hit_test(new_point),
+        HitResult::SeriesPoint {
+            point_index: 320,
+            ..
+        }
     ));
 }
 fn color_centroid<F>(image: &Image, predicate: F) -> Option<ViewportPoint>


### PR DESCRIPTION
## Summary

- lazily build a screen-space index for displayed point-series frames
- keep hit testing coherent across reactive, streaming, scaled, and reversed views
- preserve point/heatmap tie ordering and safely handle invalid or unbounded queries

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- six focused indexed hit-test, SymLog, invalid-query, and streaming regressions