### PR TITLE
Expose GPUI plot coordinate mapping and pointer events

### DIFF
--- a/crates/ruviz-gpui/README.md
+++ b/crates/ruviz-gpui/README.md
@@ -19,7 +19,52 @@ ruviz-gpui = "0.4.20"
 - an embeddable GPUI plot view for static and interactive plots
 - configurable image and hybrid presentation modes
 - pan, zoom, hover, selection, and context-menu integration
+- absolute-window coordinate conversion and frame-aware click/hover callbacks
 - PNG save and clipboard-copy actions routed through the host platform
+
+## Coordinates and pointer callbacks
+
+`RuvizPlot::data_at` maps an absolute GPUI window `Point<Pixels>` into the
+currently displayed data coordinates. `RuvizPlot::screen_at` performs the inverse
+mapping and also returns an absolute window point. Both return `Ok(None)` before a
+displayed layout is available or when the requested position is out of bounds;
+applications do not need to estimate plot margins or presentation scaling.
+
+Click and hover handlers receive the same `PlotPointerEvent` payload, including
+the absolute window position, backing-frame viewport position, optional data
+position, displayed viewport snapshot, and frame-aware `HitResult`:
+
+```rust
+let plot = plot_builder(plot)
+    .on_plot_click(|event| {
+        println!("click: data={:?}, hit={:?}", event.data_position, event.hit);
+    })
+    .on_plot_hover(|event| {
+        println!("hover: window={:?}, data={:?}", event.window_position, event.data_position);
+    })
+    .build(cx);
+```
+
+Builder callbacks are convenient for simple thread-safe observers. Host views
+that update GPUI state should normally subscribe to the plot entity so the
+handler receives a usable GPUI context:
+
+```rust,ignore,reason=gpui-host-subscription
+let plot = plot_builder(plot).build(cx);
+let subscription = cx.subscribe(&plot, |this, _plot, event, cx| {
+    this.last_pointer_event = Some(event.clone());
+    cx.notify();
+});
+```
+
+Keep the returned subscription alive with the host view. `RuvizPlot` emits click
+and hover events to GPUI subscribers in addition to invoking builder callbacks.
+
+Click events run on a primary-button release for a non-drag gesture. With normal
+platform double-click delivery, the completed click-count 1 release may emit
+before click-count 2 is known; the click-count 2 release emits no additional
+click, so the complete sequence produces at most one click event.
+Built-in hover and tooltip processing continues alongside hover callbacks.
 
 ## Platform Notes
 
@@ -40,6 +85,7 @@ Runnable examples live in the crate:
 cargo run -p ruviz-gpui --example static_embed
 cargo run -p ruviz-gpui --example observable_embed
 cargo run -p ruviz-gpui --example streaming_embed
+cargo run -p ruviz-gpui --example coordinate_events
 ```
 
 ## Related Docs

--- a/crates/ruviz-gpui/examples/coordinate_events.rs
+++ b/crates/ruviz-gpui/examples/coordinate_events.rs
@@ -1,0 +1,87 @@
+mod support;
+
+use gpui::{
+    App, Bounds, Context, Render, Window, WindowBounds, WindowOptions, div, prelude::*, px, rgb,
+    size,
+};
+use ruviz::{core::HitResult, plots::heatmap::HeatmapConfig, prelude::*};
+use ruviz_gpui::{PlotPointerEvent, RuvizPlot, plot_builder};
+use support::{application, exit_on_window_open_failure};
+
+struct CoordinateEventsDemo {
+    plot: gpui::Entity<RuvizPlot>,
+    last_event: Option<PlotPointerEvent>,
+    _subscription: gpui::Subscription,
+}
+
+impl CoordinateEventsDemo {
+    fn new(_window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let values = vec![
+            vec![0.0, 0.3, 0.8, 1.0],
+            vec![0.2, 0.7, 0.9, 0.6],
+            vec![0.5, 1.0, 0.4, 0.1],
+        ];
+        let plot: Plot = Plot::new()
+            .heatmap(&values, Some(HeatmapConfig::new().colorbar(false)))
+            .title("GPUI Coordinate Events")
+            .into();
+
+        let plot = plot_builder(plot).build(cx);
+        let subscription = cx.subscribe(&plot, |this, _, event, cx| {
+            match &event.hit {
+                HitResult::HeatmapCell {
+                    row, col, value, ..
+                } => println!(
+                    "{:?} cell ({row}, {col}) = {value:.3}; data={:?}; window={:?}",
+                    event.kind, event.data_position, event.window_position
+                ),
+                other => println!(
+                    "{:?} data={:?}, hit={other:?}",
+                    event.kind, event.data_position
+                ),
+            }
+            this.last_event = Some(event.clone());
+            cx.notify();
+        });
+        Self {
+            plot,
+            last_event: None,
+            _subscription: subscription,
+        }
+    }
+}
+
+impl Render for CoordinateEventsDemo {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .p_4()
+            .bg(rgb(0xf6f7fb))
+            .child(
+                self.last_event
+                    .as_ref()
+                    .map(|event| {
+                        format!("Last event: {:?} at {:?}", event.kind, event.data_position)
+                    })
+                    .unwrap_or_else(|| "Move over or click the plot".to_string()),
+            )
+            .child(self.plot.clone())
+    }
+}
+
+fn main() {
+    application().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(900.0), px(640.0)), cx);
+        exit_on_window_open_failure(
+            cx.open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    ..Default::default()
+                },
+                |window, cx| cx.new(|cx| CoordinateEventsDemo::new(window, cx)),
+            ),
+            "coordinate events",
+        );
+        cx.activate(true);
+    });
+}

--- a/crates/ruviz-gpui/src/lib.rs
+++ b/crates/ruviz-gpui/src/lib.rs
@@ -10,7 +10,31 @@
 //! - `RuvizPlot` for embedding static or interactive plots in GPUI views
 //! - configurable presentation modes for image-backed and hybrid rendering
 //! - built-in pan, zoom, hover, selection, and context-menu behavior
+//! - absolute-window coordinate mapping and frame-aware click/hover callbacks
 //! - clipboard and PNG save helpers routed through the host platform
+//!
+//! # Coordinates And Pointer Events
+//!
+//! [`RuvizPlot::data_at`] accepts an absolute GPUI window [`Point<Pixels>`], while
+//! [`RuvizPlot::screen_at`] returns one. Both methods use the currently displayed
+//! backing frame and return `Ok(None)` when layout or a valid in-bounds mapping is
+//! unavailable. Click and hover callbacks share [`PlotPointerEvent`]:
+//!
+//! ```rust,ignore
+//! let plot = ruviz_gpui::plot_builder(plot)
+//!     .on_plot_click(|event| {
+//!         println!("clicked data={:?}, hit={:?}", event.data_position, event.hit);
+//!     })
+//!     .on_plot_hover(|event| {
+//!         update_status(event.window_position, event.data_position);
+//!     })
+//!     .build(cx);
+//! ```
+//!
+//! Builder callbacks are convenient thread-safe observers. GPUI views that update host UI state
+//! should normally subscribe to the plot entity with `cx.subscribe(&plot, ...)`; [`RuvizPlot`]
+//! emits every click and hover event through [`gpui::EventEmitter`] as well as invoking the
+//! corresponding builder callback.
 //!
 //! # Platform Support
 //!
