### PR TITLE
Prepare v0.4.20 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to this project will be documented in this file.
 
 _None yet._
 
+## [0.4.20] - 2026-07-15
+
+### Added
+
+- Added frame-coherent, lazily constructed point hit-test indexing for large interactive plots, including scaled, reversed, reactive, and streaming frames.
+- Added exact bundled-font golden-image CI coverage for all committed deterministic visual fixtures and stricter checked documentation-fence validation.
+- Added packaged-crate verification for clean external `ruviz` and `ruviz-gpui` consumers, including release artifact and VCS provenance checks.
+
+### Changed
+
+- Unified resolved plot data, series styling, typography, markers, legends, annotations, and error bars across raster, SVG, parallel, prepared, and interactive render paths.
+- Made backend selection and diagnostics report the renderer that actually executed, with truthful fallbacks for unsupported Parallel, GPU, and DataShader operations.
+- Made coordinate transforms, hit testing, overlays, subplots, and interactive rendering scale-aware while preserving exact fixed-size output contracts.
+- Shared runtime font registration across renderers and completed the public multiline `TextStyle` contract for plain and Typst text.
+
+### Fixed
+
+- Fixed animation completion/reentrancy races, transactional reactive notifications, memory-manager lock ordering, and same-session reentrant interactive render deadlocks.
+- Fixed text alpha compositing, font-family precedence, SVG marker/legend parity, asymmetric error bars, subplot DPI handling, margin validation, and stale per-frame resolution.
+- Fixed feature aliases and release gating so ndarray compatibility, packaged GPUI consumers, and tag publication are checked against the exact required CI runs.
+- Corrected stale backend, performance, sizing, font, API, and deprecation documentation and made documentation/visual CI failures retain actionable artifacts.
+
 ## [0.4.19] - 2026-06-03
 
 ### Fixed
