### PR TITLE
Preserve GPUI view across plot replacement

### DIFF
--- a/crates/ruviz-gpui/README.md
+++ b/crates/ruviz-gpui/README.md
@@ -88,6 +88,45 @@ cargo run -p ruviz-gpui --example streaming_embed
 cargo run -p ruviz-gpui --example coordinate_events
 ```
 
+## Updating Data and Replacing Plots
+
+For data-only changes, build the plot once with `line_source` or
+`scatter_source` and use `Observable<Vec<f64>>` for the changing coordinates.
+Replace a complete vector with `Observable::set`; the existing interactive
+session and its subscriptions stay in place:
+
+```rust
+use ruviz::{data::{BatchUpdate, Observable}, prelude::*};
+
+let x = Observable::new(vec![0.0, 1.0, 2.0]);
+let y = Observable::new(vec![0.0, 1.0, 4.0]);
+let plot: Plot = Plot::new().line_source(x.clone(), y.clone()).into();
+
+{
+    let mut batch = BatchUpdate::new();
+    batch.add(&x);
+    batch.add(&y);
+    x.set(vec![0.0, 2.0, 4.0]);
+    y.set(vec![1.0, 3.0, 9.0]);
+}
+```
+
+Reactive rerendering retains a user-customized visible view. If the visible
+view still matches the base view, it may autoscale to the replacement data.
+`BatchUpdate` defers each observable's notifications until guard drop, and
+repeated changes within each observable are coalesced. Separate observables
+still flush independently; the guard is not a shared data lock, so concurrent
+readers can observe the two objects independently.
+
+Use `RuvizPlot::set_plot` only when the plot definition itself must change. It
+replaces the whole interactive session and resets the visible and home views,
+pointer, drag, hover, selection, cached frames, scheduler and in-flight work,
+and reactive subscriptions. `RuvizPlot::set_plot_keep_view` performs the same
+replacement but queues old visible data bounds for restoration when the old view
+was customized. Restoration happens during the replacement's next render, after
+its data bounds have been resolved for the configured time. Incompatible bounds
+are discarded and the replacement keeps its natural view.
+
 ## Related Docs
 
 - Root crate docs: <https://docs.rs/ruviz>

--- a/crates/ruviz-gpui/examples/observable_embed.rs
+++ b/crates/ruviz-gpui/examples/observable_embed.rs
@@ -3,7 +3,10 @@ mod support;
 use gpui::{
     App, Bounds, Context, Render, Window, WindowBounds, WindowOptions, div, prelude::*, px, size,
 };
-use ruviz::{data::Observable, prelude::*};
+use ruviz::{
+    data::{BatchUpdate, Observable},
+    prelude::*,
+};
 use ruviz_gpui::{PerformancePreset, RuvizPlot, plot_builder};
 use std::time::Duration;
 use support::{application, exit_on_window_open_failure, sleep};
@@ -15,7 +18,8 @@ struct ObservableEmbedDemo {
 impl ObservableEmbedDemo {
     fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
         let x: Vec<f64> = (0..200).map(|i| i as f64 * 0.05).collect();
-        let y = Observable::new(x.iter().map(|value| value.sin()).collect::<Vec<_>>());
+        let x = Observable::new(x);
+        let y = Observable::new(x.read().iter().map(|value| value.sin()).collect::<Vec<_>>());
         let plot: Plot = Plot::new()
             .line_source(x.clone(), y.clone())
             .title("Observable GPUI Embed")
@@ -29,10 +33,23 @@ impl ObservableEmbedDemo {
 
         window
             .spawn(cx, {
+                let x = x.clone();
                 let y = y.clone();
                 async move |_| {
                     sleep(Duration::from_millis(750)).await;
-                    y.set(x.iter().map(|value| (value * 1.5).cos()).collect());
+                    let next_x: Vec<f64> = (0..240).map(|index| index as f64 * 0.04).collect();
+                    let next_y = next_x.iter().map(|value| (value * 1.5).cos()).collect();
+
+                    // Replace both complete vectors without rebuilding the plot
+                    // session. The batch defers each observable's notifications
+                    // until guard drop and coalesces repeated changes within that
+                    // observable. The two observables still flush independently;
+                    // the guard is not a shared data lock.
+                    let mut batch = BatchUpdate::new();
+                    batch.add(&x);
+                    batch.add(&y);
+                    x.set(next_x);
+                    y.set(next_y);
                 }
             })
             .detach();

--- a/crates/ruviz-gpui/src/lib.rs
+++ b/crates/ruviz-gpui/src/lib.rs
@@ -55,6 +55,15 @@
 //! component. See the repository examples under
 //! `crates/ruviz-gpui/examples/` for end-to-end setups.
 //!
+//! For data-only updates, build the plot once with `Plot::line_source` or
+//! `Plot::scatter_source` and `Observable<Vec<f64>>`, then call
+//! `Observable::set` to replace a complete coordinate vector. Reactive renders
+//! retain a customized visible view; a view still at its base bounds can
+//! autoscale to the new data. `BatchUpdate` defers each observable's
+//! notifications until guard drop and coalesces repeated changes within that
+//! observable. Separate observables still flush independently; the guard is not
+//! a shared data lock.
+//!
 //! # Documentation
 //!
 //! - Repository README: <https://github.com/Ameyanagi/ruviz/blob/main/README.md>
@@ -93,6 +102,7 @@ mod platform_impl {
     };
     use image::{Frame, ImageBuffer, Rgba};
     use ruviz::{
+        axes::AxisScale,
         core::plot::Image as RuvizImage,
         core::{
             FramePacing, FrameStats, HitResult, ImageTarget, InteractivePlotSession,
@@ -955,11 +965,60 @@ mod platform_impl {
                 .stats()
         }
 
+        /// Converts `plot` into an interactive session and replaces the current one.
+        ///
+        /// This is a destructive replacement. The previous visible view is
+        /// discarded (a session created from a plot starts at its natural/base
+        /// bounds), any custom home view is cleared, and pointer, drag, hover,
+        /// selection, cached frames, scheduler and in-flight work, and reactive
+        /// subscriptions from the previous session are discarded.
+        ///
+        /// For a replacement that retains only a user-customized visible view,
+        /// use [`Self::set_plot_keep_view`]. For data-only changes, prefer
+        /// source-backed series and replace their `Observable<Vec<f64>>` values.
         pub fn set_plot<P>(&mut self, plot: P, cx: &mut Context<Self>)
         where
             P: IntoPlotSession,
         {
             self.replace_session(plot.into_plot_session());
+            cx.notify();
+        }
+
+        /// Replaces the plot while attempting to retain a customized visible view.
+        ///
+        /// The old visible data bounds are retained only when they materially
+        /// differ from the old base bounds. An untouched view therefore keeps the
+        /// replacement session's own view, normally the replacement plot's
+        /// natural bounds. Restoration goes through the new session's normal
+        /// scale validation and normalization, including log-domain checks,
+        /// reversed axes, and zoom limits.
+        ///
+        /// Like [`Self::set_plot`], this still replaces the entire interactive
+        /// session. It does not preserve the home view, pointer, drag, hover,
+        /// selection, cached frames, scheduler or in-flight work, or reactive
+        /// subscriptions.
+        ///
+        /// Restoration is applied during the replacement session's next render,
+        /// after its data bounds have been resolved for the configured time. If the
+        /// old bounds are incompatible with the replacement scales, the replacement
+        /// session keeps its natural bounds.
+        pub fn set_plot_keep_view<P>(&mut self, plot: P, cx: &mut Context<Self>)
+        where
+            P: IntoPlotSession,
+        {
+            let old_viewport = self.session.view_bounds_snapshot();
+            let should_restore = viewport_bounds_materially_differ(
+                old_viewport.visible_bounds,
+                old_viewport.base_bounds,
+                &old_viewport.x_scale,
+                &old_viewport.y_scale,
+            );
+
+            self.replace_session(plot.into_plot_session());
+            if should_restore {
+                self.session
+                    .defer_visible_bounds_restore(old_viewport.visible_bounds);
+            }
             cx.notify();
         }
 
@@ -1119,6 +1178,42 @@ mod platform_impl {
             self.last_layout = None;
             self.interaction_state.reset();
         }
+    }
+
+    const VIEW_BOUNDS_NORMALIZED_TOLERANCE: f64 = 1e-12;
+
+    fn viewport_bounds_materially_differ(
+        visible: ViewportRect,
+        base: ViewportRect,
+        x_scale: &AxisScale,
+        y_scale: &AxisScale,
+    ) -> bool {
+        !viewport_axis_bounds_close(
+            (visible.min.x, visible.max.x),
+            (base.min.x, base.max.x),
+            x_scale,
+        ) || !viewport_axis_bounds_close(
+            (visible.min.y, visible.max.y),
+            (base.min.y, base.max.y),
+            y_scale,
+        )
+    }
+
+    fn viewport_axis_bounds_close(
+        visible: (f64, f64),
+        base: (f64, f64),
+        scale: &AxisScale,
+    ) -> bool {
+        if (visible.1 - visible.0).is_sign_negative() != (base.1 - base.0).is_sign_negative() {
+            return false;
+        }
+
+        let start = scale.normalized_position(visible.0, base.0, base.1);
+        let end = scale.normalized_position(visible.1, base.0, base.1);
+        start.is_finite()
+            && end.is_finite()
+            && start.abs() <= VIEW_BOUNDS_NORMALIZED_TOLERANCE
+            && (end - 1.0).abs() <= VIEW_BOUNDS_NORMALIZED_TOLERANCE
     }
 
     impl Render for RuvizPlot {
@@ -1324,7 +1419,40 @@ mod platform_impl {
         use super::*;
         use gpui::{Modifiers, MouseButton, TestAppContext};
         use ruviz::plots::heatmap::HeatmapConfig;
-        use ruviz::{axes::AxisScale, data::Observable, prelude::Plot};
+        use ruviz::{
+            axes::AxisScale,
+            data::{BatchUpdate, Observable, signal},
+            prelude::Plot,
+        };
+
+        fn viewport_rect(x_min: f64, x_max: f64, y_min: f64, y_max: f64) -> ViewportRect {
+            ViewportRect {
+                min: ViewportPoint::new(x_min, y_min),
+                max: ViewportPoint::new(x_max, y_max),
+            }
+        }
+
+        fn assert_viewport_bounds_close(actual: ViewportRect, expected: ViewportRect) {
+            assert!(
+                !viewport_bounds_materially_differ(
+                    actual,
+                    expected,
+                    &AxisScale::Linear,
+                    &AxisScale::Linear,
+                ),
+                "actual bounds {actual:?} differed from expected bounds {expected:?}"
+            );
+        }
+
+        fn render_test_surface(session: &InteractivePlotSession) {
+            session
+                .render_to_surface(SurfaceTarget {
+                    size_px: (320, 240),
+                    scale_factor: 1.0,
+                    time_seconds: 0.0,
+                })
+                .expect("test surface should render");
+        }
 
         struct PointerEventSubscriber {
             events: Arc<Mutex<Vec<PlotPointerEvent>>>,
@@ -2149,6 +2277,719 @@ mod platform_impl {
         }
 
         #[test]
+        fn test_set_plot_resets_customized_view_and_replacement_state() {
+            let cx = TestAppContext::single();
+            let old_y = Observable::new(vec![5.0]);
+            let replacement_y = Observable::new(vec![1.0, 2.0]);
+            let initial_plot: Plot = Plot::new()
+                .scatter_source(vec![5.0], old_y.clone())
+                .xlim(0.0, 10.0)
+                .ylim(0.0, 10.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let custom_view = viewport_rect(2.0, 8.0, 1.0, 9.0);
+            let replacement_plot: Plot = Plot::new()
+                .line_source(vec![100.0, 200.0], replacement_y.clone())
+                .xlim(100.0, 200.0)
+                .ylim(-5.0, 5.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    view.session
+                        .render_to_surface(SurfaceTarget {
+                            size_px: (320, 240),
+                            scale_factor: 1.0,
+                            time_seconds: 0.0,
+                        })
+                        .expect("initial selection frame should render");
+                    let point = view
+                        .session
+                        .data_to_screen(ViewportPoint::new(5.0, 5.0))
+                        .expect("selection conversion should succeed")
+                        .expect("selection point should be visible");
+                    view.session
+                        .apply_input(PlotInputEvent::SelectAt { position_px: point });
+                    assert!(view.session.restore_visible_bounds(custom_view));
+
+                    view.interaction_state.last_pointer_px = Some(ViewportPoint::new(4.0, 5.0));
+                    view.interaction_state.active_drag = ActiveDrag::LeftPan {
+                        anchor_px: ViewportPoint::new(1.0, 1.0),
+                        anchor_window: Point::new(px(1.0), px(1.0)),
+                        last_px: ViewportPoint::new(2.0, 2.0),
+                        crossed_threshold: true,
+                        click_eligible: false,
+                    };
+                    view.interaction_state.home_view_bounds = Some(custom_view);
+                    view.last_layout = Some(InteractionLayout {
+                        component_bounds: Bounds::default(),
+                        content_bounds: Bounds::default(),
+                        frame_size_px: (320, 240),
+                    });
+                    view.cached_frame = Some(CachedFrame {
+                        request: RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid),
+                        base_generation: 0,
+                        primary: PrimaryFrame::Image(render_image_from_ruviz(
+                            ruviz::core::plot::Image::new(1, 1, vec![0, 0, 0, 255]),
+                        )),
+                        overlay_image: None,
+                        stats: FrameStats::default(),
+                        target: RenderTargetKind::Surface,
+                    });
+                    view.scheduler.latest_requested_generation = 7;
+                    view.scheduler.dropped_frames = 3;
+
+                    view.set_plot(replacement_plot, cx);
+                });
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view
+                        .session
+                        .viewport_snapshot()
+                        .expect("replacement viewport should be available");
+                    assert_eq!(snapshot.visible_bounds, snapshot.base_bounds);
+                    assert_ne!(snapshot.visible_bounds, custom_view);
+                    assert_eq!(snapshot.selected_count, 0);
+                    assert!(view.cached_frame.is_none());
+                    assert_eq!(view.retired_images.len(), 1);
+                    assert!(view.last_layout.is_none());
+                    assert_eq!(view.interaction_state, InteractionState::default());
+                    assert_eq!(view.scheduler.latest_requested_generation, 0);
+                    assert!(view.scheduler.in_flight.is_none());
+                    assert!(view.scheduler.queued.is_none());
+                    assert_eq!(view.scheduler.dropped_frames, 0);
+                    assert!(view.in_flight_render.is_none());
+                })
+            });
+            assert_eq!(old_y.subscriber_count(), 0);
+            assert_eq!(replacement_y.subscriber_count(), 2);
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_restores_customized_view_and_resets_non_view_state() {
+            let cx = TestAppContext::single();
+            let old_y = Observable::new(vec![5.0]);
+            let replacement_y = Observable::new(vec![0.0, 100.0]);
+            let initial_plot: Plot = Plot::new()
+                .scatter_source(vec![5.0], old_y.clone())
+                .xlim(0.0, 10.0)
+                .ylim(0.0, 10.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let custom_view = viewport_rect(2.0, 8.0, 1.0, 9.0);
+            let replacement_plot: Plot = Plot::new()
+                .line_source(vec![0.0, 100.0], replacement_y.clone())
+                .xlim(0.0, 100.0)
+                .ylim(0.0, 100.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    render_test_surface(&view.session);
+                    let point = view
+                        .session
+                        .data_to_screen(ViewportPoint::new(5.0, 5.0))
+                        .expect("selection conversion should succeed")
+                        .expect("selection point should be visible");
+                    view.session
+                        .apply_input(PlotInputEvent::SelectAt { position_px: point });
+                    assert_eq!(view.session.viewport_snapshot().unwrap().selected_count, 1);
+                    assert!(view.session.restore_visible_bounds(custom_view));
+                    view.interaction_state.last_pointer_px = Some(ViewportPoint::new(4.0, 5.0));
+                    view.interaction_state.active_drag = ActiveDrag::RightZoom {
+                        anchor_px: ViewportPoint::new(1.0, 1.0),
+                        anchor_window: Point::new(px(1.0), px(1.0)),
+                        current_px: ViewportPoint::new(2.0, 2.0),
+                        crossed_threshold: true,
+                        zoom_enabled: true,
+                    };
+                    view.interaction_state.home_view_bounds = Some(custom_view);
+                    view.scheduler.latest_requested_generation = 4;
+
+                    view.set_plot_keep_view(replacement_plot, cx)
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view
+                        .session
+                        .viewport_snapshot()
+                        .expect("replacement viewport should be available");
+                    assert_viewport_bounds_close(snapshot.visible_bounds, custom_view);
+                    assert_ne!(snapshot.visible_bounds, snapshot.base_bounds);
+                    assert_eq!(snapshot.selected_count, 0);
+                    assert_eq!(view.interaction_state, InteractionState::default());
+                    assert_eq!(view.scheduler.latest_requested_generation, 0);
+                    assert!(view.cached_frame.is_none());
+                    assert!(view.in_flight_render.is_none());
+                })
+            });
+            assert_eq!(old_y.subscriber_count(), 0);
+            assert_eq!(replacement_y.subscriber_count(), 2);
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_restores_after_temporal_bounds_resolve() {
+            let cx = TestAppContext::single();
+            let initial_plot: Plot = Plot::new()
+                .line(&[0.0, 1.0], &[0.0, 100.0])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 100.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let custom_view = viewport_rect(0.0, 1.0, 20.0, 80.0);
+            let temporal_y = signal::of(|time| {
+                if time < 50.0 {
+                    vec![-1.0, 1.0]
+                } else {
+                    vec![0.0, 100.0]
+                }
+            });
+            let replacement_plot: Plot = Plot::new()
+                .line_source(vec![0.0, 1.0], temporal_y)
+                .xlim(0.0, 1.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    render_test_surface(&view.session);
+                    assert!(view.session.restore_visible_bounds(custom_view));
+                    view.set_plot_keep_view(replacement_plot, cx);
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    view.session
+                        .render_to_surface(SurfaceTarget {
+                            size_px: (320, 240),
+                            scale_factor: 1.0,
+                            time_seconds: 100.0,
+                        })
+                        .expect("temporal replacement frame should render");
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert_viewport_bounds_close(snapshot.visible_bounds, custom_view);
+                    assert_eq!(snapshot.base_bounds, viewport_rect(0.0, 1.0, 0.0, 100.0));
+                })
+            });
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_uses_replacement_bounds_for_untouched_view() {
+            let cx = TestAppContext::single();
+            let initial_plot: Plot = Plot::new()
+                .line(&[0.0, 10.0], &[0.0, 10.0])
+                .xlim(0.0, 10.0)
+                .ylim(0.0, 10.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let replacement_plot: Plot = Plot::new()
+                .line(&[100.0, 200.0], &[-5.0, 5.0])
+                .xlim(100.0, 200.0)
+                .ylim(-5.0, 5.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| view.set_plot_keep_view(replacement_plot, cx))
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert_eq!(snapshot.visible_bounds, snapshot.base_bounds);
+                    assert_eq!(snapshot.base_bounds, viewport_rect(100.0, 200.0, -5.0, 5.0));
+                })
+            });
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_keeps_already_equal_replacement_bounds() {
+            let cx = TestAppContext::single();
+            let initial_plot: Plot = Plot::new()
+                .line(&[0.0, 10.0], &[0.0, 10.0])
+                .xlim(0.0, 10.0)
+                .ylim(0.0, 10.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let custom_view = viewport_rect(2.0, 8.0, 1.0, 9.0);
+            let replacement_plot: Plot = Plot::new()
+                .line(&[2.0, 8.0], &[1.0, 9.0])
+                .xlim(2.0, 8.0)
+                .ylim(1.0, 9.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    assert!(view.session.restore_visible_bounds(custom_view));
+                    view.set_plot_keep_view(replacement_plot, cx)
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert_viewport_bounds_close(snapshot.visible_bounds, custom_view);
+                    assert_viewport_bounds_close(snapshot.visible_bounds, snapshot.base_bounds);
+                })
+            });
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_detects_customization_on_large_log_range() {
+            let cx = TestAppContext::single();
+            let initial_plot: Plot = Plot::new()
+                .line(&[1.0, 1e15], &[0.0, 1.0])
+                .xscale(AxisScale::Log)
+                .xlim(1.0, 1e15)
+                .ylim(0.0, 1.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let custom_view = viewport_rect(10.0, 1e15, 0.0, 1.0);
+            let replacement_plot: Plot = Plot::new()
+                .line(&[1.0, 1e16], &[0.0, 1.0])
+                .xscale(AxisScale::Log)
+                .xlim(1.0, 1e16)
+                .ylim(0.0, 1.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    assert!(view.session.restore_visible_bounds(custom_view));
+                    view.set_plot_keep_view(replacement_plot, cx)
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view.session.view_bounds_snapshot();
+                    assert!(!viewport_bounds_materially_differ(
+                        snapshot.visible_bounds,
+                        custom_view,
+                        &AxisScale::Log,
+                        &AxisScale::Linear,
+                    ));
+                })
+            });
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_rejects_old_bounds_outside_new_log_domain() {
+            let cx = TestAppContext::single();
+            let initial_plot: Plot = Plot::new()
+                .line(&[-100.0, 100.0], &[0.0, 1.0])
+                .xlim(-100.0, 100.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let invalid_for_log = viewport_rect(-10.0, -1.0, 0.1, 0.9);
+            let replacement_plot: Plot = Plot::new()
+                .line(&[1.0, 100.0], &[0.0, 1.0])
+                .xscale(AxisScale::Log)
+                .xlim(1.0, 100.0)
+                .ylim(0.0, 1.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    render_test_surface(&view.session);
+                    assert!(view.session.restore_visible_bounds(invalid_for_log));
+                    view.set_plot_keep_view(replacement_plot, cx)
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert_eq!(snapshot.visible_bounds, snapshot.base_bounds);
+                    assert!(snapshot.visible_bounds.min.x > 0.0);
+                })
+            });
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_normalizes_linear_bounds_for_new_log_scale() {
+            let cx = TestAppContext::single();
+            let initial_plot: Plot = Plot::new()
+                .line(&[1.0, 100.0], &[0.0, 1.0])
+                .xlim(1.0, 100.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let far_linear_view = viewport_rect(1.0, 1e15, 0.0, 1.0);
+            let replacement_plot: Plot = Plot::new()
+                .line(&[1.0, 100.0], &[0.0, 1.0])
+                .xscale(AxisScale::Log)
+                .xlim(1.0, 100.0)
+                .ylim(0.0, 1.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    assert!(view.session.restore_visible_bounds(far_linear_view));
+                    view.set_plot_keep_view(replacement_plot, cx)
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view.session.view_bounds_snapshot();
+                    let normalized_span = AxisScale::Log.normalized_position(
+                        snapshot.visible_bounds.max.x,
+                        snapshot.base_bounds.min.x,
+                        snapshot.base_bounds.max.x,
+                    ) - AxisScale::Log.normalized_position(
+                        snapshot.visible_bounds.min.x,
+                        snapshot.base_bounds.min.x,
+                        snapshot.base_bounds.max.x,
+                    );
+                    assert!(snapshot.visible_bounds.min.x > 0.0);
+                    assert!((normalized_span.abs() - 0.01).abs() < 1e-12);
+                    assert_ne!(snapshot.visible_bounds, snapshot.base_bounds);
+                })
+            });
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_normalizes_outlying_bounds_to_new_zoom_limits() {
+            let cx = TestAppContext::single();
+            let initial_plot: Plot = Plot::new()
+                .line(&[0.0, 100.0], &[0.0, 100.0])
+                .xlim(0.0, 100.0)
+                .ylim(0.0, 100.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let outlying_view = viewport_rect(-450.0, 550.0, -450.0, 550.0);
+            let replacement_plot: Plot = Plot::new()
+                .line(&[0.0, 1.0], &[0.0, 1.0])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    render_test_surface(&view.session);
+                    assert!(view.session.restore_visible_bounds(outlying_view));
+                    render_test_surface(&view.session);
+                    view.set_plot_keep_view(replacement_plot, cx)
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert!((snapshot.visible_bounds.width().abs() - 10.0).abs() < 1e-9);
+                    assert!((snapshot.visible_bounds.height().abs() - 10.0).abs() < 1e-9);
+                    assert_ne!(snapshot.visible_bounds, outlying_view);
+                })
+            });
+        }
+
+        #[test]
+        fn test_set_plot_keep_view_restores_bounds_across_opposite_axis_orientation() {
+            let cx = TestAppContext::single();
+            let initial_plot: Plot = Plot::new()
+                .line(&[0.0, 10.0], &[0.0, 20.0])
+                .xlim(10.0, 0.0)
+                .ylim(20.0, 0.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        initial_plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let reversed_view = viewport_rect(8.0, 2.0, 15.0, 5.0);
+            let replacement_plot: Plot = Plot::new()
+                .line(&[0.0, 100.0], &[0.0, 200.0])
+                .xlim(0.0, 100.0)
+                .ylim(0.0, 200.0)
+                .into();
+
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    render_test_surface(&view.session);
+                    assert!(view.session.restore_visible_bounds(reversed_view));
+                    view.set_plot_keep_view(replacement_plot, cx)
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    render_test_surface(&view.session);
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert_viewport_bounds_close(snapshot.visible_bounds, reversed_view);
+                    assert!(snapshot.visible_bounds.width() < 0.0);
+                    assert!(snapshot.visible_bounds.height() < 0.0);
+                })
+            });
+        }
+
+        #[test]
+        fn test_observable_vector_replacement_keeps_session_and_customized_view() {
+            let cx = TestAppContext::single();
+            let x = Observable::new(vec![0.0, 5.0, 10.0]);
+            let y = Observable::new(vec![0.0, 5.0, 10.0]);
+            let plot: Plot = Plot::new().line_source(x.clone(), y.clone()).into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let custom_view = viewport_rect(2.0, 8.0, 1.0, 9.0);
+            let old_base = cx.update(|cx| {
+                view.update(cx, |view, _| {
+                    view.session
+                        .render_to_surface(SurfaceTarget {
+                            size_px: (320, 240),
+                            scale_factor: 1.0,
+                            time_seconds: 0.0,
+                        })
+                        .expect("initial observable frame should render");
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert!(view.session.restore_visible_bounds(custom_view));
+                    view.interaction_state.last_pointer_px = Some(ViewportPoint::new(3.0, 4.0));
+                    snapshot.base_bounds
+                })
+            });
+
+            {
+                let mut batch = BatchUpdate::new();
+                batch.add(&x);
+                batch.add(&y);
+                x.set(vec![0.0, 10.0, 20.0]);
+                y.set(vec![-10.0, 0.0, 10.0]);
+            }
+
+            cx.update(|cx| {
+                view.update(cx, |view, _| {
+                    view.session
+                        .render_to_surface(SurfaceTarget {
+                            size_px: (320, 240),
+                            scale_factor: 1.0,
+                            time_seconds: 0.0,
+                        })
+                        .expect("updated observable frame should render");
+                })
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert_ne!(snapshot.base_bounds, old_base);
+                    assert_viewport_bounds_close(snapshot.visible_bounds, custom_view);
+                    assert_eq!(
+                        view.interaction_state.last_pointer_px,
+                        Some(ViewportPoint::new(3.0, 4.0))
+                    );
+                    assert!(!view.subscription.is_empty());
+                })
+            });
+            assert_eq!(x.subscriber_count(), 2);
+            assert_eq!(y.subscriber_count(), 2);
+        }
+
+        #[test]
+        fn test_observable_replacement_keeps_customized_wide_log_view() {
+            let cx = TestAppContext::single();
+            let x = Observable::new(vec![1.0, 1e15]);
+            let y = Observable::new(vec![0.0, 1.0]);
+            let plot: Plot = Plot::new()
+                .line_source(x.clone(), y.clone())
+                .xscale(AxisScale::Log)
+                .xlim(1.0, 1e15)
+                .ylim(0.0, 1.0)
+                .into();
+            let view = cx.update(|cx| {
+                cx.new(|cx| {
+                    RuvizPlot::from_options_impl(
+                        plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+            let custom_view = viewport_rect(10.0, 1e15, 0.0, 1.0);
+
+            cx.update(|cx| {
+                view.update(cx, |view, _| {
+                    render_test_surface(&view.session);
+                    assert!(view.session.restore_visible_bounds(custom_view));
+                })
+            });
+
+            {
+                let mut batch = BatchUpdate::new();
+                batch.add(&x);
+                batch.add(&y);
+                x.set(vec![1.0, 1e16]);
+                y.set(vec![0.0, 1.0]);
+            }
+
+            cx.update(|cx| {
+                view.update(cx, |view, _| render_test_surface(&view.session));
+            });
+
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    let snapshot = view.session.viewport_snapshot().unwrap();
+                    assert!(!viewport_bounds_materially_differ(
+                        snapshot.visible_bounds,
+                        custom_view,
+                        &AxisScale::Log,
+                        &AxisScale::Linear,
+                    ));
+                    assert!(viewport_bounds_materially_differ(
+                        snapshot.visible_bounds,
+                        snapshot.base_bounds,
+                        &AxisScale::Log,
+                        &AxisScale::Linear,
+                    ));
+                })
+            });
+        }
+
+        #[test]
+        fn test_viewport_customization_comparison_ignores_roundoff() {
+            let base = viewport_rect(0.0, 100.0, -50.0, 50.0);
+            let roundoff = viewport_rect(5e-11, 100.0 - 5e-11, -50.0, 50.0);
+            let customized = viewport_rect(0.01, 99.99, -50.0, 50.0);
+            let reversed = viewport_rect(100.0, 0.0, -50.0, 50.0);
+
+            assert!(!viewport_bounds_materially_differ(
+                base,
+                roundoff,
+                &AxisScale::Linear,
+                &AxisScale::Linear,
+            ));
+            assert!(viewport_bounds_materially_differ(
+                base,
+                customized,
+                &AxisScale::Linear,
+                &AxisScale::Linear,
+            ));
+            assert!(viewport_bounds_materially_differ(
+                reversed,
+                base,
+                &AxisScale::Linear,
+                &AxisScale::Linear,
+            ));
+        }
+
+        #[test]
         fn test_replace_session_retires_cached_frame() {
             let cx = TestAppContext::single();
             let focus_handle = cx.update(|cx| cx.focus_handle());
@@ -2189,7 +3030,7 @@ mod platform_impl {
                     last_pointer_px: Some(ViewportPoint::new(2.0, 2.0)),
                     active_drag: ActiveDrag::LeftPan {
                         anchor_px: ViewportPoint::new(1.0, 1.0),
-                        anchor_window: point(px(1.0), px(1.0)),
+                        anchor_window: Point::new(px(1.0), px(1.0)),
                         last_px: ViewportPoint::new(2.0, 2.0),
                         crossed_threshold: true,
                         click_eligible: false,

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -112,6 +112,24 @@ pub struct InteractiveViewportSnapshot {
     pub selected_count: usize,
 }
 
+/// Current interactive view bounds and their configured axis scales.
+///
+/// Unlike [`InteractiveViewportSnapshot`], this snapshot reads only the
+/// session's current pending view state and immutable scale configuration. It
+/// does not require layout or render geometry, and therefore may be used before
+/// the first render or after input whose result has not yet been displayed.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct InteractiveViewBoundsSnapshot {
+    /// The session's current base bounds.
+    pub base_bounds: ViewportRect,
+    /// The session's current pending visible bounds.
+    pub visible_bounds: ViewportRect,
+    /// The configured X-axis scale used to interpret the bounds.
+    pub x_scale: AxisScale,
+    /// The configured Y-axis scale used to interpret the bounds.
+    pub y_scale: AxisScale,
+}
+
 const MIN_ZOOM_LEVEL: f64 = 0.1;
 const MAX_ZOOM_LEVEL: f64 = 100.0;
 const VIEWPORT_EPSILON: f64 = 1e-9;
@@ -474,6 +492,7 @@ struct SessionState {
     data_bounds: DataBounds,
     base_bounds: DataBounds,
     visible_bounds: DataBounds,
+    pending_visible_restore: Option<DataBounds>,
     zoom_level: f64,
     pan_offset: ViewportPoint,
     hovered: Option<HitResult>,
@@ -498,6 +517,7 @@ impl Default for SessionState {
             data_bounds: DataBounds::default(),
             base_bounds: DataBounds::default(),
             visible_bounds: DataBounds::default(),
+            pending_visible_restore: None,
             zoom_level: 1.0,
             pan_offset: ViewportPoint::default(),
             hovered: None,
@@ -1496,6 +1516,7 @@ impl InteractivePlotSession {
             PlotInputEvent::ResetView => {
                 state.brush_anchor = None;
                 state.brushed_region = None;
+                state.pending_visible_restore = None;
                 state.visible_bounds = state.base_bounds;
                 sync_legacy_viewport_fields(
                     &mut state,
@@ -1823,6 +1844,26 @@ impl InteractivePlotSession {
         })
     }
 
+    /// Returns the current pending base and visible view bounds.
+    ///
+    /// This state-only snapshot does not require layout or render geometry. Its
+    /// bounds reflect input and restoration changes immediately, even when the
+    /// latest displayed frame still uses older bounds.
+    pub fn view_bounds_snapshot(&self) -> InteractiveViewBoundsSnapshot {
+        let state = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned");
+        let plot = self.inner.prepared.plot();
+        InteractiveViewBoundsSnapshot {
+            base_bounds: data_bounds_to_viewport_rect(state.base_bounds),
+            visible_bounds: data_bounds_to_viewport_rect(state.visible_bounds),
+            x_scale: plot.layout.x_scale.clone(),
+            y_scale: plot.layout.y_scale.clone(),
+        }
+    }
+
     /// Restores the visible bounds for the interactive viewport.
     pub fn restore_visible_bounds(&self, bounds: ViewportRect) -> bool {
         let next_visible = DataBounds::from_viewport_rect(bounds);
@@ -1851,22 +1892,70 @@ impl InteractivePlotSession {
             .lock()
             .expect("InteractivePlotSession state lock poisoned");
         self.begin_mutation();
-        let next_visible = normalize_visible_bounds(
+        let Some(next_visible) = normalize_visible_bounds(
             next_visible,
             state.base_bounds,
             &plot.layout.x_scale,
             &plot.layout.y_scale,
-        );
-        if bounds_close(state.visible_bounds, next_visible) {
+        ) else {
+            return false;
+        };
+        if !bounds_have_extent(next_visible)
+            || plot
+                .layout
+                .x_scale
+                .validate_range(next_visible.x_min, next_visible.x_max)
+                .is_err()
+            || plot
+                .layout
+                .y_scale
+                .validate_range(next_visible.y_min, next_visible.y_max)
+                .is_err()
+        {
+            return false;
+        }
+        if scaled_bounds_close(
+            state.visible_bounds,
+            next_visible,
+            state.base_bounds,
+            &plot.layout.x_scale,
+            &plot.layout.y_scale,
+        ) {
             return false;
         }
 
-        set_visible_bounds(
-            &mut state,
-            next_visible,
-            &plot.layout.x_scale,
-            &plot.layout.y_scale,
-        );
+        state.pending_visible_restore = None;
+        state.visible_bounds = next_visible;
+        sync_legacy_viewport_fields(&mut state, &plot.layout.x_scale, &plot.layout.y_scale);
+        drop(state);
+        self.mark_dirty(DirtyDomain::Data);
+        self.mark_dirty(DirtyDomain::Overlay);
+        true
+    }
+
+    /// Queues visible bounds to be restored after the next data or temporal refresh.
+    ///
+    /// This is intended for adapters that replace a session and need the replacement
+    /// plot's current-time data bounds to be resolved before normalization.
+    #[doc(hidden)]
+    pub fn defer_visible_bounds_restore(&self, bounds: ViewportRect) -> bool {
+        let requested = DataBounds::from_viewport_rect(bounds);
+        if !bounds_have_extent(requested) {
+            return false;
+        }
+
+        let plot = self.inner.prepared.plot();
+        if !bounds_are_valid_for_scales(requested, &plot.layout.x_scale, &plot.layout.y_scale) {
+            return false;
+        }
+
+        let mut state = self
+            .inner
+            .state
+            .lock()
+            .expect("InteractivePlotSession state lock poisoned");
+        self.begin_mutation();
+        state.pending_visible_restore = Some(requested);
         drop(state);
         self.mark_dirty(DirtyDomain::Data);
         self.mark_dirty(DirtyDomain::Overlay);
@@ -1938,7 +2027,29 @@ impl InteractivePlotSession {
                     .unwrap_or(state.data_bounds);
                 state.data_bounds = next_data_bounds;
                 state.base_bounds = constraints.apply(next_data_bounds);
-                if bounds_close(previous_visible, previous_base) {
+                let pending_visible_restore = state.pending_visible_restore.take();
+                if let Some(requested) = pending_visible_restore {
+                    state.visible_bounds = normalize_visible_bounds(
+                        requested,
+                        state.base_bounds,
+                        &source_plot.layout.x_scale,
+                        &source_plot.layout.y_scale,
+                    )
+                    .filter(|bounds| {
+                        bounds_are_valid_for_scales(
+                            *bounds,
+                            &source_plot.layout.x_scale,
+                            &source_plot.layout.y_scale,
+                        )
+                    })
+                    .unwrap_or(state.base_bounds);
+                } else if scaled_bounds_close(
+                    previous_visible,
+                    previous_base,
+                    previous_base,
+                    &source_plot.layout.x_scale,
+                    &source_plot.layout.y_scale,
+                ) {
                     state.visible_bounds = state.base_bounds;
                 } else {
                     state.visible_bounds = normalize_visible_bounds(
@@ -1946,7 +2057,15 @@ impl InteractivePlotSession {
                         state.base_bounds,
                         &source_plot.layout.x_scale,
                         &source_plot.layout.y_scale,
-                    );
+                    )
+                    .filter(|bounds| {
+                        bounds_are_valid_for_scales(
+                            *bounds,
+                            &source_plot.layout.x_scale,
+                            &source_plot.layout.y_scale,
+                        )
+                    })
+                    .unwrap_or(state.base_bounds);
                 }
                 sync_legacy_viewport_fields(
                     &mut state,
@@ -2747,6 +2866,50 @@ fn bounds_close(a: DataBounds, b: DataBounds) -> bool {
         && axis_bounds_close((a.y_min, a.y_max), (b.y_min, b.y_max))
 }
 
+fn scaled_bounds_close(
+    a: DataBounds,
+    b: DataBounds,
+    base: DataBounds,
+    x_scale: &AxisScale,
+    y_scale: &AxisScale,
+) -> bool {
+    scaled_axis_bounds_close(
+        (a.x_min, a.x_max),
+        (b.x_min, b.x_max),
+        (base.x_min, base.x_max),
+        x_scale,
+    ) && scaled_axis_bounds_close(
+        (a.y_min, a.y_max),
+        (b.y_min, b.y_max),
+        (base.y_min, base.y_max),
+        y_scale,
+    )
+}
+
+fn scaled_axis_bounds_close(
+    a: (f64, f64),
+    b: (f64, f64),
+    base: (f64, f64),
+    scale: &AxisScale,
+) -> bool {
+    const NORMALIZED_TOLERANCE: f64 = 1e-12;
+
+    if (a.1 - a.0).is_sign_negative() != (b.1 - b.0).is_sign_negative() {
+        return false;
+    }
+
+    let a_start = scale.normalized_position(a.0, base.0, base.1);
+    let a_end = scale.normalized_position(a.1, base.0, base.1);
+    let b_start = scale.normalized_position(b.0, base.0, base.1);
+    let b_end = scale.normalized_position(b.1, base.0, base.1);
+    a_start.is_finite()
+        && a_end.is_finite()
+        && b_start.is_finite()
+        && b_end.is_finite()
+        && (a_start - b_start).abs() <= NORMALIZED_TOLERANCE
+        && (a_end - b_end).abs() <= NORMALIZED_TOLERANCE
+}
+
 fn axis_bounds_close(a: (f64, f64), b: (f64, f64)) -> bool {
     let tolerance = (a.1 - a.0).abs().max((b.1 - b.0).abs()) * 1e-12;
     (a.0 == b.0 || (a.0 - b.0).abs() <= tolerance) && (a.1 == b.1 || (a.1 - b.1).abs() <= tolerance)
@@ -2765,19 +2928,33 @@ fn normalize_axis_bounds(
     bounds: (f64, f64),
     base_bounds: (f64, f64),
     scale: &AxisScale,
-) -> (f64, f64) {
+) -> Option<(f64, f64)> {
     let start = scale.normalized_position(bounds.0, base_bounds.0, base_bounds.1);
     let end = scale.normalized_position(bounds.1, base_bounds.0, base_bounds.1);
-    let center = (start + end) * 0.5;
-    let direction = direction_for_span(end - start, 1.0);
-    let span = (end - start)
+    if !start.is_finite() || !end.is_finite() {
+        return None;
+    }
+
+    let center = start * 0.5 + end * 0.5;
+    let half_span = end * 0.5 - start * 0.5;
+    if !center.is_finite() || !half_span.is_finite() {
+        return None;
+    }
+
+    let direction = direction_for_span(half_span, 1.0);
+    let half_span = half_span
         .abs()
-        .clamp(1.0 / MAX_ZOOM_LEVEL, 1.0 / MIN_ZOOM_LEVEL)
+        .clamp(0.5 / MAX_ZOOM_LEVEL, 0.5 / MIN_ZOOM_LEVEL)
         * direction;
-    (
-        scale.inverse_normalized_position(center - span * 0.5, base_bounds.0, base_bounds.1),
-        scale.inverse_normalized_position(center + span * 0.5, base_bounds.0, base_bounds.1),
-    )
+    let normalized_start = center - half_span;
+    let normalized_end = center + half_span;
+    if !normalized_start.is_finite() || !normalized_end.is_finite() {
+        return None;
+    }
+
+    let start = scale.inverse_normalized_position(normalized_start, base_bounds.0, base_bounds.1);
+    let end = scale.inverse_normalized_position(normalized_end, base_bounds.0, base_bounds.1);
+    (start.is_finite() && end.is_finite()).then_some((start, end))
 }
 
 fn zoom_axis_bounds(
@@ -2813,18 +2990,18 @@ fn normalize_visible_bounds(
     base_bounds: DataBounds,
     x_scale: &AxisScale,
     y_scale: &AxisScale,
-) -> DataBounds {
+) -> Option<DataBounds> {
     let x = normalize_axis_bounds(
         (bounds.x_min, bounds.x_max),
         (base_bounds.x_min, base_bounds.x_max),
         x_scale,
-    );
+    )?;
     let y = normalize_axis_bounds(
         (bounds.y_min, bounds.y_max),
         (base_bounds.y_min, base_bounds.y_max),
         y_scale,
-    );
-    DataBounds::from_limits(x.0, x.1, y.0, y.1)
+    )?;
+    Some(DataBounds::from_limits(x.0, x.1, y.0, y.1))
 }
 
 fn legacy_viewport_metrics(
@@ -2874,9 +3051,28 @@ fn set_visible_bounds(
     bounds: DataBounds,
     x_scale: &AxisScale,
     y_scale: &AxisScale,
-) {
-    state.visible_bounds = normalize_visible_bounds(bounds, state.base_bounds, x_scale, y_scale);
+) -> bool {
+    let Some(bounds) = normalize_visible_bounds(bounds, state.base_bounds, x_scale, y_scale) else {
+        return false;
+    };
+    if !bounds_are_valid_for_scales(bounds, x_scale, y_scale) {
+        return false;
+    }
+
+    state.pending_visible_restore = None;
+    state.visible_bounds = bounds;
     sync_legacy_viewport_fields(state, x_scale, y_scale);
+    true
+}
+
+fn bounds_are_valid_for_scales(
+    bounds: DataBounds,
+    x_scale: &AxisScale,
+    y_scale: &AxisScale,
+) -> bool {
+    bounds_have_extent(bounds)
+        && x_scale.validate_range(bounds.x_min, bounds.x_max).is_ok()
+        && y_scale.validate_range(bounds.y_min, bounds.y_max).is_ok()
 }
 
 fn direction_for_span(span: f64, fallback: f64) -> f64 {

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -230,6 +230,59 @@ fn test_viewport_snapshot_remains_available_before_first_render() {
 }
 
 #[test]
+fn test_view_bounds_snapshot_is_available_immediately_after_construction() {
+    let plot: Plot = Plot::new()
+        .line(&[1.0, 1000.0], &[-5.0, 5.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .xlim(1000.0, 1.0)
+        .ylim(-5.0, 5.0)
+        .into();
+    let session = plot.prepare_interactive();
+
+    let snapshot = session.view_bounds_snapshot();
+
+    assert_eq!(snapshot.visible_bounds, snapshot.base_bounds);
+    assert_eq!(
+        (snapshot.base_bounds.min.x, snapshot.base_bounds.max.x),
+        (1000.0, 1.0)
+    );
+    assert_eq!(snapshot.x_scale, crate::axes::AxisScale::Log);
+    assert_eq!(snapshot.y_scale, crate::axes::AxisScale::Linear);
+}
+
+#[test]
+fn test_view_bounds_snapshot_reflects_restore_before_next_render() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 10.0], &[0.0, 20.0])
+        .xlim(0.0, 10.0)
+        .ylim(0.0, 20.0)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial frame should render");
+    let displayed_before = session.viewport_snapshot().unwrap().visible_bounds;
+    let restored = ViewportRect {
+        min: ViewportPoint::new(2.0, 4.0),
+        max: ViewportPoint::new(8.0, 16.0),
+    };
+
+    assert!(session.restore_visible_bounds(restored));
+
+    let pending = session.view_bounds_snapshot();
+    assert!(bounds_close(
+        DataBounds::from_viewport_rect(pending.visible_bounds),
+        DataBounds::from_viewport_rect(restored),
+    ));
+    assert_eq!(pending.base_bounds, displayed_before);
+    assert_eq!(
+        session.viewport_snapshot().unwrap().visible_bounds,
+        displayed_before,
+        "the geometry-backed snapshot should still describe the displayed frame"
+    );
+}
+
+#[test]
 fn test_displayed_coordinate_conversion_supports_scales_reversal_and_clamping() {
     let plot: Plot = Plot::new()
         .line(&[1.0, 1000.0], &[-100.0, 100.0])
@@ -919,6 +972,35 @@ fn test_restore_visible_bounds_rejects_invalid_log_domain() {
     }));
     assert_eq!(session.viewport_snapshot().unwrap(), before);
     assert!(!session.dirty_domains().needs_base_render());
+}
+
+#[test]
+fn test_restore_visible_bounds_rejects_extreme_finite_linear_bounds() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .xlim(0.0, 1.0)
+        .ylim(0.0, 1.0)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial linear frame should render");
+    let before = session.view_bounds_snapshot();
+
+    for (x_min, x_max) in [(1e308, 1.1e308), (1.1e308, 1e308)] {
+        assert!(!session.restore_visible_bounds(ViewportRect {
+            min: ViewportPoint::new(x_min, 0.0),
+            max: ViewportPoint::new(x_max, 1.0),
+        }));
+
+        let after = session.view_bounds_snapshot();
+        assert_eq!(after, before);
+        assert!(after.visible_bounds.min.x.is_finite());
+        assert!(after.visible_bounds.max.x.is_finite());
+        assert!(after.visible_bounds.min.y.is_finite());
+        assert!(after.visible_bounds.max.y.is_finite());
+        assert!(!session.dirty_domains().needs_base_render());
+    }
 }
 
 #[test]

--- a/src/core/plot/mod.rs
+++ b/src/core/plot/mod.rs
@@ -510,9 +510,9 @@ pub use data::{IntoPlotData, PlotData, PlotSource, PlotText, ReactiveValue};
 pub use image::Image;
 pub use interactive_session::{
     DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, ImageTarget, InteractiveFrame,
-    InteractiveFrameWithGeneration, InteractivePlotSession, InteractiveViewportSnapshot,
-    LayerRenderState, PlotInputEvent, QualityPolicy, RenderTargetKind, SurfaceCapability,
-    SurfaceTarget, ViewportPoint, ViewportRect,
+    InteractiveFrameWithGeneration, InteractivePlotSession, InteractiveViewBoundsSnapshot,
+    InteractiveViewportSnapshot, LayerRenderState, PlotInputEvent, QualityPolicy, RenderTargetKind,
+    SurfaceCapability, SurfaceTarget, ViewportPoint, ViewportRect,
 };
 pub use layout_manager::LayoutManager;
 pub use prepared::{PreparedPlot, ReactiveSubscription};

--- a/src/core/plot/series_api.rs
+++ b/src/core/plot/series_api.rs
@@ -162,6 +162,13 @@ impl Plot {
     }
 
     /// Add a line series from source-backed data.
+    ///
+    /// With `Observable<Vec<f64>>` inputs, [`Observable::set`](crate::data::Observable::set)
+    /// replaces a complete coordinate vector without rebuilding the plot or its
+    /// interactive session. A [`BatchUpdate`](crate::data::BatchUpdate) defers
+    /// each observable's notifications until guard drop and coalesces repeated
+    /// changes within that observable. Separate observables still flush
+    /// independently; the guard is not a shared data lock.
     pub fn line_source<X, Y>(
         self,
         x_data: X,
@@ -306,6 +313,13 @@ impl Plot {
     }
 
     /// Add a scatter series from source-backed data.
+    ///
+    /// With `Observable<Vec<f64>>` inputs, [`Observable::set`](crate::data::Observable::set)
+    /// replaces a complete coordinate vector without rebuilding the plot or its
+    /// interactive session. A [`BatchUpdate`](crate::data::BatchUpdate) defers
+    /// each observable's notifications until guard drop and coalesces repeated
+    /// changes within that observable. Separate observables still flush
+    /// independently; the guard is not a shared data lock.
     pub fn scatter_source<X, Y>(
         self,
         x_data: X,


### PR DESCRIPTION
## Summary

- add `RuvizPlot::set_plot_keep_view` while keeping ordinary `set_plot` fully destructive
- preserve only a materially customized visible viewport; untouched views adopt replacement natural bounds
- defer restoration until replacement data bounds resolve, including temporal plots at nonzero time
- normalize or reject incompatible log, reversed-axis, extreme, and zoom-limited bounds through the core session path
- preserve customized wide-log views during reactive `Observable` updates
- document `Observable<Vec<f64>>::set` as the preferred whole-series update path and refresh `observable_embed`

## Stack

This PR is intentionally stacked on #110 (`gpui/coordinate-events`) and targets that branch. After #110 merges, it should be rebased and retargeted to `main`.

## Runtime verification

A temporary public-API GPUI verifier app exercised seven scenarios in a real window:

1. customized view `[2,8] × [1,9]` survived replacement base `[0,100] × [0,100]`
2. untouched view adopted replacement base `[100,200] × [-5,5]`
3. temporal replacement restored Y `[20,80]` after time-100 bounds resolved from `[0,100]`
4. `Observable<Vec<f64>>::set` kept the same GPUI entity and customized view while base bounds updated
5. wide-log custom X `[10,1e15]` survived a reactive base update to `[1,1e16]`
6. reversed X/Y orientation and values survived replacement
7. ordinary `set_plot` reset the viewport, selection count, and home view

All seven scenarios passed. Pointer/drag/hover internals have no public state getter, so the runtime verifier covered their reset indirectly through the public viewport/selection/home behavior; focused unit tests cover the complete internal reset.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p ruviz-gpui` — 43 passed
- `cargo test --lib core::plot::interactive_session::tests` — 73 passed
- `cargo check -p ruviz-gpui --example observable_embed`
- `cargo clippy -p ruviz-gpui --all-targets -- -D warnings`
- `cargo test --doc` — 146 passed, 106 ignored
- `make check-docs`
- repeated Codex review; wide-log reactive retention and temporal restoration findings were fixed, final review reported no actionable issues

The existing Cargo/clippy MSRV configuration mismatch warning remains unchanged.

Closes #103
Part of #97