@@ -71,9 +95,10 @@ mod platform_impl {
     use ruviz::{
         core::plot::Image as RuvizImage,
         core::{
-            FramePacing, FrameStats, ImageTarget, InteractivePlotSession, Plot, PlotInputEvent,
-            PlottingError, PreparedPlot, QualityPolicy, ReactiveSubscription, RenderTargetKind,
-            Result, SurfaceCapability, SurfaceTarget, ViewportPoint, ViewportRect,
+            FramePacing, FrameStats, HitResult, ImageTarget, InteractivePlotSession,
+            InteractiveViewportSnapshot, Plot, PlotInputEvent, PlottingError, PreparedPlot,
+            QualityPolicy, ReactiveSubscription, RenderTargetKind, Result, SurfaceCapability,
+            SurfaceTarget, ViewportPoint, ViewportRect,
         },
         export::write_rgba_png_atomic,
     };
@@ -104,6 +129,13 @@ mod platform_impl {
 
     type ContextMenuActionHandler =
         Arc<dyn Fn(GpuiContextMenuActionContext) -> Result<()> + Send + Sync>;
+    type PlotPointerEventHandler = Arc<dyn Fn(PlotPointerEvent) + Send + Sync>;
+
+    #[derive(Clone, Default)]
+    struct PlotPointerEventHandlers {
+        click: Option<PlotPointerEventHandler>,
+        hover: Option<PlotPointerEventHandler>,
+    }
 
     pub trait IntoPlotSession {
         fn into_plot_session(self) -> InteractivePlotSession;
@@ -285,6 +317,37 @@ mod platform_impl {
         pub image: RuvizImage,
     }
 
+    /// The kind of pointer event delivered by a [`PlotPointerEvent`] callback.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum PlotPointerEventKind {
+        Click,
+        Hover,
+    }
+
+    /// Frame-aware coordinates and hit information for a plot pointer event.
+    ///
+    /// [`Self::window_position`] is an absolute GPUI window coordinate. The
+    /// viewport coordinate, data coordinate, snapshot, and hit result all use
+    /// the interactive session's currently displayed backing frame.
+    /// [`RuvizPlot`] emits this type through [`gpui::EventEmitter`], so host views can use
+    /// `cx.subscribe(&plot, ...)` and update UI state with their normal GPUI context.
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct PlotPointerEvent {
+        pub kind: PlotPointerEventKind,
+        /// The mouse button for a click, or the currently pressed button for a hover.
+        pub mouse_button: Option<MouseButton>,
+        /// Absolute position in the GPUI window coordinate system.
+        pub window_position: Point<Pixels>,
+        /// Position in the plot's displayed backing frame, in viewport pixels.
+        pub viewport_position: ViewportPoint,
+        /// Displayed data coordinates, or `None` in frame margins outside the plot area.
+        pub data_position: Option<ViewportPoint>,
+        /// Current displayed viewport state, including plot area and visible bounds.
+        pub viewport: InteractiveViewportSnapshot,
+        /// Hit result from the same displayed-frame coordinate contract.
+        pub hit: HitResult,
+    }
+
     /// Performance tuning options for the shared interactive session.
     #[derive(Clone, Copy, Debug, PartialEq)]
     pub struct PerformanceOptions {
@@ -423,6 +486,7 @@ mod platform_impl {
         scale_bits: u32,
         time_bits: u64,
         presentation_mode: PresentationMode,
+        presented_base_generation: Option<u64>,
     }
 
     impl RenderRequest {
@@ -437,7 +501,13 @@ mod platform_impl {
                 scale_bits: sanitize_scale_factor(scale_factor).to_bits(),
                 time_bits: time_seconds.to_bits(),
                 presentation_mode,
+                presented_base_generation: None,
             }
+        }
+
+        fn with_presented_base_generation(mut self, generation: Option<u64>) -> Self {
+            self.presented_base_generation = generation;
+            self
         }
 
         fn scale_factor(&self) -> f32 {
@@ -479,6 +549,7 @@ mod platform_impl {
     #[derive(Clone)]
     struct CachedFrame {
         request: RenderRequest,
+        base_generation: u64,
         primary: PrimaryFrame,
         overlay_image: Option<Arc<RenderImage>>,
         stats: FrameStats,
@@ -486,10 +557,16 @@ mod platform_impl {
     }
 
     struct RenderedFrame {
+        base_generation: u64,
         primary: Option<RenderedPrimary>,
-        overlay_image: Option<Arc<RenderImage>>,
+        overlay: RenderedOverlay,
         stats: FrameStats,
         target: RenderTargetKind,
+    }
+
+    enum RenderedOverlay {
+        Reuse,
+        Replace(Option<Arc<RenderImage>>),
     }
 
     #[derive(Clone, Debug, Eq, PartialEq)]
@@ -549,6 +626,7 @@ mod platform_impl {
         plot: P,
         options: RuvizPlotOptions,
         context_menu_action_handler: Option<ContextMenuActionHandler>,
+        pointer_event_handlers: PlotPointerEventHandlers,
     }
 
     impl<P> RuvizPlotBuilder<P>
@@ -560,6 +638,7 @@ mod platform_impl {
                 plot,
                 options: RuvizPlotOptions::default(),
                 context_menu_action_handler: None,
+                pointer_event_handlers: PlotPointerEventHandlers::default(),
             }
         }
 
@@ -624,6 +703,32 @@ mod platform_impl {
             self
         }
 
+        /// Registers a thread-safe observer for primary-button clicks on the displayed plot frame.
+        ///
+        /// The callback runs on release and is suppressed for drags. Under standard platform
+        /// double-click semantics, click-count 1 may emit before click-count 2 is known; the
+        /// click-count 2 release emits no additional click. Host UI state should normally use
+        /// `cx.subscribe(&plot, ...)` instead so the subscriber receives a GPUI context.
+        pub fn on_plot_click<F>(mut self, handler: F) -> Self
+        where
+            F: Fn(PlotPointerEvent) + Send + Sync + 'static,
+        {
+            self.pointer_event_handlers.click = Some(Arc::new(handler));
+            self
+        }
+
+        /// Registers a thread-safe observer for pointer movement over the displayed plot frame.
+        ///
+        /// This callback is independent of the built-in hover/tooltip option, which continues
+        /// to run when enabled. Host UI state should normally use `cx.subscribe(&plot, ...)`.
+        pub fn on_plot_hover<F>(mut self, handler: F) -> Self
+        where
+            F: Fn(PlotPointerEvent) + Send + Sync + 'static,
+        {
+            self.pointer_event_handlers.hover = Some(Arc::new(handler));
+            self
+        }
+
         fn validate(&self) -> Result<()> {
             if self.options.context_menu.enabled
                 && !self.options.context_menu.custom_items.is_empty()
@@ -645,8 +750,15 @@ mod platform_impl {
             let options = self.options;
             let plot = self.plot;
             let context_menu_action_handler = self.context_menu_action_handler;
+            let pointer_event_handlers = self.pointer_event_handlers;
             Ok(cx.new(move |cx| {
-                RuvizPlot::from_options_impl(plot, options, context_menu_action_handler, cx)
+                RuvizPlot::from_options_impl(
+                    plot,
+                    options,
+                    context_menu_action_handler,
+                    pointer_event_handlers,
+                    cx,
+                )
             }))
         }
 
@@ -720,6 +832,7 @@ mod platform_impl {
         focus_handle: FocusHandle,
         interaction_state: InteractionState,
         context_menu_action_handler: Option<ContextMenuActionHandler>,
+        pointer_event_handlers: PlotPointerEventHandlers,
     }
 
     impl RuvizPlot {
@@ -727,6 +840,7 @@ mod platform_impl {
             plot: P,
             options: RuvizPlotOptions,
             context_menu_action_handler: Option<ContextMenuActionHandler>,
+            pointer_event_handlers: PlotPointerEventHandlers,
             cx: &mut Context<Self>,
         ) -> Self
         where
@@ -754,6 +868,7 @@ mod platform_impl {
                 focus_handle: cx.focus_handle(),
                 interaction_state: InteractionState::default(),
                 context_menu_action_handler,
+                pointer_event_handlers,
             }
         }
 
@@ -762,7 +877,13 @@ mod platform_impl {
         where
             P: IntoPlotSession,
         {
-            Self::from_options_impl(plot, RuvizPlotOptions::default(), None, cx)
+            Self::from_options_impl(
+                plot,
+                RuvizPlotOptions::default(),
+                None,
+                PlotPointerEventHandlers::default(),
+                cx,
+            )
         }
 
         #[deprecated(note = "Use ruviz_gpui::plot_builder(...).build(cx).")]
@@ -770,7 +891,13 @@ mod platform_impl {
         where
             P: IntoPlotSession,
         {
-            Self::from_options_impl(plot, options, None, _cx)
+            Self::from_options_impl(
+                plot,
+                options,
+                None,
+                PlotPointerEventHandlers::default(),
+                _cx,
+            )
         }
 
         pub fn interactive_session(&self) -> &InteractivePlotSession {
@@ -1190,11 +1317,81 @@ mod platform_impl {
         }
     }
 
+    impl gpui::EventEmitter<PlotPointerEvent> for RuvizPlot {}
+
     #[cfg(test)]
     mod tests {
         use super::*;
         use gpui::{Modifiers, MouseButton, TestAppContext};
+        use ruviz::plots::heatmap::HeatmapConfig;
         use ruviz::{axes::AxisScale, data::Observable, prelude::Plot};
+
+        struct PointerEventSubscriber {
+            events: Arc<Mutex<Vec<PlotPointerEvent>>>,
+            _subscription: gpui::Subscription,
+        }
+
+        fn mapped_test_view(
+            plot: Plot,
+            options: RuvizPlotOptions,
+            frame_size_px: (u32, u32),
+            scale_factor: f32,
+            component_bounds: Bounds<Pixels>,
+        ) -> (TestAppContext, Entity<RuvizPlot>) {
+            let session = plot.prepare_interactive();
+            let result = session
+                .render_to_surface_with_generation(SurfaceTarget {
+                    size_px: frame_size_px,
+                    scale_factor,
+                    time_seconds: options.interaction.time_seconds,
+                })
+                .expect("mapped test frame should render");
+            let base_generation = result.base_generation;
+            let frame = result.frame;
+            let time_seconds = options.interaction.time_seconds;
+            let presentation_mode = options.presentation_mode;
+            let cx = TestAppContext::single();
+            let view = cx.update(|cx| {
+                cx.new(move |cx| {
+                    let mut view = RuvizPlot::from_options_impl(
+                        session,
+                        options,
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    );
+                    view.cached_frame = Some(CachedFrame {
+                        request: RenderRequest::new(
+                            frame_size_px,
+                            scale_factor,
+                            time_seconds,
+                            presentation_mode,
+                        ),
+                        base_generation,
+                        primary: PrimaryFrame::Image(render_image_from_ruviz(
+                            frame.layers.base.as_ref().clone(),
+                        )),
+                        overlay_image: None,
+                        stats: frame.stats,
+                        target: frame.target,
+                    });
+                    view.update_layout(component_bounds, frame_size_px);
+                    view
+                })
+            });
+            (cx, view)
+        }
+
+        fn assert_window_points_close(actual: Point<Pixels>, expected: Point<Pixels>) {
+            assert!((f64::from(actual.x) - f64::from(expected.x)).abs() < 1e-4);
+            assert!((f64::from(actual.y) - f64::from(expected.y)).abs() < 1e-4);
+        }
+
+        fn synchronize_test_frame(view: &mut RuvizPlot, request: RenderRequest) {
+            let frame = render_frame_from_session(view.session.clone(), request.clone())
+                .expect("test frame should render");
+            view.replace_cached_frame(request, frame);
+        }
 
         #[test]
         fn test_rgba_to_bgra_conversion() {
@@ -1237,6 +1434,7 @@ mod platform_impl {
                 options: RuvizPlotOptions::default(),
                 cached_frame: Some(CachedFrame {
                     request: RenderRequest::new((1, 1), 1.0, 0.0, PresentationMode::Hybrid),
+                    base_generation: 0,
                     primary: PrimaryFrame::Image(render_image_from_ruviz(base)),
                     overlay_image: Some(render_image_from_ruviz(overlay)),
                     stats: FrameStats::default(),
@@ -1251,6 +1449,7 @@ mod platform_impl {
                 focus_handle,
                 interaction_state: InteractionState::default(),
                 context_menu_action_handler: None,
+                pointer_event_handlers: PlotPointerEventHandlers::default(),
             };
 
             let captured = view
@@ -1310,6 +1509,557 @@ mod platform_impl {
             assert_eq!(fill_backing_dimension_px(320, 1.5), 480);
             assert_eq!(fill_backing_dimension_px(320, 0.5), 320);
             assert_eq!(fill_backing_dimension_px(0, 2.0), 0);
+        }
+
+        #[test]
+        fn test_window_data_round_trip_respects_scale_and_presentation_geometry() {
+            let component_bounds =
+                Bounds::new(point(px(100.0), px(50.0)), size(px(500.0), px(300.0)));
+            let plot: Plot = Plot::new()
+                .size(4.0, 3.0)
+                .scatter(&[5.0], &[10.0])
+                .xlim(0.0, 10.0)
+                .ylim(0.0, 20.0)
+                .into();
+            let (cx, view) = mapped_test_view(
+                plot,
+                RuvizPlotOptions::default(),
+                (800, 600),
+                2.0,
+                component_bounds,
+            );
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    let layout = view.last_layout.as_ref().expect("layout should exist");
+                    assert_eq!(layout.content_bounds.origin, point(px(150.0), px(50.0)));
+                    assert_eq!(layout.content_bounds.size, size(px(400.0), px(300.0)));
+
+                    let window_position = view
+                        .screen_at(ViewportPoint::new(5.0, 10.0))
+                        .expect("data mapping should succeed")
+                        .expect("center data should be visible");
+                    let data_position = view
+                        .data_at(window_position)
+                        .expect("window mapping should succeed")
+                        .expect("mapped point should be in the plot area");
+                    assert!((data_position.x - 5.0).abs() < 1e-6);
+                    assert!((data_position.y - 10.0).abs() < 1e-6);
+                    assert_window_points_close(
+                        view.screen_at(data_position)
+                            .expect("inverse mapping should succeed")
+                            .expect("round-tripped data should remain visible"),
+                        window_position,
+                    );
+                })
+            });
+
+            let plot: Plot = Plot::new()
+                .size(4.0, 3.0)
+                .line(&[0.0, 1.0], &[0.0, 1.0])
+                .into();
+            let mut fill_options = RuvizPlotOptions::default();
+            fill_options.interaction.image_fit = ImageFit::Fill;
+            let (cx, view) =
+                mapped_test_view(plot, fill_options, (800, 600), 2.0, component_bounds);
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    let layout = view.last_layout.as_ref().expect("layout should exist");
+                    assert_eq!(layout.content_bounds, component_bounds);
+                    let center = ViewportPoint::new(0.5, 0.5);
+                    let window_position = view
+                        .screen_at(center)
+                        .expect("fill inverse mapping should succeed")
+                        .expect("center should be visible");
+                    let round_trip = view
+                        .data_at(window_position)
+                        .expect("fill forward mapping should succeed")
+                        .expect("fill center should remain inside the plot area");
+                    assert!((round_trip.x - center.x).abs() < 1e-6);
+                    assert!((round_trip.y - center.y).abs() < 1e-6);
+                })
+            });
+        }
+
+        #[test]
+        fn test_coordinate_mapping_returns_none_before_layout_and_outside_plot() {
+            let plot: Plot = Plot::new()
+                .line(&[0.0, 1.0], &[0.0, 1.0])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let session = plot.prepare_interactive();
+            session
+                .render_to_surface(SurfaceTarget {
+                    size_px: (400, 300),
+                    scale_factor: 1.0,
+                    time_seconds: 0.0,
+                })
+                .expect("coordinate test frame should render");
+            let cx = TestAppContext::single();
+            let view = cx.update(|cx| {
+                cx.new(move |cx| {
+                    RuvizPlot::from_options_impl(
+                        session,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    assert_eq!(view.data_at(point(px(10.0), px(10.0))).unwrap(), None);
+                    assert_eq!(view.screen_at(ViewportPoint::new(0.5, 0.5)).unwrap(), None);
+                })
+            });
+
+            let bounds = Bounds::new(point(px(100.0), px(100.0)), size(px(400.0), px(300.0)));
+            cx.update(|app| {
+                view.update(app, |view, _| view.update_layout(bounds, (400, 300)));
+            });
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    assert_eq!(view.data_at(point(px(99.0), px(100.0))).unwrap(), None);
+                    let frame_corner = view
+                        .viewport_point_to_window_position(ViewportPoint::new(0.0, 0.0))
+                        .expect("layout should map frame coordinates");
+                    assert_eq!(view.data_at(frame_corner).unwrap(), None);
+                    assert_eq!(view.screen_at(ViewportPoint::new(2.0, 2.0)).unwrap(), None);
+                })
+            });
+        }
+
+        #[test]
+        fn test_generation_recovery_replaces_base_and_clears_stale_overlay() {
+            let component_bounds =
+                Bounds::new(point(px(40.0), px(30.0)), size(px(400.0), px(300.0)));
+            let plot: Plot = Plot::new()
+                .scatter(&[0.5], &[0.5])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let (cx, view) = mapped_test_view(
+                plot,
+                RuvizPlotOptions::default(),
+                (400, 300),
+                1.0,
+                component_bounds,
+            );
+
+            let (window_position, installed_generation) = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    (
+                        view.screen_at(ViewportPoint::new(0.5, 0.5))
+                            .expect("initial mapping should succeed")
+                            .expect("center should be visible"),
+                        view.cached_frame
+                            .as_ref()
+                            .expect("test frame should be installed")
+                            .base_generation,
+                    )
+                })
+            });
+
+            cx.update(|app| {
+                view.update(app, |view, _| {
+                    view.session.apply_input(PlotInputEvent::Hover {
+                        position_px: ViewportPoint::new(200.0, 150.0),
+                    });
+                    synchronize_test_frame(
+                        view,
+                        RenderRequest::new((400, 300), 1.0, 0.0, PresentationMode::Hybrid)
+                            .with_presented_base_generation(Some(installed_generation)),
+                    );
+                    assert!(
+                        view.cached_frame
+                            .as_ref()
+                            .expect("generation A should remain installed")
+                            .overlay_image
+                            .is_some(),
+                        "generation A must start with a visible overlay"
+                    );
+                    let installed_generation = view
+                        .cached_frame
+                        .as_ref()
+                        .expect("generation A should remain installed")
+                        .base_generation;
+
+                    view.session.apply_input(PlotInputEvent::ClearHover);
+                    view.session.apply_input(PlotInputEvent::Pan {
+                        delta_px: ViewportPoint::new(30.0, 0.0),
+                    });
+                    let newer = view
+                        .session
+                        .render_to_surface_with_generation(SurfaceTarget {
+                            size_px: (400, 300),
+                            scale_factor: 1.0,
+                            time_seconds: 0.0,
+                        })
+                        .expect("newer core frame should render");
+                    assert!(newer.base_generation > installed_generation);
+                    assert_eq!(
+                        view.cached_frame
+                            .as_ref()
+                            .expect("old GPUI frame remains installed")
+                            .base_generation,
+                        installed_generation
+                    );
+                    assert!(
+                        newer.frame.layers.overlay.is_none(),
+                        "generation B should authoritatively have no overlay"
+                    );
+                    assert!(
+                        !view.session.dirty_domains().overlay,
+                        "the external B render must leave no later overlay dirtiness"
+                    );
+                    assert!(
+                        view.cached_frame
+                            .as_ref()
+                            .expect("old GPUI frame remains installed")
+                            .overlay_image
+                            .is_some(),
+                        "GPUI should still hold A's overlay before recovery"
+                    );
+
+                    assert_eq!(view.data_at(window_position).unwrap(), None);
+                    assert_eq!(view.screen_at(ViewportPoint::new(0.5, 0.5)).unwrap(), None);
+                    assert_eq!(
+                        view.build_plot_pointer_event(
+                            PlotPointerEventKind::Hover,
+                            None,
+                            window_position,
+                        )
+                        .unwrap(),
+                        None
+                    );
+
+                    let recovery_request =
+                        RenderRequest::new((400, 300), 1.0, 0.0, PresentationMode::Hybrid)
+                            .with_presented_base_generation(Some(installed_generation));
+                    assert!(!view.cache_is_current(&recovery_request));
+
+                    let recovered =
+                        render_frame_from_session(view.session.clone(), recovery_request.clone())
+                            .expect("the next GPUI render should recover the newer generation");
+                    assert_eq!(recovered.base_generation, newer.base_generation);
+                    assert!(
+                        recovered.primary.is_some(),
+                        "a generation mismatch must carry the matching base image"
+                    );
+                    assert!(
+                        matches!(recovered.overlay, RenderedOverlay::Replace(None)),
+                        "generation recovery must authoritatively clear A's overlay"
+                    );
+                    match recovered
+                        .primary
+                        .as_ref()
+                        .expect("recovery frame must include a primary")
+                    {
+                        RenderedPrimary::Image(image) => {
+                            let recovered_base = render_image_to_ruviz(image)
+                                .expect("recovered base image should be readable");
+                            assert_eq!(
+                                recovered_base.pixels.as_slice(),
+                                newer.frame.layers.base.pixels.as_slice(),
+                                "generation B must be associated with generation B's base pixels"
+                            );
+                        }
+                        #[cfg(all(feature = "gpu", target_os = "macos"))]
+                        RenderedPrimary::Surface(_) => {}
+                    }
+                    view.replace_cached_frame(recovery_request, recovered);
+
+                    assert_eq!(
+                        view.cached_frame
+                            .as_ref()
+                            .expect("recovered GPUI frame should be installed")
+                            .base_generation,
+                        newer.base_generation
+                    );
+                    assert!(
+                        view.cached_frame
+                            .as_ref()
+                            .expect("recovered GPUI frame should be installed")
+                            .overlay_image
+                            .is_none(),
+                        "A's overlay must not be reused with generation B"
+                    );
+                    assert!(view.data_at(window_position).unwrap().is_some());
+                    assert!(
+                        view.screen_at(ViewportPoint::new(0.5, 0.5))
+                            .unwrap()
+                            .is_some()
+                    );
+                    let installed_request = &view
+                        .cached_frame
+                        .as_ref()
+                        .expect("recovered GPUI frame should be installed")
+                        .request;
+                    assert!(view.cache_is_current(installed_request));
+                });
+            });
+        }
+
+        #[test]
+        fn test_pointer_handlers_ignore_generation_mismatch_and_recover_after_install() {
+            let component_bounds =
+                Bounds::new(point(px(40.0), px(30.0)), size(px(400.0), px(300.0)));
+            let plot: Plot = Plot::new()
+                .scatter(&[0.5], &[0.5])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let (cx, view) = mapped_test_view(
+                plot,
+                RuvizPlotOptions::default(),
+                (400, 300),
+                1.0,
+                component_bounds,
+            );
+            let events = Arc::new(Mutex::new(Vec::<PlotPointerEvent>::new()));
+
+            cx.update(|app| {
+                view.update(app, |view, cx| {
+                    let events_for_click = Arc::clone(&events);
+                    let events_for_hover = Arc::clone(&events);
+                    view.pointer_event_handlers = PlotPointerEventHandlers {
+                        click: Some(Arc::new(move |event| {
+                            events_for_click
+                                .lock()
+                                .expect("pointer event lock poisoned")
+                                .push(event);
+                        })),
+                        hover: Some(Arc::new(move |event| {
+                            events_for_hover
+                                .lock()
+                                .expect("pointer event lock poisoned")
+                                .push(event);
+                        })),
+                    };
+
+                    let stale_window_position = view
+                        .screen_at(ViewportPoint::new(0.5, 0.5))
+                        .expect("initial mapping should succeed")
+                        .expect("scatter point should be visible");
+                    let installed_generation = view
+                        .cached_frame
+                        .as_ref()
+                        .expect("generation A should be installed")
+                        .base_generation;
+                    view.session.apply_input(PlotInputEvent::Pan {
+                        delta_px: ViewportPoint::new(30.0, 0.0),
+                    });
+                    let newer = view
+                        .session
+                        .render_to_surface_with_generation(SurfaceTarget {
+                            size_px: (400, 300),
+                            scale_factor: 1.0,
+                            time_seconds: 0.0,
+                        })
+                        .expect("generation B should render externally");
+                    assert!(newer.base_generation > installed_generation);
+                    assert!(!view.session.dirty_domains().overlay);
+
+                    view.handle_mouse_move(
+                        &MouseMoveEvent {
+                            position: stale_window_position,
+                            pressed_button: None,
+                            modifiers: Modifiers::default(),
+                        },
+                        cx,
+                    )
+                    .expect("mismatched hover should be ignored normally");
+                    let stale_px = view
+                        .local_viewport_point(stale_window_position)
+                        .expect("stale point should still map through the installed layout");
+                    view.interaction_state.active_drag = ActiveDrag::LeftPan {
+                        anchor_px: stale_px,
+                        anchor_window: stale_window_position,
+                        last_px: stale_px,
+                        crossed_threshold: false,
+                        click_eligible: true,
+                    };
+                    view.handle_left_mouse_up(
+                        &MouseUpEvent {
+                            button: MouseButton::Left,
+                            position: stale_window_position,
+                            modifiers: Modifiers::default(),
+                            click_count: 1,
+                        },
+                        cx,
+                    )
+                    .expect("mismatched click should be ignored normally");
+
+                    assert!(
+                        !view.session.dirty_domains().overlay,
+                        "mismatched hover/click must not alter core hover or selection"
+                    );
+                    assert_eq!(
+                        view.session
+                            .viewport_snapshot()
+                            .expect("generation B viewport should exist")
+                            .selected_count,
+                        0
+                    );
+                    assert!(
+                        events
+                            .lock()
+                            .expect("pointer event lock poisoned")
+                            .is_empty()
+                    );
+
+                    let recovery_request =
+                        RenderRequest::new((400, 300), 1.0, 0.0, PresentationMode::Hybrid)
+                            .with_presented_base_generation(Some(installed_generation));
+                    let recovered =
+                        render_frame_from_session(view.session.clone(), recovery_request.clone())
+                            .expect("GPUI recovery should succeed");
+                    view.replace_cached_frame(recovery_request, recovered);
+
+                    let current_window_position = view
+                        .screen_at(ViewportPoint::new(0.5, 0.5))
+                        .expect("recovered mapping should succeed")
+                        .expect("scatter point should remain visible");
+                    view.handle_mouse_move(
+                        &MouseMoveEvent {
+                            position: current_window_position,
+                            pressed_button: None,
+                            modifiers: Modifiers::default(),
+                        },
+                        cx,
+                    )
+                    .expect("hover should recover after B installation");
+                    let current_px = view
+                        .local_viewport_point(current_window_position)
+                        .expect("current point should map through the layout");
+                    view.interaction_state.active_drag = ActiveDrag::LeftPan {
+                        anchor_px: current_px,
+                        anchor_window: current_window_position,
+                        last_px: current_px,
+                        crossed_threshold: false,
+                        click_eligible: true,
+                    };
+                    view.handle_left_mouse_up(
+                        &MouseUpEvent {
+                            button: MouseButton::Left,
+                            position: current_window_position,
+                            modifiers: Modifiers::default(),
+                            click_count: 1,
+                        },
+                        cx,
+                    )
+                    .expect("click should recover after B installation");
+
+                    assert!(view.session.dirty_domains().overlay);
+                    assert_eq!(
+                        view.session
+                            .viewport_snapshot()
+                            .expect("recovered viewport should exist")
+                            .selected_count,
+                        1
+                    );
+                    let events = events.lock().expect("pointer event lock poisoned");
+                    assert_eq!(events.len(), 2);
+                    assert_eq!(events[0].kind, PlotPointerEventKind::Hover);
+                    assert_eq!(events[1].kind, PlotPointerEventKind::Click);
+                });
+            });
+        }
+
+        #[test]
+        fn test_heatmap_hover_payload_coexists_with_builtin_hover_and_coalesces_duplicates() {
+            let events = Arc::new(Mutex::new(Vec::<PlotPointerEvent>::new()));
+            let events_for_callback = Arc::clone(&events);
+            let plot: Plot = Plot::new()
+                .heatmap(
+                    &vec![vec![1.0, 2.0], vec![3.0, 4.0]],
+                    Some(HeatmapConfig::new().colorbar(false)),
+                )
+                .xlim(0.0, 2.0)
+                .ylim(0.0, 2.0)
+                .into();
+            let session = plot.prepare_interactive();
+            let cx = TestAppContext::single();
+            let view = cx.update(|cx| {
+                cx.new(move |cx| {
+                    let mut view = RuvizPlot::from_options_impl(
+                        session,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers {
+                            click: None,
+                            hover: Some(Arc::new(move |event| {
+                                events_for_callback
+                                    .lock()
+                                    .expect("hover event lock poisoned")
+                                    .push(event);
+                            })),
+                        },
+                        cx,
+                    );
+                    synchronize_test_frame(
+                        &mut view,
+                        RenderRequest::new((400, 300), 1.0, 0.0, PresentationMode::Hybrid),
+                    );
+                    view.update_layout(
+                        Bounds::new(Point::default(), size(px(400.0), px(300.0))),
+                        (400, 300),
+                    );
+                    view
+                })
+            });
+            let window_position = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    view.screen_at(ViewportPoint::new(1.5, 1.5))
+                        .expect("heatmap inverse mapping should succeed")
+                        .expect("heatmap cell center should be visible")
+                })
+            });
+
+            cx.update(|app| {
+                view.update(app, |view, cx| {
+                    view.handle_mouse_move(
+                        &MouseMoveEvent {
+                            position: window_position,
+                            pressed_button: None,
+                            modifiers: Modifiers::default(),
+                        },
+                        cx,
+                    )
+                    .expect("heatmap hover should succeed");
+                    assert!(view.session.dirty_domains().overlay);
+                    view.handle_mouse_move(
+                        &MouseMoveEvent {
+                            position: window_position,
+                            pressed_button: None,
+                            modifiers: Modifiers::default(),
+                        },
+                        cx,
+                    )
+                    .expect("duplicate heatmap hover should succeed");
+                });
+            });
+
+            let events = events.lock().expect("hover event lock poisoned");
+            assert_eq!(events.len(), 1);
+            let event = &events[0];
+            assert_eq!(event.kind, PlotPointerEventKind::Hover);
+            assert_eq!(event.mouse_button, None);
+            assert_eq!(event.window_position, window_position);
+            assert!(event.viewport.plot_area.contains(event.viewport_position));
+            assert!(matches!(
+                event.hit,
+                HitResult::HeatmapCell {
+                    series_index: 0,
+                    row: 0,
+                    col: 1,
+                    value: 2.0,
+                    ..
+                }
+            ));
         }
 
         #[test]