@@ -455,7 +477,8 @@ _None yet._
 - [@yonas](https://github.com/yonas) - FreeBSD support (#1)
 - [@Ameyanagi](https://github.com/Ameyanagi) - Cross-platform build fixes (#4)
 
-[Unreleased]: https://github.com/Ameyanagi/ruviz/compare/v0.4.19...HEAD
+[Unreleased]: https://github.com/Ameyanagi/ruviz/compare/v0.4.20...HEAD
+[0.4.20]: https://github.com/Ameyanagi/ruviz/compare/v0.4.19...v0.4.20
 [0.4.19]: https://github.com/Ameyanagi/ruviz/compare/v0.4.18...v0.4.19
 [0.4.18]: https://github.com/Ameyanagi/ruviz/compare/v0.4.17...v0.4.18
 [0.4.17]: https://github.com/Ameyanagi/ruviz/compare/v0.4.16...v0.4.17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8123,7 +8123,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "approx",
@@ -8183,7 +8183,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-gpui"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "arboard",
  "core-foundation 0.10.0",
@@ -8201,7 +8201,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-py"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "image",
  "pollster 0.4.0",
@@ -8213,7 +8213,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-web"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ gpui = { git = "https://github.com/zed-industries/zed", rev = "3060e4170ea5ef0e6
 
 [package]
 name = "ruviz"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Ruviz Contributors"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-ruviz = "0.4.19"
+ruviz = "0.4.20"
 ```
 
 Create and save a PNG:
@@ -162,7 +162,7 @@ Enable Typst-backed text rendering with:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["typst-math"] }
+ruviz = { version = "0.4.20", features = ["typst-math"] }
 ```
 
 Then call `.typst(true)`. The configured family is passed to plain raster,
@@ -197,7 +197,7 @@ compiled. If Typst is optional in your crate, forward and guard your own feature
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", default-features = false }
+ruviz = { version = "0.4.20", default-features = false }
 
 [features]
 default = []

--- a/crates/ruviz-gpui/Cargo.toml
+++ b/crates/ruviz-gpui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-gpui"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -13,7 +13,7 @@ default = []
 gpu = ["ruviz/gpu"]
 
 [dependencies]
-ruviz = { version = "0.4.19", path = "../.." }
+ruviz = { version = "0.4.20", path = "../.." }
 image = "0.25"
 smallvec = "1.15"
 futures = "0.3"

--- a/crates/ruviz-gpui/README.md
+++ b/crates/ruviz-gpui/README.md
@@ -10,8 +10,8 @@ own the window, layout tree, and surrounding application shell.
 
 ```toml
 [dependencies]
-ruviz = "0.4.19"
-ruviz-gpui = "0.4.19"
+ruviz = "0.4.20"
+ruviz-gpui = "0.4.20"
 ```
 
 ## What This Crate Provides

--- a/crates/ruviz-gpui/src/lib.rs
+++ b/crates/ruviz-gpui/src/lib.rs
@@ -23,8 +23,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ruviz = "0.4.19"
-//! ruviz-gpui = "0.4.19"
+//! ruviz = "0.4.20"
+//! ruviz-gpui = "0.4.20"
 //! ```
 //!
 //! Then build a normal `ruviz::Plot` or `PreparedPlot` and hand it to the GPUI

--- a/crates/ruviz-web/Cargo.toml
+++ b/crates/ruviz-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-web"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -12,7 +12,7 @@ readme = "README.md"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-ruviz = { version = "0.4.19", path = "../..", default-features = false }
+ruviz = { version = "0.4.20", path = "../..", default-features = false }
 js-sys = "0.3.92"
 wasm-bindgen = "0.2.105"
 console_error_panic_hook = "0.1.7"

--- a/crates/ruviz-web/README.md
+++ b/crates/ruviz-web/README.md
@@ -21,7 +21,7 @@ Add the bridge crate to your Cargo manifest:
 
 ```toml
 [dependencies]
-ruviz-web = "0.4.19"
+ruviz-web = "0.4.20"
 ```
 
 Build for `wasm32-unknown-unknown` and generate bindings with your preferred

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,14 +2,15 @@
 
 Get started with ruviz in less than 5 minutes!
 
-## What's New in v0.4.19
+## What's New in v0.4.20
 
-- GPUI interactive plots now scale typography, ticks, borders, and series styling with requested output dimensions.
-- `FixedPixels` stays exact while `Fill` uses aspect-fitted output sizing for resizable panes.
-- Fitted interactive canvases now keep base layers, overlays, and advertised dimensions aligned.
+- Rendering now shares resolved data, styling, fonts, annotations, and error bars across raster, SVG, prepared, parallel, and interactive paths.
+- Interactive transforms and hit testing are scale-aware, frame-coherent, and indexed for large displayed datasets.
+- Backend diagnostics now report actual execution and explain safe fallbacks for unsupported GPU, Parallel, and DataShader operations.
+- Deterministic bundled-font golden tests and checked documentation examples now guard visual and documentation quality in CI.
 
 See full details:
-- [Release notes for v0.4.19](releases/v0.4.19.md)
+- [Release notes for v0.4.20](releases/v0.4.20.md)
 - [Project changelog](../CHANGELOG.md)
 
 ## Installation
@@ -23,7 +24,7 @@ cd my_plot
 2. **Add ruviz to your `Cargo.toml`**:
 ```toml
 [dependencies]
-ruviz = "0.4.19"
+ruviz = "0.4.20"
 ```
 
 3. **Write your first plot** in `src/main.rs`:
@@ -62,8 +63,8 @@ an embedded interactive plot view:
 
 ```toml
 [dependencies]
-ruviz = "0.4.19"
-ruviz-gpui = "0.4.19"
+ruviz = "0.4.20"
+ruviz-gpui = "0.4.20"
 ```
 
 `ruviz-gpui` is supported on Linux, macOS, and Windows. On Windows, prefer the
@@ -91,7 +92,7 @@ If you want publication-style math in labels and titles, enable Typst text rende
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["typst-math"] }
+ruviz = { version = "0.4.20", features = ["typst-math"] }
 ```
 
 `.typst(true)` is only available when `typst-math` is enabled. The configured
@@ -110,7 +111,7 @@ If you want Typst to stay optional in your own crate, forward a local feature fi
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", default-features = false }
+ruviz = { version = "0.4.20", default-features = false }
 
 [features]
 default = []
@@ -362,7 +363,7 @@ Plot::new()
 ### With polars (requires `polars_support` feature)
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["polars_support"] }
+ruviz = { version = "0.4.20", features = ["polars_support"] }
 polars = "0.50"
 ```
 
@@ -390,7 +391,7 @@ The default feature set already includes `parallel`. Add `performance` only
 when you have benchmarked a path that benefits from the extra SIMD support:
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["performance"] }
+ruviz = { version = "0.4.20", features = ["performance"] }
 ```
 
 ### Large Dataset Export

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -62,14 +62,14 @@ Add ruviz to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruviz = "0.4.19"
+ruviz = "0.4.20"
 ```
 
 Or with specific features:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.4.20", features = ["ndarray_support", "parallel"] }
 ```
 
 ## Feature Flags
@@ -79,7 +79,7 @@ ruviz uses feature flags to enable optional functionality. Choose based on your 
 ### Default Features
 
 ```toml
-ruviz = "0.4.19"  # Includes: ndarray_support, parallel
+ruviz = "0.4.20"  # Includes: ndarray_support, parallel
 ```
 
 **Enabled by default**:
@@ -108,40 +108,40 @@ SVG export is available without an extra feature flag. The legacy `svg` feature 
 
 ```toml
 # High performance (parallel + SIMD)
-ruviz = { version = "0.4.19", features = ["performance"] }
+ruviz = { version = "0.4.20", features = ["performance"] }
 
 # Maximum capability (all features)
-ruviz = { version = "0.4.19", features = ["full"] }
+ruviz = { version = "0.4.20", features = ["full"] }
 
 # Minimal (no default features)
-ruviz = { version = "0.4.19", default-features = false }
+ruviz = { version = "0.4.20", default-features = false }
 ```
 
 ### Feature Combinations
 
 **Scientific Computing**:
 ```toml
-ruviz = { version = "0.4.19", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.4.20", features = ["ndarray_support", "parallel"] }
 ```
 
 **Data Analysis**:
 ```toml
-ruviz = { version = "0.4.19", features = ["polars_support", "performance"] }
+ruviz = { version = "0.4.20", features = ["polars_support", "performance"] }
 ```
 
 **Publication Quality**:
 ```toml
-ruviz = { version = "0.4.19", features = ["serde", "pdf"] }
+ruviz = { version = "0.4.20", features = ["serde", "pdf"] }
 ```
 
 **Real-time Visualization**:
 ```toml
-ruviz = { version = "0.4.19", features = ["interactive-gpu"] }
+ruviz = { version = "0.4.20", features = ["interactive-gpu"] }
 ```
 
 **Large Datasets**:
 ```toml
-ruviz = { version = "0.4.19", features = ["parallel", "simd", "gpu"] }
+ruviz = { version = "0.4.20", features = ["parallel", "simd", "gpu"] }
 ```
 
 ## Verification
@@ -187,7 +187,7 @@ Test specific features:
 **ndarray**:
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["ndarray_support"] }
+ruviz = { version = "0.4.20", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -280,7 +280,7 @@ rustup update
 
 ### Feature Conflicts
 
-**Problem**: `error: package ruviz v0.4.19 cannot be built because it requires rustc 1.92 or newer`
+**Problem**: `error: package ruviz v0.4.20 cannot be built because it requires rustc 1.92 or newer`
 
 **Solution**: Update Rust:
 ```bash
@@ -304,7 +304,7 @@ vulkaninfo
 
 Or disable GPU features:
 ```toml
-ruviz = { version = "0.4.19", default-features = false, features = ["parallel"] }
+ruviz = { version = "0.4.20", default-features = false, features = ["parallel"] }
 ```
 
 ### Memory Issues (Large Datasets)

--- a/docs/guide/03_first_plot.md
+++ b/docs/guide/03_first_plot.md
@@ -166,7 +166,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = "0.4.19"
+ruviz = "0.4.20"
 ```
 
 ## Customization Basics
@@ -304,7 +304,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["ndarray_support"] }
+ruviz = { version = "0.4.20", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 

--- a/docs/guide/04_plot_types.md
+++ b/docs/guide/04_plot_types.md
@@ -614,7 +614,7 @@ before adding more feature flags.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["parallel"] }
+ruviz = { version = "0.4.20", features = ["parallel"] }
 ```
 
 ### Large Datasets (20K+ points)
@@ -623,7 +623,7 @@ Use `performance` only after benchmarking a path that benefits from SIMD support
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["parallel", "simd"] }
+ruviz = { version = "0.4.20", features = ["parallel", "simd"] }
 ```
 
 ### Very Large Datasets (> 100K points)

--- a/docs/guide/07_backends.md
+++ b/docs/guide/07_backends.md
@@ -112,7 +112,7 @@ public render path:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["parallel"] }
+ruviz = { version = "0.4.20", features = ["parallel"] }
 ```
 
 ```rust
@@ -141,7 +141,7 @@ not a guarantee that a public `render()` call will take a SIMD path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["parallel", "simd"] }
+ruviz = { version = "0.4.20", features = ["parallel", "simd"] }
 ```
 
 ## What `save()` actually does