@@ -1409,6 +2159,7 @@ mod platform_impl {
                 render_image_from_ruviz(ruviz::core::plot::Image::new(1, 1, vec![0, 0, 0, 255]));
             let cached_frame = CachedFrame {
                 request: RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid),
+                base_generation: 0,
                 primary: PrimaryFrame::Image(cached_primary),
                 overlay_image: None,
                 stats: FrameStats::default(),
@@ -1438,13 +2189,17 @@ mod platform_impl {
                     last_pointer_px: Some(ViewportPoint::new(2.0, 2.0)),
                     active_drag: ActiveDrag::LeftPan {
                         anchor_px: ViewportPoint::new(1.0, 1.0),
+                        anchor_window: point(px(1.0), px(1.0)),
                         last_px: ViewportPoint::new(2.0, 2.0),
                         crossed_threshold: true,
+                        click_eligible: false,
                     },
                     context_menu: None,
                     home_view_bounds: None,
+                    last_hover_event: None,
                 },
                 context_menu_action_handler: None,
+                pointer_event_handlers: PlotPointerEventHandlers::default(),
             };
 
             let replacement_plot: Plot = Plot::new().line(&[0.0, 1.0], &[1.0, 2.0]).into();
@@ -1481,6 +2236,7 @@ mod platform_impl {
                 focus_handle: TestAppContext::single().update(|cx| cx.focus_handle()),
                 interaction_state: InteractionState::default(),
                 context_menu_action_handler: None,
+                pointer_event_handlers: PlotPointerEventHandlers::default(),
             };
 
             let save = KeyDownEvent {
@@ -1513,17 +2269,485 @@ mod platform_impl {
         }
 
         #[test]
+        fn test_click_fires_once_while_drag_and_builtin_interactions_do_not_click() {
+            let clicks = Arc::new(Mutex::new(Vec::<PlotPointerEvent>::new()));
+            let clicks_for_callback = Arc::clone(&clicks);
+            let mut app = TestAppContext::single();
+            let (view, cx) = app.add_window_view(|_, cx| {
+                let plot: Plot = Plot::new()
+                    .scatter(&[0.5], &[0.5])
+                    .xlim(0.0, 1.0)
+                    .ylim(0.0, 1.0)
+                    .into();
+                RuvizPlot::from_options_impl(
+                    plot,
+                    RuvizPlotOptions::default(),
+                    None,
+                    PlotPointerEventHandlers {
+                        click: Some(Arc::new(move |event| {
+                            clicks_for_callback
+                                .lock()
+                                .expect("click event lock poisoned")
+                                .push(event);
+                        })),
+                        hover: None,
+                    },
+                    cx,
+                )
+            });
+
+            for _ in 0..4 {
+                cx.refresh().expect("rendered frame refresh should succeed");
+                cx.run_until_parked();
+            }
+            cx.update(|_, app| {
+                view.update(app, |view, _| {
+                    let layout = view
+                        .last_layout
+                        .clone()
+                        .expect("prepaint should resolve test layout");
+                    synchronize_test_frame(
+                        view,
+                        RenderRequest::new(
+                            layout.frame_size_px,
+                            1.0,
+                            0.0,
+                            PresentationMode::Hybrid,
+                        ),
+                    );
+                    view.update_layout(layout.component_bounds, layout.frame_size_px);
+                });
+            });
+
+            let (click_position, drag_start, drag_end, initial_bounds) = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    let screen_at = |data_position| {
+                        view.screen_at(data_position)
+                            .expect("test inverse mapping should succeed")
+                            .expect("test point should be visible")
+                    };
+                    (
+                        screen_at(ViewportPoint::new(0.5, 0.5)),
+                        screen_at(ViewportPoint::new(0.25, 0.25)),
+                        screen_at(ViewportPoint::new(0.75, 0.75)),
+                        view.session
+                            .viewport_snapshot()
+                            .expect("initial viewport should exist")
+                            .visible_bounds,
+                    )
+                })
+            });
+
+            cx.simulate_mouse_down(click_position, MouseButton::Left, Modifiers::default());
+            assert!(clicks.lock().expect("click event lock poisoned").is_empty());
+            cx.simulate_mouse_up(click_position, MouseButton::Left, Modifiers::default());
+            {
+                let clicks = clicks.lock().expect("click event lock poisoned");
+                assert_eq!(clicks.len(), 1);
+                assert_eq!(clicks[0].kind, PlotPointerEventKind::Click);
+                assert_eq!(clicks[0].mouse_button, Some(MouseButton::Left));
+                assert!(matches!(clicks[0].hit, HitResult::SeriesPoint { .. }));
+            }
+            let selected_count = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    view.session
+                        .viewport_snapshot()
+                        .expect("selected viewport should exist")
+                        .selected_count
+                })
+            });
+            assert_eq!(selected_count, 1);
+
+            cx.simulate_mouse_down(drag_start, MouseButton::Right, Modifiers::default());
+            cx.simulate_mouse_move(drag_end, MouseButton::Right, Modifiers::default());
+            cx.simulate_mouse_up(drag_end, MouseButton::Right, Modifiers::default());
+            assert_eq!(clicks.lock().expect("click event lock poisoned").len(), 1);
+            let zoomed_bounds = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    view.session
+                        .viewport_snapshot()
+                        .expect("zoomed viewport should exist")
+                        .visible_bounds
+                })
+            });
+            assert_ne!(zoomed_bounds, initial_bounds);
+            cx.refresh().expect("zoomed frame refresh should succeed");
+            cx.run_until_parked();
+            cx.update(|_, app| {
+                view.update(app, |view, _| {
+                    let layout = view
+                        .last_layout
+                        .clone()
+                        .expect("zoomed layout should remain available");
+                    synchronize_test_frame(
+                        view,
+                        RenderRequest::new(
+                            layout.frame_size_px,
+                            1.0,
+                            0.0,
+                            PresentationMode::Hybrid,
+                        ),
+                    );
+                });
+            });
+
+            cx.simulate_mouse_down(drag_start, MouseButton::Left, Modifiers::default());
+            cx.simulate_mouse_move(drag_end, MouseButton::Left, Modifiers::default());
+            let pan_crossed_threshold = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    matches!(
+                        view.interaction_state.active_drag,
+                        ActiveDrag::LeftPan {
+                            crossed_threshold: true,
+                            ..
+                        }
+                    )
+                })
+            });
+            assert!(pan_crossed_threshold);
+            cx.simulate_mouse_up(drag_end, MouseButton::Left, Modifiers::default());
+            assert_eq!(clicks.lock().expect("click event lock poisoned").len(), 1);
+
+            cx.simulate_mouse_down(drag_start, MouseButton::Left, Modifiers::shift());
+            cx.simulate_mouse_move(drag_end, MouseButton::Left, Modifiers::shift());
+            let brush_crossed_threshold = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    matches!(
+                        view.interaction_state.active_drag,
+                        ActiveDrag::Brush {
+                            crossed_threshold: true,
+                            ..
+                        }
+                    )
+                })
+            });
+            assert!(brush_crossed_threshold);
+            cx.simulate_mouse_up(drag_end, MouseButton::Left, Modifiers::shift());
+            assert_eq!(clicks.lock().expect("click event lock poisoned").len(), 1);
+
+            cx.simulate_mouse_down(click_position, MouseButton::Right, Modifiers::default());
+            cx.simulate_mouse_up(click_position, MouseButton::Right, Modifiers::default());
+            let context_menu_open = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    view.interaction_state.context_menu.is_some()
+                })
+            });
+            assert!(context_menu_open);
+            assert_eq!(clicks.lock().expect("click event lock poisoned").len(), 1);
+
+            cx.simulate_event(MouseDownEvent {
+                button: MouseButton::Left,
+                position: click_position,
+                modifiers: Modifiers::default(),
+                click_count: 2,
+                first_mouse: false,
+            });
+            cx.simulate_event(MouseUpEvent {
+                button: MouseButton::Left,
+                position: click_position,
+                modifiers: Modifiers::default(),
+                click_count: 2,
+            });
+            assert_eq!(clicks.lock().expect("click event lock poisoned").len(), 1);
+        }
+
+        #[test]
+        fn test_full_double_click_sequence_emits_at_most_one_click_to_gpui_subscriber() {
+            let mut app = TestAppContext::single();
+            let (view, cx) = app.add_window_view(|_, cx| {
+                let plot: Plot = Plot::new()
+                    .scatter(&[0.5], &[0.5])
+                    .xlim(0.0, 1.0)
+                    .ylim(0.0, 1.0)
+                    .into();
+                RuvizPlot::from_options_impl(
+                    plot,
+                    RuvizPlotOptions::default(),
+                    None,
+                    PlotPointerEventHandlers::default(),
+                    cx,
+                )
+            });
+            for _ in 0..4 {
+                cx.refresh().expect("rendered frame refresh should succeed");
+                cx.run_until_parked();
+            }
+            cx.update(|_, app| {
+                view.update(app, |view, _| {
+                    let request = view.cached_frame.as_ref().map_or_else(
+                        || {
+                            let layout = view
+                                .last_layout
+                                .as_ref()
+                                .expect("prepaint should resolve test layout");
+                            RenderRequest::new(
+                                layout.frame_size_px,
+                                1.0,
+                                0.0,
+                                PresentationMode::Hybrid,
+                            )
+                        },
+                        |frame| frame.request.clone(),
+                    );
+                    synchronize_test_frame(view, request);
+                });
+            });
+
+            let events = Arc::new(Mutex::new(Vec::new()));
+            let subscriber = cx.update(|_, app| {
+                let events = Arc::clone(&events);
+                app.new(|cx: &mut Context<PointerEventSubscriber>| {
+                    let subscription = cx.subscribe(
+                        &view,
+                        move |subscriber: &mut PointerEventSubscriber,
+                              _,
+                              event: &PlotPointerEvent,
+                              cx| {
+                            subscriber
+                                .events
+                                .lock()
+                                .expect("subscriber event lock poisoned")
+                                .push(event.clone());
+                            cx.notify();
+                        },
+                    );
+                    PointerEventSubscriber {
+                        events,
+                        _subscription: subscription,
+                    }
+                })
+            });
+            cx.run_until_parked();
+
+            let click_position = cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    view.screen_at(ViewportPoint::new(0.5, 0.5))
+                        .expect("click mapping should succeed")
+                        .expect("center should be visible")
+                })
+            });
+            for click_count in [1, 2] {
+                cx.simulate_event(MouseDownEvent {
+                    button: MouseButton::Left,
+                    position: click_position,
+                    modifiers: Modifiers::default(),
+                    click_count,
+                    first_mouse: false,
+                });
+                cx.simulate_event(MouseUpEvent {
+                    button: MouseButton::Left,
+                    position: click_position,
+                    modifiers: Modifiers::default(),
+                    click_count,
+                });
+            }
+            cx.run_until_parked();
+
+            cx.read(|app| {
+                app.read_entity(&subscriber, |subscriber, _| {
+                    let events = subscriber
+                        .events
+                        .lock()
+                        .expect("subscriber event lock poisoned");
+                    assert_eq!(events.len(), 1);
+                    assert_eq!(events[0].kind, PlotPointerEventKind::Click);
+                })
+            });
+        }
+
+        #[test]
+        fn test_pan_threshold_uses_window_pixels_across_presentation_scales() {
+            for (frame_size_px, component_size, scale_factor) in [
+                ((100, 100), 400.0, 2.0),
+                ((800, 800), 200.0, 2.0),
+                ((300, 300), 300.0, 1.5),
+            ] {
+                let component_bounds = Bounds::new(
+                    point(px(20.0), px(30.0)),
+                    size(px(component_size), px(component_size)),
+                );
+                let plot: Plot = Plot::new()
+                    .line(&[0.0, 1.0], &[0.0, 1.0])
+                    .xlim(0.0, 1.0)
+                    .ylim(0.0, 1.0)
+                    .into();
+                let (cx, view) = mapped_test_view(
+                    plot,
+                    RuvizPlotOptions::default(),
+                    frame_size_px,
+                    scale_factor,
+                    component_bounds,
+                );
+
+                let anchor_window = point(
+                    component_bounds.origin.x + component_bounds.size.width * 0.5,
+                    component_bounds.origin.y + component_bounds.size.height * 0.5,
+                );
+                cx.update(|app| {
+                    view.update(app, |view, cx| {
+                        let anchor_px = view
+                            .local_viewport_point(anchor_window)
+                            .expect("anchor should map into the frame");
+                        assert!(!view.session.dirty_domains().data);
+                        view.interaction_state.active_drag = ActiveDrag::LeftPan {
+                            anchor_px,
+                            anchor_window,
+                            last_px: anchor_px,
+                            crossed_threshold: false,
+                            click_eligible: true,
+                        };
+
+                        view.handle_mouse_move(
+                            &MouseMoveEvent {
+                                position: point(anchor_window.x + px(2.0), anchor_window.y),
+                                pressed_button: Some(MouseButton::Left),
+                                modifiers: Modifiers::default(),
+                            },
+                            cx,
+                        )
+                        .expect("sub-threshold move should succeed");
+                        assert!(
+                            !view.session.dirty_domains().data,
+                            "sub-threshold jitter must not pan for frame {frame_size_px:?}"
+                        );
+                        assert!(matches!(
+                            view.interaction_state.active_drag,
+                            ActiveDrag::LeftPan {
+                                last_px,
+                                crossed_threshold: false,
+                                ..
+                            } if last_px == anchor_px
+                        ));
+
+                        view.handle_mouse_move(
+                            &MouseMoveEvent {
+                                position: point(anchor_window.x + px(4.0), anchor_window.y),
+                                pressed_button: Some(MouseButton::Left),
+                                modifiers: Modifiers::default(),
+                            },
+                            cx,
+                        )
+                        .expect("threshold-crossing move should succeed");
+                        assert!(matches!(
+                            view.interaction_state.active_drag,
+                            ActiveDrag::LeftPan {
+                                crossed_threshold: true,
+                                last_px,
+                                ..
+                            } if last_px != anchor_px
+                        ));
+                        assert!(
+                            view.session.dirty_domains().data,
+                            "crossing must apply the accumulated pan for frame {frame_size_px:?}"
+                        );
+                    });
+                });
+            }
+        }
+
+        #[test]
+        fn test_scroll_during_primary_press_cancels_click_eligibility() {
+            let component_bounds =
+                Bounds::new(point(px(10.0), px(10.0)), size(px(400.0), px(300.0)));
+            let plot: Plot = Plot::new()
+                .scatter(&[0.5], &[0.5])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let (cx, view) = mapped_test_view(
+                plot,
+                RuvizPlotOptions::default(),
+                (400, 300),
+                1.0,
+                component_bounds,
+            );
+            let anchor_window = point(px(210.0), px(160.0));
+
+            cx.update(|app| {
+                view.update(app, |view, cx| {
+                    let anchor_px = view
+                        .local_viewport_point(anchor_window)
+                        .expect("anchor should map into the frame");
+                    view.interaction_state.active_drag = ActiveDrag::LeftPan {
+                        anchor_px,
+                        anchor_window,
+                        last_px: anchor_px,
+                        crossed_threshold: false,
+                        click_eligible: true,
+                    };
+                    view.handle_scroll_wheel(
+                        &ScrollWheelEvent {
+                            position: anchor_window,
+                            delta: ScrollDelta::Pixels(point(px(0.0), px(-20.0))),
+                            ..Default::default()
+                        },
+                        cx,
+                    )
+                    .expect("scroll zoom should succeed");
+                    assert!(matches!(
+                        view.interaction_state.active_drag,
+                        ActiveDrag::LeftPan {
+                            click_eligible: false,
+                            ..
+                        }
+                    ));
+
+                    view.handle_left_mouse_up(
+                        &MouseUpEvent {
+                            button: MouseButton::Left,
+                            position: anchor_window,
+                            modifiers: Modifiers::default(),
+                            click_count: 1,
+                        },
+                        cx,
+                    )
+                    .expect("release after scroll should succeed");
+                    assert_eq!(
+                        view.session
+                            .viewport_snapshot()
+                            .expect("viewport should exist")
+                            .selected_count,
+                        0
+                    );
+                });
+            });
+        }
+
+        #[test]
         fn test_right_mouse_up_far_from_anchor_zooms_without_move_events() {
             let mut app = TestAppContext::single();
             let (view, cx) = app.add_window_view(|_, cx| {
                 let plot: Plot = Plot::new()
                     .line(&[0.0, 1.0, 2.0, 3.0], &[0.0, 1.0, 0.5, 1.5])
                     .into();
-                RuvizPlot::from_options_impl(plot, RuvizPlotOptions::default(), None, cx)
+                RuvizPlot::from_options_impl(
+                    plot,
+                    RuvizPlotOptions::default(),
+                    None,
+                    PlotPointerEventHandlers::default(),
+                    cx,
+                )
             });
 
             cx.refresh().expect("window refresh should succeed");
             cx.run_until_parked();
+            cx.update(|_, app| {
+                view.update(app, |view, _| {
+                    let layout = view
+                        .last_layout
+                        .clone()
+                        .expect("plot should have a resolved layout");
+                    synchronize_test_frame(
+                        view,
+                        RenderRequest::new(
+                            layout.frame_size_px,
+                            1.0,
+                            0.0,
+                            PresentationMode::Hybrid,
+                        ),
+                    );
+                });
+            });
 
             let (start, end, initial_bounds) = cx.read(|app| {
                 app.read_entity(&view, |view, _| {
@@ -1706,6 +2930,7 @@ mod platform_impl {
         fn test_active_backend_reports_fallback_for_image_backed_surface_frames() {
             let frame = CachedFrame {
                 request: RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid),
+                base_generation: 0,
                 primary: PrimaryFrame::Image(render_image_from_ruviz(
                     ruviz::core::plot::Image::new(1, 1, vec![0, 0, 0, 255]),
                 )),
@@ -1738,6 +2963,7 @@ mod platform_impl {
                 .expect("surface upload should succeed");
             let frame = CachedFrame {
                 request: RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid),
+                base_generation: 0,
                 primary: PrimaryFrame::Surface(surface),
                 overlay_image: None,
                 stats: FrameStats::default(),

--- a/crates/ruviz-gpui/src/platform_impl/interaction.rs
+++ b/crates/ruviz-gpui/src/platform_impl/interaction.rs
@@ -41,19 +41,29 @@ pub(super) enum ActiveDrag {
     None,
     LeftPan {
         anchor_px: ViewportPoint,
+        anchor_window: Point<Pixels>,
         last_px: ViewportPoint,
         crossed_threshold: bool,
+        click_eligible: bool,
     },
     RightZoom {
         anchor_px: ViewportPoint,
+        anchor_window: Point<Pixels>,
         current_px: ViewportPoint,
         crossed_threshold: bool,
         zoom_enabled: bool,
     },
     Brush {
         anchor_px: ViewportPoint,
+        anchor_window: Point<Pixels>,
         current_px: ViewportPoint,
         crossed_threshold: bool,
+    },
+    PrimaryClick {
+        anchor_px: ViewportPoint,
+        anchor_window: Point<Pixels>,
+        crossed_threshold: bool,
+        click_eligible: bool,
     },
 }
 
@@ -63,6 +73,7 @@ pub(super) struct InteractionState {
     pub(super) active_drag: ActiveDrag,
     pub(super) context_menu: Option<ContextMenuState>,
     pub(super) home_view_bounds: Option<ViewportRect>,
+    pub(super) last_hover_event: Option<PlotPointerEvent>,
 }
 
 impl InteractionState {
@@ -75,6 +86,7 @@ impl InteractionState {
     fn reset_pointer_state(&mut self) {
         self.last_pointer_px = None;
         self.active_drag = ActiveDrag::None;
+        self.last_hover_event = None;
     }
 }
 
@@ -82,13 +94,78 @@ pub(super) fn log_interaction_error(action: &str, err: &PlottingError) {
     eprintln!("ruviz-gpui {action} failed: {err}");
 }
 
-pub(super) fn distance_px(a: ViewportPoint, b: ViewportPoint) -> f64 {
-    let dx = a.x - b.x;
-    let dy = a.y - b.y;
+pub(super) fn window_distance_px(a: Point<Pixels>, b: Point<Pixels>) -> f64 {
+    let dx = f64::from(a.x - b.x);
+    let dy = f64::from(a.y - b.y);
     (dx * dx + dy * dy).sqrt()
 }
 
 impl RuvizPlot {
+    fn pointer_base_generation_is_current(&mut self, cx: &mut Context<Self>) -> bool {
+        let is_current = self.cached_frame.as_ref().is_some_and(|frame| {
+            self.session.displayed_frame_generation() == Some(frame.base_generation)
+        });
+        if !is_current {
+            self.reset_pointer_state();
+            cx.notify();
+        }
+        is_current
+    }
+
+    fn emit_plot_click(
+        &self,
+        window_position: Point<Pixels>,
+        cx: &mut Context<Self>,
+    ) -> Result<()> {
+        let Some(event) = self.build_plot_pointer_event(
+            PlotPointerEventKind::Click,
+            Some(MouseButton::Left),
+            window_position,
+        )?
+        else {
+            return Ok(());
+        };
+        cx.emit(event.clone());
+        if let Some(handler) = self.pointer_event_handlers.click.as_ref() {
+            handler(event);
+        }
+        Ok(())
+    }
+
+    fn emit_plot_hover(
+        &mut self,
+        window_position: Point<Pixels>,
+        mouse_button: Option<MouseButton>,
+        cx: &mut Context<Self>,
+    ) -> Result<()> {
+        let Some(event) = self.build_plot_pointer_event(
+            PlotPointerEventKind::Hover,
+            mouse_button,
+            window_position,
+        )?
+        else {
+            self.interaction_state.last_hover_event = None;
+            return Ok(());
+        };
+        if self.interaction_state.last_hover_event.as_ref() == Some(&event) {
+            return Ok(());
+        }
+        self.interaction_state.last_hover_event = Some(event.clone());
+        cx.emit(event.clone());
+        if let Some(handler) = self.pointer_event_handlers.hover.clone() {
+            handler(event);
+        }
+        Ok(())
+    }
+
+    fn cancel_primary_click(&mut self) {
+        match &mut self.interaction_state.active_drag {
+            ActiveDrag::LeftPan { click_eligible, .. }
+            | ActiveDrag::PrimaryClick { click_eligible, .. } => *click_eligible = false,
+            _ => {}
+        }
+    }
+
     pub(super) fn reset_pointer_state(&mut self) {
         self.interaction_state.reset_pointer_state();
     }
@@ -441,6 +518,7 @@ impl RuvizPlot {
             current_px,
             crossed_threshold,
             zoom_enabled,
+            ..
         } = self.interaction_state.active_drag
         else {
             return None;
@@ -466,6 +544,10 @@ impl RuvizPlot {
     ) -> Result<()> {
         cx.focus_self(window);
 
+        if !self.pointer_base_generation_is_current(cx) {
+            return Ok(());
+        }
+
         if self.interaction_state.context_menu.is_some() {
             return self.handle_context_menu_left_click(event.position, window, cx);
         }
@@ -475,6 +557,7 @@ impl RuvizPlot {
         };
 
         self.interaction_state.last_pointer_px = Some(position_px);
+        self.interaction_state.last_hover_event = None;
         if event.click_count >= 2 {
             self.reset_view(cx);
             return Ok(());
@@ -483,6 +566,7 @@ impl RuvizPlot {
         if event.modifiers.shift && self.options.interaction.selection {
             self.interaction_state.active_drag = ActiveDrag::Brush {
                 anchor_px: position_px,
+                anchor_window: event.position,
                 current_px: position_px,
                 crossed_threshold: false,
             };
@@ -495,11 +579,18 @@ impl RuvizPlot {
         if self.options.interaction.pan {
             self.interaction_state.active_drag = ActiveDrag::LeftPan {
                 anchor_px: position_px,
+                anchor_window: event.position,
                 last_px: position_px,
                 crossed_threshold: false,
+                click_eligible: true,
             };
         } else {
-            self.interaction_state.active_drag = ActiveDrag::None;
+            self.interaction_state.active_drag = ActiveDrag::PrimaryClick {
+                anchor_px: position_px,
+                anchor_window: event.position,
+                crossed_threshold: false,
+                click_eligible: true,
+            };
         }
         cx.notify();
         Ok(())
@@ -512,6 +603,9 @@ impl RuvizPlot {
         cx: &mut Context<Self>,
     ) -> Result<()> {
         cx.focus_self(window);
+        if !self.pointer_base_generation_is_current(cx) {
+            return Ok(());
+        }
         if self.interaction_state.context_menu.is_some() {
             self.close_context_menu(cx);
         }
@@ -520,8 +614,10 @@ impl RuvizPlot {
             return Ok(());
         };
         self.interaction_state.last_pointer_px = Some(position_px);
+        self.interaction_state.last_hover_event = None;
         self.interaction_state.active_drag = ActiveDrag::RightZoom {
             anchor_px: position_px,
+            anchor_window: event.position,
             current_px: position_px,
             crossed_threshold: false,
             zoom_enabled: self.options.interaction.zoom,
@@ -540,6 +636,9 @@ impl RuvizPlot {
             self.update_context_menu_hover(hovered_index, cx);
             return Ok(());
         }
+        if !self.pointer_base_generation_is_current(cx) {
+            return Ok(());
+        }
 
         let position_px = self.local_viewport_point(event.position);
         if let Some(position_px) = position_px {
@@ -548,34 +647,72 @@ impl RuvizPlot {
 
         match (self.interaction_state.active_drag, event.pressed_button) {
             (
+                ActiveDrag::PrimaryClick {
+                    anchor_px,
+                    anchor_window,
+                    crossed_threshold,
+                    click_eligible,
+                },
+                Some(MouseButton::Left),
+            ) => {
+                if position_px.is_none() {
+                    return Ok(());
+                }
+                self.interaction_state.active_drag = ActiveDrag::PrimaryClick {
+                    anchor_px,
+                    anchor_window,
+                    crossed_threshold: crossed_threshold
+                        || window_distance_px(anchor_window, event.position) > DRAG_THRESHOLD_PX,
+                    click_eligible,
+                };
+                return Ok(());
+            }
+            (
                 ActiveDrag::LeftPan {
                     anchor_px,
+                    anchor_window,
                     last_px,
                     crossed_threshold,
+                    click_eligible,
                 },
                 Some(MouseButton::Left),
             ) if self.options.interaction.pan => {
                 let Some(position_px) = position_px else {
                     return Ok(());
                 };
-                let crossed_threshold_now =
-                    crossed_threshold || distance_px(anchor_px, position_px) > DRAG_THRESHOLD_PX;
-                let delta_px =
-                    ViewportPoint::new(position_px.x - last_px.x, position_px.y - last_px.y);
-                if delta_px.x.abs() > f64::EPSILON || delta_px.y.abs() > f64::EPSILON {
-                    self.session.apply_input(PlotInputEvent::Pan { delta_px });
-                    cx.notify();
-                }
+                let crossed_threshold_now = crossed_threshold
+                    || window_distance_px(anchor_window, event.position) > DRAG_THRESHOLD_PX;
+                let next_last_px = if crossed_threshold_now {
+                    let delta_anchor = if crossed_threshold {
+                        last_px
+                    } else {
+                        anchor_px
+                    };
+                    let delta_px = ViewportPoint::new(
+                        position_px.x - delta_anchor.x,
+                        position_px.y - delta_anchor.y,
+                    );
+                    if delta_px.x.abs() > f64::EPSILON || delta_px.y.abs() > f64::EPSILON {
+                        self.session.apply_input(PlotInputEvent::Pan { delta_px });
+                        cx.notify();
+                    }
+                    position_px
+                } else {
+                    last_px
+                };
                 self.interaction_state.active_drag = ActiveDrag::LeftPan {
                     anchor_px,
-                    last_px: position_px,
+                    anchor_window,
+                    last_px: next_last_px,
                     crossed_threshold: crossed_threshold_now,
+                    click_eligible,
                 };
                 return Ok(());
             }
             (
                 ActiveDrag::Brush {
                     anchor_px,
+                    anchor_window,
                     current_px: _,
                     crossed_threshold,
                 },
@@ -584,12 +721,13 @@ impl RuvizPlot {
                 let Some(position_px) = position_px else {
                     return Ok(());
                 };
-                let crossed_threshold_now =
-                    crossed_threshold || distance_px(anchor_px, position_px) > DRAG_THRESHOLD_PX;
+                let crossed_threshold_now = crossed_threshold
+                    || window_distance_px(anchor_window, event.position) > DRAG_THRESHOLD_PX;
                 self.session
                     .apply_input(PlotInputEvent::BrushMove { position_px });
                 self.interaction_state.active_drag = ActiveDrag::Brush {
                     anchor_px,
+                    anchor_window,
                     current_px: position_px,
                     crossed_threshold: crossed_threshold_now,
                 };
@@ -599,6 +737,7 @@ impl RuvizPlot {
             (
                 ActiveDrag::RightZoom {
                     anchor_px,
+                    anchor_window,
                     current_px: _,
                     crossed_threshold,
                     zoom_enabled,
@@ -611,14 +750,15 @@ impl RuvizPlot {
                 } else {
                     position_px.unwrap_or(anchor_px)
                 };
-                let crossed_threshold_now =
-                    crossed_threshold || distance_px(anchor_px, position_px) > DRAG_THRESHOLD_PX;
+                let crossed_threshold_now = crossed_threshold
+                    || window_distance_px(anchor_window, event.position) > DRAG_THRESHOLD_PX;
                 if crossed_threshold_now {
                     self.session.apply_input(PlotInputEvent::ClearHover);
                     self.session.apply_input(PlotInputEvent::HideTooltip);
                 }
                 self.interaction_state.active_drag = ActiveDrag::RightZoom {
                     anchor_px,
+                    anchor_window,
                     current_px: position_px,
                     crossed_threshold: crossed_threshold_now,
                     zoom_enabled,
@@ -646,6 +786,12 @@ impl RuvizPlot {
             None | Some(_) => {}
         }
 
+        if position_px.is_some() {
+            self.emit_plot_hover(event.position, event.pressed_button, cx)?;
+        } else {
+            self.interaction_state.last_hover_event = None;
+        }
+
         Ok(())
     }
 
@@ -654,16 +800,21 @@ impl RuvizPlot {
         event: &MouseUpEvent,
         cx: &mut Context<Self>,
     ) -> Result<()> {
+        if !self.pointer_base_generation_is_current(cx) {
+            return Ok(());
+        }
         let position_px = self
             .local_viewport_point(event.position)
             .or(self.interaction_state.last_pointer_px);
 
+        let mut is_true_click = false;
         match (self.interaction_state.active_drag, position_px) {
             (
                 ActiveDrag::Brush {
                     anchor_px: _,
                     current_px: _,
                     crossed_threshold: _,
+                    ..
                 },
                 Some(position_px),
             ) if self.options.interaction.selection => {
@@ -673,19 +824,52 @@ impl RuvizPlot {
             }
             (
                 ActiveDrag::LeftPan {
-                    anchor_px,
+                    anchor_px: _,
+                    anchor_window,
                     last_px: _,
                     crossed_threshold,
+                    click_eligible,
                 },
                 Some(position_px),
             ) if self.options.interaction.selection && !crossed_threshold => {
-                if distance_px(anchor_px, position_px) <= DRAG_THRESHOLD_PX {
+                if click_eligible
+                    && window_distance_px(anchor_window, event.position) <= DRAG_THRESHOLD_PX
+                {
                     self.session
                         .apply_input(PlotInputEvent::SelectAt { position_px });
                     cx.notify();
+                    is_true_click = true;
                 }
             }
+            (
+                ActiveDrag::LeftPan {
+                    anchor_window,
+                    crossed_threshold,
+                    click_eligible,
+                    ..
+                },
+                Some(_),
+            ) if !crossed_threshold => {
+                is_true_click = click_eligible
+                    && window_distance_px(anchor_window, event.position) <= DRAG_THRESHOLD_PX;
+            }
+            (
+                ActiveDrag::PrimaryClick {
+                    anchor_window,
+                    crossed_threshold,
+                    click_eligible,
+                    ..
+                },
+                Some(_),
+            ) if !crossed_threshold => {
+                is_true_click = click_eligible
+                    && window_distance_px(anchor_window, event.position) <= DRAG_THRESHOLD_PX;
+            }
             _ => {}
+        }
+
+        if is_true_click && event.click_count < 2 {
+            self.emit_plot_click(event.position, cx)?;
         }
 
         self.reset_pointer_state();
@@ -697,6 +881,9 @@ impl RuvizPlot {
         event: &MouseUpEvent,
         cx: &mut Context<Self>,
     ) -> Result<()> {
+        if !self.pointer_base_generation_is_current(cx) {
+            return Ok(());
+        }
         let position_px = self
             .local_viewport_point(event.position)
             .or_else(|| self.clamped_viewport_point(event.position))
@@ -706,19 +893,21 @@ impl RuvizPlot {
             (
                 ActiveDrag::RightZoom {
                     anchor_px,
+                    anchor_window,
                     current_px: _,
                     crossed_threshold,
                     zoom_enabled,
                 },
                 Some(position_px),
             ) => {
-                let crossed_threshold_now =
-                    crossed_threshold || distance_px(anchor_px, position_px) > DRAG_THRESHOLD_PX;
+                let crossed_threshold_now = crossed_threshold
+                    || window_distance_px(anchor_window, event.position) > DRAG_THRESHOLD_PX;
                 if crossed_threshold_now {
                     if zoom_enabled {
                         let region_px = ViewportRect::from_points(anchor_px, position_px);
-                        if region_px.width() > DRAG_THRESHOLD_PX
-                            && region_px.height() > DRAG_THRESHOLD_PX
+                        if f64::from(event.position.x - anchor_window.x).abs() > DRAG_THRESHOLD_PX
+                            && f64::from(event.position.y - anchor_window.y).abs()
+                                > DRAG_THRESHOLD_PX
                         {
                             self.session
                                 .apply_input(PlotInputEvent::ZoomRect { region_px });
@@ -749,12 +938,18 @@ impl RuvizPlot {
             self.update_context_menu_hover(None, cx);
             return;
         }
+        if !self.pointer_base_generation_is_current(cx) {
+            return;
+        }
 
         self.session.apply_input(PlotInputEvent::ClearHover);
         self.session.apply_input(PlotInputEvent::HideTooltip);
         if !matches!(
             self.interaction_state.active_drag,
-            ActiveDrag::RightZoom { .. } | ActiveDrag::LeftPan { .. } | ActiveDrag::Brush { .. }
+            ActiveDrag::RightZoom { .. }
+                | ActiveDrag::LeftPan { .. }
+                | ActiveDrag::Brush { .. }
+                | ActiveDrag::PrimaryClick { .. }
         ) {
             self.reset_pointer_state();
         }
@@ -776,10 +971,14 @@ impl RuvizPlot {
         if !self.options.interaction.zoom || self.interaction_state.context_menu.is_some() {
             return Ok(());
         }
+        if !self.pointer_base_generation_is_current(cx) {
+            return Ok(());
+        }
 
         let Some(center_px) = self.local_viewport_point(event.position) else {
             return Ok(());
         };
+        self.cancel_primary_click();
         let factor = (1.0025f64)
             .powf(-Self::normalize_scroll_delta(event.delta))
             .clamp(0.25, 4.0);

--- a/crates/ruviz-gpui/src/platform_impl/presentation.rs
+++ b/crates/ruviz-gpui/src/platform_impl/presentation.rs
@@ -1,6 +1,83 @@
 use super::*;
 
 impl RuvizPlot {
+    /// Maps an absolute GPUI window position to displayed plot data coordinates.
+    ///
+    /// Returns `Ok(None)` before GPUI layout is available, outside the displayed
+    /// frame, or in a frame margin outside the core plot area. Core displayed-frame
+    /// conversion errors are returned unchanged.
+    pub fn data_at(&self, window_position: Point<Pixels>) -> Result<Option<ViewportPoint>> {
+        let Some(base_generation) = self.presented_base_generation() else {
+            return Ok(None);
+        };
+        let Some(viewport_position) = self.local_viewport_point(window_position) else {
+            return Ok(None);
+        };
+        let data_position = self.session.screen_to_data(viewport_position)?;
+        if !self.is_base_generation_presented(base_generation) {
+            return Ok(None);
+        }
+        Ok(data_position)
+    }
+
+    /// Maps displayed plot data coordinates to an absolute GPUI window position.
+    ///
+    /// Returns `Ok(None)` before GPUI layout is available or when the data point is
+    /// outside the displayed visible bounds. Core displayed-frame conversion errors
+    /// are returned unchanged.
+    pub fn screen_at(&self, data_position: ViewportPoint) -> Result<Option<Point<Pixels>>> {
+        let Some(base_generation) = self.presented_base_generation() else {
+            return Ok(None);
+        };
+        let viewport_position = self.session.data_to_screen(data_position)?;
+        if !self.is_base_generation_presented(base_generation) {
+            return Ok(None);
+        }
+        Ok(viewport_position.and_then(|position| self.viewport_point_to_window_position(position)))
+    }
+
+    pub(super) fn build_plot_pointer_event(
+        &self,
+        kind: PlotPointerEventKind,
+        mouse_button: Option<MouseButton>,
+        window_position: Point<Pixels>,
+    ) -> Result<Option<PlotPointerEvent>> {
+        let Some(base_generation) = self.presented_base_generation() else {
+            return Ok(None);
+        };
+        let Some(viewport_position) = self.local_viewport_point(window_position) else {
+            return Ok(None);
+        };
+        let data_position = self.session.screen_to_data(viewport_position)?;
+        let viewport = self.session.viewport_snapshot()?;
+        let hit = self.session.hit_test(viewport_position);
+        if !self.is_base_generation_presented(base_generation) {
+            return Ok(None);
+        }
+        Ok(Some(PlotPointerEvent {
+            kind,
+            mouse_button,
+            window_position,
+            viewport_position,
+            data_position,
+            viewport,
+            hit,
+        }))
+    }
+
+    fn presented_base_generation(&self) -> Option<u64> {
+        let generation = self.cached_frame.as_ref()?.base_generation;
+        self.is_base_generation_presented(generation)
+            .then_some(generation)
+    }
+
+    fn is_base_generation_presented(&self, generation: u64) -> bool {
+        self.cached_frame
+            .as_ref()
+            .is_some_and(|frame| frame.base_generation == generation)
+            && self.session.displayed_frame_generation() == Some(generation)
+    }
+
     pub(super) fn retire_cached_frame(&mut self) {
         if let Some(frame) = self.cached_frame.take() {
             retire_primary_frame(&mut self.retired_images, frame.primary);
@@ -10,7 +87,12 @@ impl RuvizPlot {
         }
     }
 
-    fn replace_cached_frame(&mut self, request: RenderRequest, mut frame: RenderedFrame) {
+    pub(super) fn replace_cached_frame(
+        &mut self,
+        mut request: RenderRequest,
+        mut frame: RenderedFrame,
+    ) {
+        request.presented_base_generation = Some(frame.base_generation);
         let previous = self.cached_frame.take();
         let primary = self
             .resolve_primary_frame(previous.as_ref(), &mut frame)
@@ -18,11 +100,12 @@ impl RuvizPlot {
         let overlay_image = if frame.target == RenderTargetKind::Image {
             None
         } else {
-            frame.overlay_image.or_else(|| {
-                previous
+            match frame.overlay {
+                RenderedOverlay::Reuse => previous
                     .as_ref()
-                    .and_then(|cached| cached.overlay_image.as_ref().map(Arc::clone))
-            })
+                    .and_then(|cached| cached.overlay_image.as_ref().map(Arc::clone)),
+                RenderedOverlay::Replace(overlay) => overlay,
+            }
         };
 
         if let Some(previous) = previous {
@@ -39,6 +122,7 @@ impl RuvizPlot {
 
         self.cached_frame = Some(CachedFrame {
             request,
+            base_generation: frame.base_generation,
             primary,
             overlay_image,
             stats: frame.stats,
@@ -129,12 +213,19 @@ impl RuvizPlot {
             scale_factor,
         )?;
 
-        Some(RenderRequest::new(
-            frame_size_px,
-            scale_factor,
-            self.options.interaction.time_seconds,
-            self.effective_presentation_mode(),
-        ))
+        Some(
+            RenderRequest::new(
+                frame_size_px,
+                scale_factor,
+                self.options.interaction.time_seconds,
+                self.effective_presentation_mode(),
+            )
+            .with_presented_base_generation(
+                self.cached_frame
+                    .as_ref()
+                    .map(|frame| frame.base_generation),
+            ),
+        )
     }
 
     pub(super) fn prepaint(
@@ -147,8 +238,13 @@ impl RuvizPlot {
         self.flush_retired_images(Some(window), cx);
 
         if let Some(request) = self.current_request(bounds, window) {
-            self.update_layout(bounds, request.size_px);
+            let requested_size_px = request.size_px;
             self.start_render_if_needed(entity, request, window, cx);
+            let frame_size_px = self
+                .cached_frame
+                .as_ref()
+                .map_or(requested_size_px, |frame| frame.request.size_px);
+            self.update_layout_state(bounds, frame_size_px);
         } else {
             self.last_layout = None;
         }
@@ -159,7 +255,12 @@ impl RuvizPlot {
         })
     }
 
-    fn update_layout(&mut self, bounds: Bounds<Pixels>, frame_size_px: (u32, u32)) {
+    #[cfg(test)]
+    pub(super) fn update_layout(&mut self, bounds: Bounds<Pixels>, frame_size_px: (u32, u32)) {
+        self.update_layout_state(bounds, frame_size_px);
+    }
+
+    fn update_layout_state(&mut self, bounds: Bounds<Pixels>, frame_size_px: (u32, u32)) {
         let image_size = size(frame_size_px.0.into(), frame_size_px.1.into());
         let content_bounds = self
             .options
@@ -182,11 +283,7 @@ impl RuvizPlot {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let cache_is_current = self
-            .cached_frame
-            .as_ref()
-            .is_some_and(|frame| frame.request == request && !request.is_dirty(&self.session));
-        if cache_is_current {
+        if self.cache_is_current(&request) {
             return;
         }
 
@@ -195,6 +292,14 @@ impl RuvizPlot {
         };
 
         self.start_render(entity, scheduled, window, cx);
+    }
+
+    pub(super) fn cache_is_current(&self, request: &RenderRequest) -> bool {
+        self.cached_frame.as_ref().is_some_and(|frame| {
+            frame.request == *request
+                && self.session.displayed_frame_generation() == Some(frame.base_generation)
+                && !request.is_dirty(&self.session)
+        })
     }
 
     fn start_render(
@@ -764,20 +869,20 @@ fn rgb_to_ycbcr_full_range(r: u8, g: u8, b: u8) -> (u8, u8, u8) {
     (y, cb, cr)
 }
 
-fn render_frame_from_session(
+pub(super) fn render_frame_from_session(
     session: InteractivePlotSession,
     request: RenderRequest,
 ) -> std::result::Result<RenderedFrame, String> {
-    let frame = match request.presentation_mode {
+    let result = match request.presentation_mode {
         PresentationMode::Image => session
-            .render_to_image(ImageTarget {
+            .render_to_image_with_generation(ImageTarget {
                 size_px: request.size_px,
                 scale_factor: request.scale_factor(),
                 time_seconds: request.time_seconds(),
             })
             .map_err(|err| err.to_string())?,
         PresentationMode::Hybrid => session
-            .render_to_surface(SurfaceTarget {
+            .render_to_surface_with_generation(SurfaceTarget {
                 size_px: request.size_px,
                 scale_factor: request.scale_factor(),
                 time_seconds: request.time_seconds(),
@@ -785,7 +890,7 @@ fn render_frame_from_session(
             .map_err(|err| err.to_string())?,
         #[allow(deprecated)]
         PresentationMode::SurfaceExperimental => session
-            .render_to_surface(SurfaceTarget {
+            .render_to_surface_with_generation(SurfaceTarget {
                 size_px: request.size_px,
                 scale_factor: request.scale_factor(),
                 time_seconds: request.time_seconds(),
@@ -793,19 +898,22 @@ fn render_frame_from_session(
             .map_err(|err| err.to_string())?,
     };
 
+    let base_generation = result.base_generation;
+    let frame = result.frame;
     let layer_state = frame.layer_state;
+    let generation_changed = request.presented_base_generation != Some(base_generation);
+    let include_base = layer_state.base_dirty || generation_changed;
     let use_surface_primary = should_use_surface_primary(
         request.presentation_mode,
         frame.target,
         frame.surface_capability,
     );
     Ok(RenderedFrame {
+        base_generation,
         primary: if use_surface_primary {
             #[cfg(all(feature = "gpu", target_os = "macos"))]
             {
-                layer_state
-                    .base_dirty
-                    .then(|| RenderedPrimary::Surface(Arc::clone(&frame.layers.base)))
+                include_base.then(|| RenderedPrimary::Surface(Arc::clone(&frame.layers.base)))
             }
             #[cfg(not(all(feature = "gpu", target_os = "macos")))]
             {
@@ -816,27 +924,31 @@ fn render_frame_from_session(
                 PresentationMode::Image => Some(RenderedPrimary::Image(render_image_from_ruviz(
                     frame.image.as_ref().clone(),
                 ))),
-                PresentationMode::Hybrid => layer_state.base_dirty.then(|| {
+                PresentationMode::Hybrid => include_base.then(|| {
                     RenderedPrimary::Image(render_image_from_ruviz(
                         frame.layers.base.as_ref().clone(),
                     ))
                 }),
                 #[allow(deprecated)]
-                PresentationMode::SurfaceExperimental => layer_state.base_dirty.then(|| {
+                PresentationMode::SurfaceExperimental => include_base.then(|| {
                     RenderedPrimary::Image(render_image_from_ruviz(
                         frame.layers.base.as_ref().clone(),
                     ))
                 }),
             }
         },
-        overlay_image: if matches!(request.presentation_mode, PresentationMode::Image) {
-            None
+        overlay: if matches!(request.presentation_mode, PresentationMode::Image) {
+            RenderedOverlay::Replace(None)
+        } else if layer_state.overlay_dirty || generation_changed {
+            RenderedOverlay::Replace(
+                frame
+                    .layers
+                    .overlay
+                    .as_ref()
+                    .map(|overlay| render_image_from_ruviz(overlay.as_ref().clone())),
+            )
         } else {
-            frame.layers.overlay.as_ref().and_then(|overlay| {
-                layer_state
-                    .overlay_dirty
-                    .then(|| render_image_from_ruviz(overlay.as_ref().clone()))
-            })
+            RenderedOverlay::Reuse
         },
         stats: frame.stats,
         target: frame.target,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -41,11 +41,11 @@ pub use legend::{
 pub use plot::{
     BackendFallbackReason, BackendOperation, BackendResolution, BackendType, DirtyDomain,
     DirtyDomains, FramePacing, FrameStats, HitResult, Image, ImageTarget, InsetAnchor, InsetLayout,
-    InteractiveFrame, InteractivePlotSession, InteractiveViewportSnapshot, IntoPlot,
-    LayerRenderState, Plot, PlotBuilder, PlotInput, PlotInputEvent, PlotSource, PreparedPlot,
-    QualityPolicy, ReactiveSubscription, ReactiveValue, RenderTargetKind, SeriesStyle,
-    SurfaceCapability, SurfaceTarget, TextEngineMode, TickDirection, TickSides, ViewportPoint,
-    ViewportRect,
+    InteractiveFrame, InteractiveFrameWithGeneration, InteractivePlotSession,
+    InteractiveViewportSnapshot, IntoPlot, LayerRenderState, Plot, PlotBuilder, PlotInput,
+    PlotInputEvent, PlotSource, PreparedPlot, QualityPolicy, ReactiveSubscription, ReactiveValue,
+    RenderTargetKind, SeriesStyle, SurfaceCapability, SurfaceTarget, TextEngineMode, TickDirection,
+    TickSides, ViewportPoint, ViewportRect,
 };
 pub use position::Position;
 pub use style::PlotStyle;

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -281,6 +281,15 @@ pub struct InteractiveFrame {
     pub surface_capability: SurfaceCapability,
 }
 
+/// Render result used by presentation integrations that must associate an image
+/// with the exact interactive geometry generation that produced it.
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub struct InteractiveFrameWithGeneration {
+    pub frame: InteractiveFrame,
+    pub base_generation: u64,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct ImageTarget {
     pub size_px: (u32, u32),
@@ -374,8 +383,33 @@ struct InteractivePlotSessionInner {
     state: Mutex<SessionState>,
     dirty: Arc<Mutex<DirtyDomains>>,
     dirty_epoch: Arc<AtomicU64>,
+    mutation_epoch: Arc<AtomicU64>,
     stats: Mutex<FrameStats>,
     reactive_epoch: Arc<AtomicU64>,
+    #[cfg(test)]
+    render_test_hook: Mutex<Option<RenderTestHook>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RenderEpoch {
+    mutation: u64,
+    dirty: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RenderTestPoint {
+    BeforeDirtyMark,
+    AfterBasePublication,
+    BeforeOverlayRefreshCommit,
+    BeforeFinalCommit,
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug)]
+struct RenderTestHook {
+    point: RenderTestPoint,
+    entered: Arc<std::sync::Barrier>,
+    release: Arc<std::sync::Barrier>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
@@ -448,6 +482,7 @@ struct SessionState {
     brushed_region: Option<ViewportRect>,
     tooltip: Option<TooltipState>,
     tooltip_source: Option<TooltipSource>,
+    base_generation: u64,
     base_cache: Option<InteractiveFrameCache>,
     overlay_cache: Option<OverlayFrameCache>,
     geometry: Option<GeometrySnapshot>,
@@ -471,11 +506,24 @@ impl Default for SessionState {
             brushed_region: None,
             tooltip: None,
             tooltip_source: None,
+            base_generation: 0,
             base_cache: None,
             overlay_cache: None,
             geometry: None,
             last_reactive_epoch: 0,
         }
+    }
+}
+
+impl SessionState {
+    fn publish_base_cache(&mut self, mut cache: InteractiveFrameCache) -> Result<u64> {
+        let generation = self.base_generation.checked_add(1).ok_or_else(|| {
+            PlottingError::RenderError("interactive base frame generation exhausted".to_string())
+        })?;
+        cache.generation = generation;
+        self.base_cache = Some(cache);
+        self.base_generation = generation;
+        Ok(generation)
     }
 }
 
@@ -831,6 +879,7 @@ fn inclusive_cell_count(min: i64, max: i64) -> Option<u64> {
 
 #[derive(Clone, Debug)]
 struct InteractiveFrameCache {
+    generation: u64,
     key: InteractiveFrameKey,
     image: Arc<Image>,
     geometry: GeometrySnapshot,
@@ -1030,6 +1079,7 @@ impl AxisConstraints {
 #[derive(Clone, Debug)]
 struct BaseLayerResult {
     image: Arc<Image>,
+    generation: u64,
     updated: bool,
     used_incremental_data: bool,
 }
@@ -1085,16 +1135,19 @@ impl InteractivePlotSession {
         let initial_bounds = AxisConstraints::from_plot(prepared.plot()).apply(initial_data_bounds);
         let dirty = Arc::new(Mutex::new(DirtyDomains::with_all()));
         let dirty_epoch = Arc::new(AtomicU64::new(0));
+        let mutation_epoch = Arc::new(AtomicU64::new(0));
         let reactive_epoch = Arc::new(AtomicU64::new(0));
         let dirty_for_callback = Arc::clone(&dirty);
         let dirty_epoch_for_callback = Arc::clone(&dirty_epoch);
+        let mutation_epoch_for_callback = Arc::clone(&mutation_epoch);
         let epoch_for_callback = Arc::clone(&reactive_epoch);
         let reactive_subscription = prepared.subscribe_reactive(move || {
+            mutation_epoch_for_callback.fetch_add(1, Ordering::AcqRel);
             if let Ok(mut domains) = dirty_for_callback.lock() {
+                dirty_epoch_for_callback.fetch_add(1, Ordering::AcqRel);
                 domains.mark(DirtyDomain::Data);
                 domains.mark(DirtyDomain::Overlay);
             }
-            dirty_epoch_for_callback.fetch_add(1, Ordering::AcqRel);
             epoch_for_callback.fetch_add(1, Ordering::AcqRel);
         });
 
@@ -1121,8 +1174,11 @@ impl InteractivePlotSession {
                 state: Mutex::new(state),
                 dirty,
                 dirty_epoch,
+                mutation_epoch,
                 stats: Mutex::new(FrameStats::default()),
                 reactive_epoch,
+                #[cfg(test)]
+                render_test_hook: Mutex::new(None),
             }),
         }
     }
@@ -1146,25 +1202,41 @@ impl InteractivePlotSession {
             .clone()
     }
 
+    /// Returns the generation of the base image and geometry currently used for interaction.
+    ///
+    /// The generation changes whenever a newly rendered base frame is published and is `None`
+    /// until a base frame is available. Presentation layers can retain the generation returned
+    /// by [`InteractiveFrameWithGeneration`] and reject coordinate queries while it differs from
+    /// this value.
+    pub fn displayed_frame_generation(&self) -> Option<u64> {
+        self.inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned")
+            .base_cache
+            .as_ref()
+            .map(|cache| cache.generation)
+    }
+
     /// Drop cached geometry and layer images so the next frame rebuilds them.
     pub fn invalidate(&self) {
+        self.begin_mutation();
         self.inner.prepared.invalidate();
-        {
-            let mut state = self
-                .inner
-                .state
-                .lock()
-                .expect("InteractivePlotSession state lock poisoned");
-            state.base_cache = None;
-            state.overlay_cache = None;
-            state.geometry = None;
-        }
-        self.inner.dirty_epoch.fetch_add(1, Ordering::AcqRel);
-        *self
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned");
+        let mut dirty = self
             .inner
             .dirty
             .lock()
-            .expect("InteractivePlotSession dirty lock poisoned") = DirtyDomains::with_all();
+            .expect("InteractivePlotSession dirty lock poisoned");
+        self.inner.dirty_epoch.fetch_add(1, Ordering::AcqRel);
+        state.base_cache = None;
+        state.overlay_cache = None;
+        state.geometry = None;
+        *dirty = DirtyDomains::with_all();
     }
 
     pub fn frame_pacing(&self) -> FramePacing {
@@ -1193,6 +1265,7 @@ impl InteractivePlotSession {
     }
 
     pub fn set_quality_policy(&self, quality: QualityPolicy) {
+        self.begin_mutation();
         *self
             .inner
             .quality_policy
@@ -1210,6 +1283,7 @@ impl InteractivePlotSession {
     }
 
     pub fn set_prefer_gpu(&self, prefer_gpu: bool) {
+        self.begin_mutation();
         *self
             .inner
             .prefer_gpu
@@ -1231,6 +1305,7 @@ impl InteractivePlotSession {
             .state
             .lock()
             .expect("InteractivePlotSession state lock poisoned");
+        self.begin_mutation();
         let changed = Self::update_resize_state(&mut state, size_px, scale_factor);
         drop(state);
         if changed {
@@ -1244,6 +1319,7 @@ impl InteractivePlotSession {
             .state
             .lock()
             .expect("InteractivePlotSession state lock poisoned");
+        self.begin_mutation();
 
         match event {
             PlotInputEvent::Resize {
@@ -1290,6 +1366,7 @@ impl InteractivePlotSession {
                     .state
                     .lock()
                     .expect("InteractivePlotSession state lock poisoned");
+                self.begin_mutation();
                 set_visible_bounds(
                     &mut state,
                     next_visible,
@@ -1333,6 +1410,7 @@ impl InteractivePlotSession {
                     .state
                     .lock()
                     .expect("InteractivePlotSession state lock poisoned");
+                self.begin_mutation();
                 let viewport_changed = !bounds_close(state.visible_bounds, next_visible);
                 state.brush_anchor = None;
                 state.brushed_region = None;
@@ -1366,6 +1444,7 @@ impl InteractivePlotSession {
                     .state
                     .lock()
                     .expect("InteractivePlotSession state lock poisoned");
+                self.begin_mutation();
                 set_visible_bounds(
                     &mut state,
                     next_visible,
@@ -1384,6 +1463,7 @@ impl InteractivePlotSession {
                     .state
                     .lock()
                     .expect("InteractivePlotSession state lock poisoned");
+                self.begin_mutation();
                 let next_hovered = match hit {
                     HitResult::None => None,
                     other => Some(other),
@@ -1434,6 +1514,7 @@ impl InteractivePlotSession {
                     .state
                     .lock()
                     .expect("InteractivePlotSession state lock poisoned");
+                self.begin_mutation();
                 state.selected.clear();
                 if !matches!(hit, HitResult::None) {
                     state.selected.push(hit);
@@ -1644,6 +1725,15 @@ impl InteractivePlotSession {
     }
 
     pub fn render_to_image(&self, target: ImageTarget) -> Result<InteractiveFrame> {
+        self.render_to_image_with_generation(target)
+            .map(|result| result.frame)
+    }
+
+    #[doc(hidden)]
+    pub fn render_to_image_with_generation(
+        &self,
+        target: ImageTarget,
+    ) -> Result<InteractiveFrameWithGeneration> {
         self.render_to_target(
             RenderTargetKind::Image,
             target.size_px,
@@ -1653,6 +1743,15 @@ impl InteractivePlotSession {
     }
 
     pub fn render_to_surface(&self, target: SurfaceTarget) -> Result<InteractiveFrame> {
+        self.render_to_surface_with_generation(target)
+            .map(|result| result.frame)
+    }
+
+    #[doc(hidden)]
+    pub fn render_to_surface_with_generation(
+        &self,
+        target: SurfaceTarget,
+    ) -> Result<InteractiveFrameWithGeneration> {
         self.render_to_target(
             RenderTargetKind::Surface,
             target.size_px,
@@ -1667,6 +1766,27 @@ impl InteractivePlotSession {
             .dirty
             .lock()
             .expect("InteractivePlotSession dirty lock poisoned")
+    }
+
+    fn render_snapshot(&self) -> (SessionState, DirtyDomains, RenderEpoch) {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned");
+        let dirty = self
+            .inner
+            .dirty
+            .lock()
+            .expect("InteractivePlotSession dirty lock poisoned");
+        (
+            state.clone(),
+            *dirty,
+            RenderEpoch {
+                mutation: self.inner.mutation_epoch.load(Ordering::Acquire),
+                dirty: self.inner.dirty_epoch.load(Ordering::Acquire),
+            },
+        )
     }
 
     /// Returns the current interactive viewport state.
@@ -1730,6 +1850,7 @@ impl InteractivePlotSession {
             .state
             .lock()
             .expect("InteractivePlotSession state lock poisoned");
+        self.begin_mutation();
         let next_visible = normalize_visible_bounds(
             next_visible,
             state.base_bounds,
@@ -1758,7 +1879,7 @@ impl InteractivePlotSession {
         size_px: (u32, u32),
         scale_factor: f32,
         time_seconds: f64,
-    ) -> Result<InteractiveFrame> {
+    ) -> Result<InteractiveFrameWithGeneration> {
         let _active_render = ActiveRenderGuard::enter(Arc::as_ptr(&self.inner) as usize)?;
         let _render_guard = self
             .inner
@@ -1769,13 +1890,9 @@ impl InteractivePlotSession {
         self.resize(size_px, scale_factor);
         self.apply_input(PlotInputEvent::SetTime { time_seconds });
 
-        let state_before_render = self
-            .inner
-            .state
-            .lock()
-            .expect("InteractivePlotSession state lock poisoned")
-            .clone();
-        let render_result = (|| -> Result<InteractiveFrame> {
+        let mut state_before_render = None;
+        let mut render_epoch = None;
+        let render_result = (|| -> Result<InteractiveFrameWithGeneration> {
             let reactive_epoch = self.inner.reactive_epoch.load(Ordering::Acquire);
             let mut mark_data_dirty = false;
             {
@@ -1794,8 +1911,9 @@ impl InteractivePlotSession {
                 self.mark_dirty(DirtyDomain::Overlay);
             }
 
-            let dirty_before_render = self.dirty_domains();
-            let dirty_epoch_before_render = self.inner.dirty_epoch.load(Ordering::Acquire);
+            let (state_snapshot, dirty_before_render, epoch_before_render) = self.render_snapshot();
+            state_before_render = Some(state_snapshot);
+            render_epoch = Some(epoch_before_render);
             let source_plot = self.inner.prepared.plot();
             let resolved_frame = dirty_before_render
                 .needs_base_render()
@@ -1859,9 +1977,11 @@ impl InteractivePlotSession {
                 &base_key,
                 &geometry,
                 dirty_before_render,
+                epoch_before_render,
                 resolved_frame.as_ref(),
             )?;
-            self.refresh_overlay_state(dirty_before_render)?;
+            self.run_render_test_hook(RenderTestPoint::AfterBasePublication);
+            self.refresh_overlay_state(dirty_before_render, epoch_before_render)?;
             let overlay_result = self.ensure_overlay_image(frame_size_px, dirty_before_render)?;
             let composed = if target == RenderTargetKind::Image {
                 if let Some(overlay_image) = overlay_result.image.as_ref() {
@@ -1873,12 +1993,13 @@ impl InteractivePlotSession {
                 Arc::clone(&base_result.image)
             };
 
+            self.run_render_test_hook(RenderTestPoint::BeforeFinalCommit);
+            self.commit_frame_if_current(epoch_before_render, base_result.generation)?;
             if base_result.updated {
                 if let Some(frame) = resolved_frame.as_ref() {
                     frame.acknowledge_rendered(source_plot);
                 }
             }
-            self.clear_dirty_after_render(dirty_epoch_before_render);
 
             let surface_capability = if target == RenderTargetKind::Surface {
                 if base_result.used_incremental_data
@@ -1896,30 +2017,32 @@ impl InteractivePlotSession {
                 target,
                 surface_capability,
             );
-
-            Ok(InteractiveFrame {
-                image: composed,
-                layers: LayerImages {
-                    base: base_result.image,
-                    overlay: overlay_result.image,
+            Ok(InteractiveFrameWithGeneration {
+                base_generation: base_result.generation,
+                frame: InteractiveFrame {
+                    image: composed,
+                    layers: LayerImages {
+                        base: base_result.image,
+                        overlay: overlay_result.image,
+                    },
+                    layer_state: LayerRenderState {
+                        base_dirty: base_result.updated,
+                        overlay_dirty: overlay_result.updated,
+                        used_incremental_data: base_result.used_incremental_data,
+                    },
+                    stats,
+                    target,
+                    surface_capability,
                 },
-                layer_state: LayerRenderState {
-                    base_dirty: base_result.updated,
-                    overlay_dirty: overlay_result.updated,
-                    used_incremental_data: base_result.used_incremental_data,
-                },
-                stats,
-                target,
-                surface_capability,
             })
         })();
 
         if render_result.is_err() {
-            *self
-                .inner
-                .state
-                .lock()
-                .expect("InteractivePlotSession state lock poisoned") = state_before_render;
+            if let (Some(previous), Some(epoch)) = (state_before_render, render_epoch) {
+                if !self.restore_state_if_epoch(previous, epoch) {
+                    return Err(render_superseded_error());
+                }
+            }
         }
         render_result
     }
@@ -1970,6 +2093,7 @@ impl InteractivePlotSession {
         key: &InteractiveFrameKey,
         geometry: &GeometrySnapshot,
         dirty_before_render: DirtyDomains,
+        epoch_before_render: RenderEpoch,
         frame: Option<&ResolvedFrame<'_>>,
     ) -> Result<BaseLayerResult> {
         {
@@ -1988,6 +2112,7 @@ impl InteractivePlotSession {
                     if cached.key == *key {
                         return Ok(BaseLayerResult {
                             image: Arc::clone(&cached.image),
+                            generation: cached.generation,
                             updated: false,
                             used_incremental_data: false,
                         });
@@ -2001,9 +2126,12 @@ impl InteractivePlotSession {
             && !dirty_before_render.temporal
             && !dirty_before_render.interaction
         {
-            if let Some(incremental) =
-                self.try_incremental_stream_render(key, geometry, frame.expect("dirty base frame"))?
-            {
+            if let Some(incremental) = self.try_incremental_stream_render(
+                key,
+                geometry,
+                frame.ok_or_else(render_superseded_error)?,
+                epoch_before_render,
+            )? {
                 return Ok(incremental);
             }
         }
@@ -2015,7 +2143,7 @@ impl InteractivePlotSession {
             .expect("InteractivePlotSession state lock poisoned")
             .clone();
         let source_plot = self.inner.prepared.plot();
-        let frame = frame.expect("dirty base render must resolve a frame");
+        let frame = frame.ok_or_else(render_superseded_error)?;
         let mut plot = source_plot
             .prepared_frame_shell_with_style(state.size_px, state.scale_factor, &frame.style)
             .xlim(geometry.x_bounds.0, geometry.x_bounds.1)
@@ -2032,20 +2160,20 @@ impl InteractivePlotSession {
         let displayed_data = DisplayedFrameData::capture(source_plot, frame);
         let point_hit_index = Arc::new(OnceLock::new());
 
-        let mut state = self
-            .inner
-            .state
-            .lock()
-            .expect("InteractivePlotSession state lock poisoned");
-        state.base_cache = Some(InteractiveFrameCache {
-            key: key.clone(),
-            image: Arc::clone(&image),
-            geometry: geometry.clone(),
-            displayed_data,
-            point_hit_index,
-        });
+        let generation = self.publish_base_cache_if_epoch(
+            InteractiveFrameCache {
+                generation: 0,
+                key: key.clone(),
+                image: Arc::clone(&image),
+                geometry: geometry.clone(),
+                displayed_data,
+                point_hit_index,
+            },
+            epoch_before_render,
+        )?;
         Ok(BaseLayerResult {
             image,
+            generation,
             updated: true,
             used_incremental_data: false,
         })
@@ -2172,7 +2300,11 @@ impl InteractivePlotSession {
         })
     }
 
-    fn refresh_overlay_state(&self, dirty_before_render: DirtyDomains) -> Result<()> {
+    fn refresh_overlay_state(
+        &self,
+        dirty_before_render: DirtyDomains,
+        expected_epoch: RenderEpoch,
+    ) -> Result<()> {
         if !dirty_before_render.layout && !dirty_before_render.data && !dirty_before_render.temporal
         {
             return Ok(());
@@ -2220,11 +2352,20 @@ impl InteractivePlotSession {
                 )
             };
 
+        self.run_render_test_hook(RenderTestPoint::BeforeOverlayRefreshCommit);
         let mut state = self
             .inner
             .state
             .lock()
             .expect("InteractivePlotSession state lock poisoned");
+        let _dirty = self
+            .inner
+            .dirty
+            .lock()
+            .expect("InteractivePlotSession dirty lock poisoned");
+        if !self.epochs_match(expected_epoch) {
+            return Err(render_superseded_error());
+        }
         state.hovered = refreshed_hovered;
         state.selected = refreshed_selected;
         state.tooltip = refreshed_tooltip;
@@ -2267,13 +2408,85 @@ impl InteractivePlotSession {
             .ok_or_else(displayed_geometry_unavailable)
     }
 
-    fn mark_dirty(&self, domain: DirtyDomain) {
-        self.inner.dirty_epoch.fetch_add(1, Ordering::AcqRel);
-        self.inner
+    fn publish_base_cache_if_epoch(
+        &self,
+        cache: InteractiveFrameCache,
+        expected_epoch: RenderEpoch,
+    ) -> Result<u64> {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned");
+        let _dirty = self
+            .inner
             .dirty
             .lock()
-            .expect("InteractivePlotSession dirty lock poisoned")
-            .mark(domain);
+            .expect("InteractivePlotSession dirty lock poisoned");
+        if !self.epochs_match(expected_epoch) {
+            return Err(render_superseded_error());
+        }
+        state.publish_base_cache(cache)
+    }
+
+    fn restore_state_if_epoch(&self, previous: SessionState, expected_epoch: RenderEpoch) -> bool {
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned");
+        let _dirty = self
+            .inner
+            .dirty
+            .lock()
+            .expect("InteractivePlotSession dirty lock poisoned");
+        if self.epochs_match(expected_epoch) {
+            *state = previous;
+            true
+        } else {
+            false
+        }
+    }
+
+    fn begin_mutation(&self) {
+        self.inner.mutation_epoch.fetch_add(1, Ordering::AcqRel);
+    }
+
+    fn epochs_match(&self, expected: RenderEpoch) -> bool {
+        self.inner.mutation_epoch.load(Ordering::Acquire) == expected.mutation
+            && self.inner.dirty_epoch.load(Ordering::Acquire) == expected.dirty
+    }
+
+    #[cfg(test)]
+    fn run_render_test_hook(&self, point: RenderTestPoint) {
+        let hook = {
+            let mut slot = self
+                .inner
+                .render_test_hook
+                .lock()
+                .expect("InteractivePlotSession render test hook lock poisoned");
+            (slot.as_ref().is_some_and(|hook| hook.point == point))
+                .then(|| slot.take())
+                .flatten()
+        };
+        if let Some(hook) = hook {
+            hook.entered.wait();
+            hook.release.wait();
+        }
+    }
+
+    #[cfg(not(test))]
+    fn run_render_test_hook(&self, _point: RenderTestPoint) {}
+
+    fn mark_dirty(&self, domain: DirtyDomain) {
+        self.run_render_test_hook(RenderTestPoint::BeforeDirtyMark);
+        let mut dirty = self
+            .inner
+            .dirty
+            .lock()
+            .expect("InteractivePlotSession dirty lock poisoned");
+        self.inner.dirty_epoch.fetch_add(1, Ordering::AcqRel);
+        dirty.mark(domain);
     }
 
     fn update_resize_state(
@@ -2296,21 +2509,25 @@ impl InteractivePlotSession {
         size_changed || scale_changed
     }
 
-    fn clear_dirty_after_render(&self, dirty_epoch_before_render: u64) {
-        if self.inner.dirty_epoch.load(Ordering::Acquire) != dirty_epoch_before_render {
-            return;
-        }
-
+    fn commit_frame_if_current(&self, expected_epoch: RenderEpoch, generation: u64) -> Result<()> {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned");
         let mut dirty = self
             .inner
             .dirty
             .lock()
             .expect("InteractivePlotSession dirty lock poisoned");
-        if self.inner.dirty_epoch.load(Ordering::Acquire) != dirty_epoch_before_render {
-            return;
+        if !self.epochs_match(expected_epoch)
+            || state.base_cache.as_ref().map(|cache| cache.generation) != Some(generation)
+        {
+            return Err(render_superseded_error());
         }
         dirty.clear_base();
         dirty.clear_overlay();
+        Ok(())
     }
 
     fn try_incremental_stream_render(
@@ -2318,6 +2535,7 @@ impl InteractivePlotSession {
         key: &InteractiveFrameKey,
         geometry: &GeometrySnapshot,
         frame: &ResolvedFrame<'_>,
+        epoch_before_render: RenderEpoch,
     ) -> Result<Option<BaseLayerResult>> {
         let (cached, state) = {
             let state = self
@@ -2358,21 +2576,21 @@ impl InteractivePlotSession {
         let displayed_data = DisplayedFrameData::capture(source_plot, frame);
         let point_hit_index = Arc::new(OnceLock::new());
 
-        let mut state = self
-            .inner
-            .state
-            .lock()
-            .expect("InteractivePlotSession state lock poisoned");
-        state.base_cache = Some(InteractiveFrameCache {
-            key: key.clone(),
-            image: Arc::clone(&image),
-            geometry: geometry.clone(),
-            displayed_data,
-            point_hit_index,
-        });
+        let generation = self.publish_base_cache_if_epoch(
+            InteractiveFrameCache {
+                generation: 0,
+                key: key.clone(),
+                image: Arc::clone(&image),
+                geometry: geometry.clone(),
+                displayed_data,
+                point_hit_index,
+            },
+            epoch_before_render,
+        )?;
 
         Ok(Some(BaseLayerResult {
             image,
+            generation,
             updated: true,
             used_incremental_data: true,
         }))
@@ -2886,6 +3104,13 @@ fn hit_test_displayed_frame(
 fn displayed_geometry_unavailable() -> PlottingError {
     PlottingError::InvalidInput(
         "interactive coordinate conversion is unavailable before a base frame is displayed"
+            .to_string(),
+    )
+}
+
+fn render_superseded_error() -> PlottingError {
+    PlottingError::RenderError(
+        "interactive render superseded by a newer mutation, invalidation, or dirty update"
             .to_string(),
     )
 }

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -15,6 +15,24 @@ fn render_target() -> SurfaceTarget {
     }
 }
 
+fn install_render_test_hook(
+    session: &InteractivePlotSession,
+    point: RenderTestPoint,
+) -> (Arc<std::sync::Barrier>, Arc<std::sync::Barrier>) {
+    let entered = Arc::new(std::sync::Barrier::new(2));
+    let release = Arc::new(std::sync::Barrier::new(2));
+    *session
+        .inner
+        .render_test_hook
+        .lock()
+        .expect("InteractivePlotSession render test hook lock poisoned") = Some(RenderTestHook {
+        point,
+        entered: Arc::clone(&entered),
+        release: Arc::clone(&release),
+    });
+    (entered, release)
+}
+
 fn assert_index_matches_brute_force(
     session: &InteractivePlotSession,
     data_probes: &[ViewportPoint],
@@ -1470,14 +1488,69 @@ fn test_inflight_dirty_marks_survive_render_clear() {
     let plot: Plot = Plot::new().line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 4.0]).into();
     let session = plot.prepare_interactive();
 
+    session
+        .render_to_surface(render_target())
+        .expect("initial frame should render");
+
     session.mark_dirty(DirtyDomain::Data);
-    let render_epoch = session.inner.dirty_epoch.load(Ordering::Acquire);
+    let (_, _, render_epoch) = session.render_snapshot();
+    let generation = session
+        .displayed_frame_generation()
+        .expect("initial frame should have a generation");
     session.mark_dirty(DirtyDomain::Overlay);
-    session.clear_dirty_after_render(render_epoch);
+    assert!(
+        session
+            .commit_frame_if_current(render_epoch, generation)
+            .is_err()
+    );
 
     let dirty = session.dirty_domains();
     assert!(dirty.data);
     assert!(dirty.overlay);
+}
+
+#[test]
+fn test_mutation_between_state_change_and_dirty_mark_returns_superseded_error() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 4.0])
+        .xlim(0.0, 2.0)
+        .ylim(0.0, 4.0)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial frame should render");
+    let visible = session.viewport_snapshot().unwrap().visible_bounds;
+    let next_visible = ViewportRect::from_points(
+        ViewportPoint::new(
+            visible.min.x + visible.width() * 0.1,
+            visible.min.y + visible.height() * 0.1,
+        ),
+        ViewportPoint::new(
+            visible.max.x - visible.width() * 0.1,
+            visible.max.y - visible.height() * 0.1,
+        ),
+    );
+    let (entered, release) = install_render_test_hook(&session, RenderTestPoint::BeforeDirtyMark);
+
+    let mutation_session = session.clone();
+    let mutation =
+        std::thread::spawn(move || mutation_session.restore_visible_bounds(next_visible));
+    entered.wait();
+
+    let error = session
+        .render_to_surface(render_target())
+        .expect_err("a changed key without its dirty mark must be superseded, not panic");
+    assert!(matches!(
+        error,
+        PlottingError::RenderError(message) if message.contains("superseded")
+    ));
+
+    release.wait();
+    assert!(mutation.join().expect("mutation thread should not panic"));
+    session
+        .render_to_surface(render_target())
+        .expect("render should recover after the delayed dirty mark");
 }
 
 #[test]
@@ -1525,6 +1598,247 @@ fn test_overlapping_render_requests_cannot_commit_stale_base_cache() {
     session
         .render_to_surface(second_target)
         .expect("latest render target should retain a coherent cache");
+}
+
+#[test]
+fn test_invalidate_during_render_supersedes_cache_publication_without_panicking() {
+    let first_resolution = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let entered = Arc::new(std::sync::Barrier::new(2));
+    let release = Arc::new(std::sync::Barrier::new(2));
+    let first_resolution_for_signal = Arc::clone(&first_resolution);
+    let entered_for_signal = Arc::clone(&entered);
+    let release_for_signal = Arc::clone(&release);
+    let color = signal::of(move |_| {
+        if first_resolution_for_signal.swap(false, Ordering::AcqRel) {
+            entered_for_signal.wait();
+            release_for_signal.wait();
+        }
+        Color::RED
+    });
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 4.0])
+        .color_source(color)
+        .into();
+    let session = plot.prepare_interactive();
+
+    let render_session = session.clone();
+    let render = std::thread::spawn(move || render_session.render_to_surface(render_target()));
+    entered.wait();
+    session.invalidate();
+    release.wait();
+
+    let error = render
+        .join()
+        .expect("render thread should not panic")
+        .expect_err("invalidated render should be superseded");
+    assert!(matches!(
+        error,
+        PlottingError::RenderError(message) if message.contains("superseded")
+    ));
+    assert_eq!(session.displayed_frame_generation(), None);
+
+    session
+        .render_to_surface(render_target())
+        .expect("a render after invalidation should recover normally");
+    assert!(session.displayed_frame_generation().is_some());
+}
+
+#[test]
+fn test_invalidation_after_base_publication_supersedes_final_return() {
+    let plot: Plot = Plot::new().line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 4.0]).into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial frame should render");
+    session.apply_input(PlotInputEvent::Pan {
+        delta_px: ViewportPoint::new(20.0, 0.0),
+    });
+    let (entered, release) =
+        install_render_test_hook(&session, RenderTestPoint::AfterBasePublication);
+
+    let render_session = session.clone();
+    let render = std::thread::spawn(move || render_session.render_to_surface(render_target()));
+    entered.wait();
+    session.invalidate();
+    release.wait();
+
+    let error = render
+        .join()
+        .expect("render thread should not panic")
+        .expect_err("invalidation after publication must supersede the final return");
+    assert!(matches!(
+        error,
+        PlottingError::RenderError(message) if message.contains("superseded")
+    ));
+    assert_eq!(session.displayed_frame_generation(), None);
+}
+
+#[test]
+fn test_cache_hit_and_overlay_only_invalidation_supersede_final_return() {
+    for overlay_only in [false, true] {
+        let plot: Plot = Plot::new().scatter(&[0.5], &[0.5]).into();
+        let session = plot.prepare_interactive();
+        session
+            .render_to_surface(render_target())
+            .expect("initial frame should render");
+        if overlay_only {
+            let point = session
+                .data_to_screen(ViewportPoint::new(0.5, 0.5))
+                .expect("mapping should succeed")
+                .expect("point should be visible");
+            session.apply_input(PlotInputEvent::Hover { position_px: point });
+            assert!(session.dirty_domains().overlay);
+            assert!(!session.dirty_domains().needs_base_render());
+        }
+        let (entered, release) =
+            install_render_test_hook(&session, RenderTestPoint::BeforeFinalCommit);
+
+        let render_session = session.clone();
+        let render = std::thread::spawn(move || render_session.render_to_surface(render_target()));
+        entered.wait();
+        session.invalidate();
+        release.wait();
+
+        let error = render
+            .join()
+            .expect("render thread should not panic")
+            .expect_err("invalidation before final commit must supersede the frame");
+        assert!(matches!(
+            error,
+            PlottingError::RenderError(message) if message.contains("superseded")
+        ));
+        assert_eq!(session.displayed_frame_generation(), None);
+    }
+}
+
+#[test]
+fn test_overlay_refresh_does_not_overwrite_concurrent_pointer_mutation() {
+    let plot: Plot = Plot::new()
+        .scatter(&[0.25, 0.75], &[0.25, 0.75])
+        .xlim(0.0, 1.0)
+        .ylim(0.0, 1.0)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial frame should render");
+    let point = session
+        .data_to_screen(ViewportPoint::new(0.25, 0.25))
+        .expect("mapping should succeed")
+        .expect("point should be visible");
+    session.apply_input(PlotInputEvent::Hover { position_px: point });
+    assert!(
+        session
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned")
+            .hovered
+            .is_some()
+    );
+    session.apply_input(PlotInputEvent::Pan {
+        delta_px: ViewportPoint::new(20.0, 0.0),
+    });
+    let (entered, release) =
+        install_render_test_hook(&session, RenderTestPoint::BeforeOverlayRefreshCommit);
+
+    let render_session = session.clone();
+    let render = std::thread::spawn(move || render_session.render_to_surface(render_target()));
+    entered.wait();
+    session.apply_input(PlotInputEvent::ClearHover);
+    release.wait();
+
+    let error = render
+        .join()
+        .expect("render thread should not panic")
+        .expect_err("concurrent pointer mutation must supersede stale overlay refresh");
+    assert!(matches!(
+        error,
+        PlottingError::RenderError(message) if message.contains("superseded")
+    ));
+    let state = session
+        .inner
+        .state
+        .lock()
+        .expect("InteractivePlotSession state lock poisoned");
+    assert!(state.hovered.is_none());
+    assert!(state.tooltip.is_none());
+}
+
+#[test]
+fn test_base_generation_exhaustion_returns_error_without_poisoning_state() {
+    let plot: Plot = Plot::new().line(&[0.0, 1.0], &[0.0, 1.0]).into();
+    let session = plot.prepare_interactive();
+    session
+        .inner
+        .state
+        .lock()
+        .expect("InteractivePlotSession state lock poisoned")
+        .base_generation = u64::MAX;
+
+    let error = session
+        .render_to_surface(render_target())
+        .expect_err("generation exhaustion should be reported");
+    assert!(matches!(
+        error,
+        PlottingError::RenderError(message) if message.contains("generation exhausted")
+    ));
+    assert_eq!(session.displayed_frame_generation(), None);
+    assert_eq!(
+        session
+            .inner
+            .state
+            .lock()
+            .expect("state lock should remain usable")
+            .base_generation,
+        u64::MAX
+    );
+}
+
+#[test]
+fn test_base_frame_generation_tracks_published_interactive_cache() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0, 2.0], &[0.0, 1.0, 4.0])
+        .xlim(0.0, 2.0)
+        .ylim(0.0, 4.0)
+        .into();
+    let session = plot.prepare_interactive();
+
+    assert_eq!(session.displayed_frame_generation(), None);
+    let first = session
+        .render_to_surface_with_generation(render_target())
+        .expect("initial frame should render");
+    assert_eq!(
+        session.displayed_frame_generation(),
+        Some(first.base_generation)
+    );
+
+    session.apply_input(PlotInputEvent::Hover {
+        position_px: ViewportPoint::new(200.0, 150.0),
+    });
+    let overlay_only = session
+        .render_to_surface_with_generation(render_target())
+        .expect("overlay-only frame should render");
+    assert_eq!(overlay_only.base_generation, first.base_generation);
+
+    session.apply_input(PlotInputEvent::Pan {
+        delta_px: ViewportPoint::new(20.0, 0.0),
+    });
+    let second = session
+        .render_to_surface_with_generation(render_target())
+        .expect("panned frame should render");
+    assert!(second.base_generation > first.base_generation);
+    assert_eq!(
+        session.displayed_frame_generation(),
+        Some(second.base_generation)
+    );
+
+    session.invalidate();
+    assert_eq!(session.displayed_frame_generation(), None);
+    let third = session
+        .render_to_surface_with_generation(render_target())
+        .expect("invalidated frame should render");
+    assert!(third.base_generation > second.base_generation);
 }
 
 #[test]

--- a/src/core/plot/mod.rs
+++ b/src/core/plot/mod.rs
@@ -510,8 +510,9 @@ pub use data::{IntoPlotData, PlotData, PlotSource, PlotText, ReactiveValue};
 pub use image::Image;
 pub use interactive_session::{
     DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, ImageTarget, InteractiveFrame,
-    InteractivePlotSession, InteractiveViewportSnapshot, LayerRenderState, PlotInputEvent,
-    QualityPolicy, RenderTargetKind, SurfaceCapability, SurfaceTarget, ViewportPoint, ViewportRect,
+    InteractiveFrameWithGeneration, InteractivePlotSession, InteractiveViewportSnapshot,
+    LayerRenderState, PlotInputEvent, QualityPolicy, RenderTargetKind, SurfaceCapability,
+    SurfaceTarget, ViewportPoint, ViewportRect,
 };
 pub use layout_manager::LayoutManager;
 pub use prepared::{PreparedPlot, ReactiveSubscription};


### PR DESCRIPTION
## Summary

- expose `RuvizPlot::data_at` and `screen_at` for absolute GPUI window ↔ displayed data conversion
- add shared `PlotPointerEvent` payloads for click and hover, available through builder callbacks and idiomatic GPUI `EventEmitter` subscriptions
- keep events frame-coherent by associating rendered base/overlay layers with the exact interactive generation GPUI installed
- reject and recover from stale/superseded renders without panics, stale hit tests, or mixed-generation overlays
- classify gestures in GPUI window pixels so click/pan/brush/zoom behavior is stable across display scales and image-fit modes
- add a focused heatmap coordinate-events example and README guidance

## Event semantics

- click fires on a primary-button release that was not consumed by pan, brush, zoom, scroll, or context-menu handling
- the first completed click in a platform double-click sequence may emit before click-count 2 is known; click-count 2 emits no additional event
- hover callbacks coexist with built-in hover/tooltips and duplicate payloads are coalesced
- during a visible/core generation mismatch, pointer-derived mutations and callbacks are skipped until GPUI installs the matching frame

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ruviz-gpui` — 30 passed
- `cargo check -p ruviz-gpui --examples`
- `cargo clippy -p ruviz-gpui --all-targets -- -D warnings`
- `cargo test --lib core::plot::interactive_session::tests` — 70 passed
- documentation contracts passed through the pre-commit hook
- repeated adversarial Codex review; all reported high/medium frame-coherence, gesture, overlay, invalidation, and rollback defects were fixed
- no `Cargo.toml`, crate manifest, or `Cargo.lock` changes

## Known baseline limitation

`cargo clippy -p ruviz-gpui --all-targets --all-features` still encounters the existing macOS `core-video` 0.4/0.5 `CVPixelBuffer` mismatch on clean `main`. This PR deliberately does not bundle that unrelated dependency change.

Closes #102
Part of #97