@@ -211,7 +211,7 @@ path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["gpu"] }
+ruviz = { version = "0.4.20", features = ["gpu"] }
 ```
 
 ```rust
@@ -247,7 +247,7 @@ dependency for you.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["interactive"] }
+ruviz = { version = "0.4.20", features = ["interactive"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 ```
 

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -48,7 +48,7 @@ at `t`.
 
 ```toml
 [dependencies]
-ruviz = "0.4.19"
+ruviz = "0.4.20"
 ```
 
 Useful opt-in features:

--- a/docs/guide/09_data_integration.md
+++ b/docs/guide/09_data_integration.md
@@ -64,7 +64,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["ndarray_support"] }
+ruviz = { version = "0.4.20", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -183,7 +183,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["nalgebra_support"] }
+ruviz = { version = "0.4.20", features = ["nalgebra_support"] }
 nalgebra = "0.32"
 ```
 
@@ -229,7 +229,7 @@ synthetic absorbed-energy style example.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.4.19", features = ["polars_support"] }
+ruviz = { version = "0.4.20", features = ["polars_support"] }
 polars = { version = "0.50", features = ["lazy", "rolling_window"] }
 ```
 

--- a/docs/guide/10_export.md
+++ b/docs/guide/10_export.md
@@ -534,7 +534,7 @@ Plot::new()
 ### PDF Export
 
 ```rust
-// Requires: ruviz = { version = "0.4.19", features = ["pdf"] }
+// Requires: ruviz = { version = "0.4.20", features = ["pdf"] }
 use ruviz::prelude::*;
 
 Plot::new()

--- a/docs/migration/matplotlib.md
+++ b/docs/migration/matplotlib.md
@@ -416,7 +416,7 @@ let viridis_like = Theme::builder()
 ## Migration Checklist
 
 - [ ] Install Rust and cargo
-- [ ] Add `ruviz = "0.4.19"` to `Cargo.toml`
+- [ ] Add `ruviz = "0.4.20"` to `Cargo.toml`
 - [ ] Convert numpy arrays to `Vec<f64>` or `ndarray`
 - [ ] Replace `plt.plot()` with `Plot::new().line()`
 - [ ] Change `plt.savefig()` to `.save()?`

--- a/docs/releases/v0.4.20.md
+++ b/docs/releases/v0.4.20.md
@@ -1,0 +1,52 @@
+# ruviz v0.4.20
+
+Released: 2026-07-15
+
+## Highlights
+
+- Raster, SVG, prepared, parallel, subplot, and interactive rendering now share one resolved contract for data, styles, fonts, annotations, legends, markers, and error bars.
+- Interactive plots now use scale-aware coordinate transforms and a lazy frame-coherent hit-test index, keeping displayed data, overlays, reactive updates, and streaming appends aligned.
+- Backend diagnostics distinguish requested and actual execution, with explicit reasons when unsupported Parallel, GPU, or DataShader operations fall back to Skia.
+- Documentation and visual CI now validate copyable examples and compare all deterministic golden fixtures exactly using a repository-owned font.
+
+## Version Alignment
+
+This release keeps the published workspace packages aligned on one version:
+
+- `ruviz` `0.4.20`
+- `ruviz-web` `0.4.20`
+- `ruviz-gpui` `0.4.20`
+- npm `ruviz` `0.4.20`
+- PyPI `ruviz` `0.4.20`
+
+## Rendering And Interaction
+
+- Shared runtime font registration now reaches all backends, and font-family/theme precedence follows the last public configuration call.
+- The complete public `TextStyle` contract now reaches multiline plain and Typst annotations, including alignment, rotation, weight, decoration, backgrounds, and whitespace behavior.
+- SVG and raster output now agree on marker shapes, legends, line widths, alpha compositing, asymmetric error bars, subplot DPI, and resolved style sampling.
+- Scale-aware interactive transforms cover linear, log, SymLog, reversed, high-DPI, reactive, temporal, and streaming views.
+- Same-session reentrant renders return a deterministic error instead of deadlocking, while concurrent threads retain serialized rendering.
+
+## Runtime And Packaging Reliability
+
+- Animation completion and recursive ticks preserve concurrent updates without stale overwrites.
+- Reactive batches are transactional and memory-manager lock acquisition no longer permits lock-order inversion.
+- The `ndarray` compatibility alias, packaged `ruviz-gpui` consumers, crate archives, VCS provenance, and exact required CI runs are verified before publication.
+- Backend routing reports what actually rendered and preserves overlays and error bars when optimized backends are incompatible.
+
+## Documentation And Quality Gates
+
+- Publication sizing, DPI, backend, GPU, DataShader, performance, font, API, and deprecation guidance now matches the implemented behavior.
+- Checked Rust, Python, TypeScript, Bash, and POSIX shell fences are validated without executing shell snippets; ignored fences require meaningful reasons.
+- All 25 committed deterministic golden fixtures are exercised by the required exact-comparison CI lane using bundled DejaVu Sans bytes.
+- Environment-sensitive visual and performance checks remain explicitly manual and separate from the deterministic required lane.
+
+## Quality And Validation
+
+The implementation landed through independently reviewed PRs [#76](https://github.com/Ameyanagi/ruviz/pull/76) through [#94](https://github.com/Ameyanagi/ruviz/pull/94). The final integrated `main` passed the required cross-platform CI, packaging, documentation, feature-contract, and deterministic visual workflows before release preparation.
+
+## References
+
+- Changelog: [`CHANGELOG.md`](../../CHANGELOG.md)
+- Previous release notes: [`v0.4.19`](./v0.4.19.md)
+- Release workflow: [`.github/workflows/release.yml`](../../.github/workflows/release.yml)

--- a/packages/ruviz-web/package.json
+++ b/packages/ruviz-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruviz",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "description": "Browser-first JS/TS SDK for ruviz WebAssembly rendering",
   "type": "module",
   "license": "MIT OR Apache-2.0",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-py"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Python bindings and notebook widget support for ruviz"
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 [dependencies]
 pollster = "0.4"
 pyo3 = { version = "0.24", features = ["abi3-py310"] }
-ruviz = { path = "..", version = "0.4.19", default-features = false, features = ["pdf", "svg"] }
+ruviz = { path = "..", version = "0.4.20", default-features = false, features = ["pdf", "svg"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruviz"
-version = "0.4.19"
+version = "0.4.20"
 description = "Python bindings and notebook widget support for ruviz"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -2132,7 +2132,7 @@ wheels = [
 
 [[package]]
 name = "ruviz"
-version = "0.4.19"
+version = "0.4.20"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary

- align Rust, npm, and Python package versions on `0.4.20`
- add the v0.4.20 changelog and release notes
- update release-facing installation examples and package references

## Validation

- `bun install --frozen-lockfile --ignore-scripts`
- `bun run check:web`
- `uv run python -m unittest scripts/test_check_docs.py`
- `uv run python scripts/check_docs.py`
- Ruff lint and format checks for repository Python tooling
- actionlint for CI and docs workflows
- exact release tag/package version contract for `v0.4.20`
- `cargo metadata --no-deps --format-version 1`
- `uv lock --project python --check`
- `cargo fmt --all -- --check`
- core/web all-target, all-feature Clippy
- `uv run python scripts/verify_packaged_crates.py --mode ci`
- `git diff --check`

The canonical packaged-crate verifier passed for `ruviz 0.4.20` and `ruviz-gpui 0.4.20` from a fresh external consumer with registry-sourced GPUI.

## Local baseline notes

A macOS all-workspace check encounters the existing split between `core-video` 0.4 and 0.5 in GPUI dependencies. Newer local Clippy also flags the existing `ruviz-py::into_plot_data(&self)` naming convention. This release-prep commit changes package versions and documentation only; required GitHub CI remains authoritative for the supported matrix.
