### PR TITLE
Add atomic StreamingXY::replace with full-redraw acknowledgement

### DIFF
--- a/examples/streaming_example.rs
+++ b/examples/streaming_example.rs
@@ -65,7 +65,24 @@ fn basic_streaming() {
     plot.save("generated/examples/streaming_basic.png")
         .expect("Failed to save plot");
 
-    println!("Saved: generated/examples/streaming_basic.png\n");
+    // A scrub supplies a complete frame: replace it atomically instead of
+    // exposing an intermediate clear followed by a batch append.
+    stream.replace((20..25).map(|i| (i as f64, (i * i) as f64)));
+    println!("Scrubbed to full frame: {:?}", stream.read_x());
+    println!("Replacement render state: {:?}", stream.render_state());
+
+    Plot::new()
+        .line_streaming(&stream)
+        .color(Color::new(31, 119, 180))
+        .title("Atomically Replaced Streaming Frame")
+        .xlabel("X")
+        .ylabel("Y")
+        .save("generated/examples/streaming_replaced.png")
+        .expect("Failed to save replaced frame");
+    println!("After replacement render: {:?}", stream.render_state());
+    println!(
+        "Saved: generated/examples/streaming_basic.png and generated/examples/streaming_replaced.png\n"
+    );
 }
 
 /// Demonstrate ring buffer wrap-around behavior

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use crate::core::IntoPlot;
-use crate::data::{Observable, StreamingBuffer, StreamingXY, signal};
+use crate::data::{Observable, StreamingBuffer, StreamingRenderState, StreamingXY, signal};
 use crate::prelude::Plot;
 use crate::render::{Color, MarkerStyle};
 use std::sync::{Arc, atomic::Ordering};
@@ -2027,6 +2027,42 @@ fn test_streaming_surface_render_falls_back_after_wraparound() {
 }
 
 #[test]
+fn test_streaming_surface_render_falls_back_and_acknowledges_replacement() {
+    let stream = StreamingXY::new(8);
+    stream.push_many([(0.0, 0.0), (1.0, 0.5), (2.0, 1.0)]);
+    let plot: Plot = Plot::new()
+        .line_streaming(&stream)
+        .xlim(0.0, 6.0)
+        .ylim(-1.0, 2.0)
+        .into();
+    let session = plot.prepare_interactive();
+    session
+        .render_to_surface(render_target())
+        .expect("initial replacement stream frame should render");
+
+    stream.replace([(3.0, 1.25), (4.0, 0.75), (5.0, 0.25)]);
+    assert_eq!(
+        stream.render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+    let rerendered = session
+        .render_to_surface(render_target())
+        .expect("replacement stream frame should render");
+
+    assert!(!rerendered.layer_state.used_incremental_data);
+    assert_eq!(stream.render_state(), StreamingRenderState::Unchanged);
+
+    stream.replace(std::iter::empty());
+    let cleared = session
+        .render_to_surface(render_target())
+        .expect("empty replacement stream frame should render");
+    assert!(cleared.layer_state.base_dirty);
+    assert!(!cleared.layer_state.used_incremental_data);
+    assert_ne!(cleared.layers.base.pixels, rerendered.layers.base.pixels);
+    assert_eq!(stream.render_state(), StreamingRenderState::Unchanged);
+}
+
+#[test]
 fn test_interactive_full_render_acknowledges_generic_streaming_buffers() {
     let x = StreamingBuffer::new(16);
     let y = StreamingBuffer::new(16);
@@ -2045,6 +2081,52 @@ fn test_interactive_full_render_acknowledges_generic_streaming_buffers() {
 
     assert_eq!(x.appended_since_mark(), 0);
     assert_eq!(y.appended_since_mark(), 0);
+}
+
+#[test]
+fn test_interactive_generic_streaming_buffers_render_after_clear() {
+    let x = StreamingBuffer::new(16);
+    let y = StreamingBuffer::new(16);
+    x.push_many(vec![0.0, 1.0, 2.0]);
+    y.push_many(vec![0.0, 0.5, 1.0]);
+    let plot: Plot = Plot::new().line_source(x.clone(), y.clone()).into();
+    let session = plot.prepare_interactive();
+
+    session
+        .render_to_surface(render_target())
+        .expect("initial generic streaming frame should render");
+
+    x.clear();
+    y.clear();
+    session
+        .render_to_surface(render_target())
+        .expect("cleared generic streaming frame should render");
+}
+
+#[test]
+fn test_viewport_snapshot_on_initially_empty_stream() {
+    let stream = StreamingXY::new(8);
+    let plot: Plot = Plot::new().line_streaming(&stream).into();
+    let session = plot.prepare_interactive();
+    session.resize((320, 240), 1.0);
+
+    let snapshot = session
+        .viewport_snapshot()
+        .expect("viewport snapshot should succeed before any data arrives");
+    assert!(snapshot.base_bounds.min.x.is_finite());
+    assert!(snapshot.base_bounds.max.x > snapshot.base_bounds.min.x);
+    assert!(snapshot.base_bounds.max.y > snapshot.base_bounds.min.y);
+
+    stream.push_many([(0.0, 0.0), (1.0, 1.0)]);
+    stream.replace(std::iter::empty());
+    let after_empty_replace = session
+        .viewport_snapshot()
+        .expect("viewport snapshot should succeed after replace(empty)");
+    assert!(after_empty_replace.base_bounds.min.x.is_finite());
+
+    session
+        .render_to_surface(render_target())
+        .expect("empty stream should still render a frame");
 }
 
 #[test]

--- a/src/core/plot/mixed_render.rs
+++ b/src/core/plot/mixed_render.rs
@@ -193,7 +193,17 @@ impl Plot {
     }
 
     pub(super) fn empty_cartesian_bounds(&self) -> (f64, f64, f64, f64) {
-        self.apply_manual_axis_limits((0.0, 1.0, 0.0, 1.0))
+        let x = if matches!(&self.layout.x_scale, crate::axes::AxisScale::Log) {
+            (1.0, 10.0)
+        } else {
+            (0.0, 1.0)
+        };
+        let y = if matches!(&self.layout.y_scale, crate::axes::AxisScale::Log) {
+            (1.0, 10.0)
+        } else {
+            (0.0, 1.0)
+        };
+        self.apply_manual_axis_limits((x.0, x.1, y.0, y.1))
     }
 
     pub(super) fn effective_main_panel_bounds_for_series(

--- a/src/core/plot/parallel_render.rs
+++ b/src/core/plot/parallel_render.rs
@@ -1631,6 +1631,10 @@ impl Plot {
             &mut y_max,
         );
 
+        if !x_min.is_finite() || !x_max.is_finite() || !y_min.is_finite() || !y_max.is_finite() {
+            return Ok(self.empty_cartesian_bounds());
+        }
+
         // Handle edge cases
         (x_min, x_max) = crate::axes::expand_degenerate_range(x_min, x_max, &self.layout.x_scale);
         (y_min, y_max) = crate::axes::expand_degenerate_range(y_min, y_max, &self.layout.y_scale);
@@ -1838,6 +1842,10 @@ impl Plot {
                     _ => unreachable!("PlotData-backed series resolve to dedicated variants"),
                 },
             }
+        }
+
+        if !x_min.is_finite() || !x_max.is_finite() || !y_min.is_finite() || !y_max.is_finite() {
+            return Ok(self.empty_cartesian_bounds());
         }
 
         (x_min, x_max) = crate::axes::expand_degenerate_range(x_min, x_max, &self.layout.x_scale);
@@ -2069,6 +2077,10 @@ impl Plot {
                     y_max = label_margin;
                 }
             }
+        }
+
+        if !x_min.is_finite() || !x_max.is_finite() || !y_min.is_finite() || !y_max.is_finite() {
+            return Ok(self.empty_cartesian_bounds());
         }
 
         (x_min, x_max) = crate::axes::expand_degenerate_range(x_min, x_max, &self.layout.x_scale);

--- a/src/core/plot/prepared.rs
+++ b/src/core/plot/prepared.rs
@@ -438,7 +438,7 @@ impl From<Plot> for PreparedPlot {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data::{Observable, StreamingXY};
+    use crate::data::{Observable, StreamingRenderState, StreamingXY};
     use crate::render::Color;
     use std::sync::{
         Arc,
@@ -678,6 +678,64 @@ mod tests {
         stream.push(1.0, 1.0);
 
         assert_eq!(hits.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_prepared_plot_full_redraw_acknowledges_streaming_replacement() {
+        let stream = StreamingXY::new(32);
+        stream.push_many([(0.0, 0.0), (1.0, 1.0)]);
+        let plot: Plot = Plot::new()
+            .line_streaming(&stream)
+            .xlim(0.0, 4.0)
+            .ylim(0.0, 16.0)
+            .into();
+        let prepared = plot.prepare();
+        prepared
+            .render_frame((320, 240), 1.0, 0.0)
+            .expect("initial prepared streaming frame should render");
+
+        stream.replace([(2.0, 4.0), (3.0, 9.0), (4.0, 16.0)]);
+        assert_eq!(
+            stream.render_state(),
+            StreamingRenderState::FullRedrawRequired
+        );
+
+        prepared
+            .render_frame((320, 240), 1.0, 0.0)
+            .expect("prepared replacement frame should render");
+        assert_eq!(stream.render_state(), StreamingRenderState::Unchanged);
+
+        stream.replace(std::iter::empty());
+        assert_eq!(
+            stream.render_state(),
+            StreamingRenderState::FullRedrawRequired
+        );
+        prepared
+            .render_frame((320, 240), 1.0, 0.0)
+            .expect("empty replacement frame should render");
+        assert_eq!(stream.render_state(), StreamingRenderState::Unchanged);
+    }
+
+    #[test]
+    fn test_prepared_plot_renders_empty_streaming_replacement_on_log_axes() {
+        let stream = StreamingXY::new(32);
+        stream.push_many([(1.0, 1.0), (10.0, 10.0)]);
+        let plot: Plot = Plot::new()
+            .line_streaming(&stream)
+            .xscale(crate::axes::AxisScale::Log)
+            .yscale(crate::axes::AxisScale::Log)
+            .into();
+        let prepared = plot.prepare();
+        prepared
+            .render_frame((320, 240), 1.0, 0.0)
+            .expect("initial logarithmic stream frame should render");
+
+        stream.replace(std::iter::empty());
+        prepared
+            .render_frame((320, 240), 1.0, 0.0)
+            .expect("empty logarithmic replacement should render");
+
+        assert_eq!(stream.render_state(), StreamingRenderState::Unchanged);
     }
 
     #[test]

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -245,7 +245,7 @@ impl Plot {
         }
 
         if !frame.series.is_empty() {
-            Self::validate_resolved_series(&frame.series)?;
+            self.validate_resolved_series(&frame.series)?;
         }
 
         let total_points = Self::calculate_total_points_from_resolved(&frame.series);
@@ -591,7 +591,7 @@ impl Plot {
         }
 
         if !frame.series.is_empty() {
-            Self::validate_resolved_series(&frame.series)?;
+            self.validate_resolved_series(&frame.series)?;
         }
 
         let total_points = Self::calculate_total_points_from_resolved(&frame.series);
@@ -2324,7 +2324,7 @@ impl Plot {
 
         self.validate_runtime_environment()?;
         if !frame.series.is_empty() {
-            Self::validate_resolved_series(&frame.series)?;
+            self.validate_resolved_series(&frame.series)?;
         }
 
         let (width_px, height_px) = self.config_canvas_size();

--- a/src/core/plot/series_internal.rs
+++ b/src/core/plot/series_internal.rs
@@ -1831,7 +1831,10 @@ impl Plot {
         Ok(())
     }
 
-    pub(super) fn validate_resolved_series(series_list: &[ResolvedSeries<'_>]) -> Result<()> {
+    pub(super) fn validate_resolved_series(
+        &self,
+        series_list: &[ResolvedSeries<'_>],
+    ) -> Result<()> {
         if series_list.is_empty() {
             return Err(PlottingError::NoDataSeries);
         }
@@ -1846,7 +1849,16 @@ impl Plot {
                             series_index: Some(idx),
                         });
                     }
-                    if x.is_empty() {
+                    let is_streaming = self.series_mgr.series.get(idx).is_some_and(|series| {
+                        matches!(
+                            &series.series_type,
+                            SeriesType::Line { x_data, y_data }
+                                | SeriesType::Scatter { x_data, y_data }
+                                if matches!(x_data, PlotData::Streaming(_))
+                                    && matches!(y_data, PlotData::Streaming(_))
+                        )
+                    });
+                    if x.is_empty() && !is_streaming {
                         return Err(PlottingError::EmptyDataSet);
                     }
                     PlottingError::validate_data(x)?;

--- a/src/data/observable.rs
+++ b/src/data/observable.rs
@@ -1303,8 +1303,10 @@ pub struct StreamingBuffer<T> {
     write_pos: Arc<std::sync::atomic::AtomicUsize>,
     /// Total elements written (used to determine if full)
     total_written: Arc<AtomicU64>,
-    /// Number of explicit clears, used by paired legacy-lane reconciliation.
+    /// Number of explicit clears or full replacements.
     clear_generation: Arc<AtomicU64>,
+    /// Highest clear generation acknowledged by a completed render.
+    rendered_clear_generation: Arc<AtomicU64>,
     /// Version counter for change detection
     version: Arc<AtomicU64>,
     /// Append count since last mark_rendered()
@@ -1346,6 +1348,7 @@ impl<T: Clone> StreamingBuffer<T> {
             write_pos: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             total_written: Arc::new(AtomicU64::new(0)),
             clear_generation: Arc::new(AtomicU64::new(0)),
+            rendered_clear_generation: Arc::new(AtomicU64::new(0)),
             version: Arc::new(AtomicU64::new(0)),
             appended_since_render: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             rendered_through: Arc::new(AtomicU64::new(0)),
@@ -1405,6 +1408,24 @@ impl<T: Clone> StreamingBuffer<T> {
         let appended = self.appended_since_render.load(Ordering::Relaxed);
         self.appended_since_render
             .store(appended.saturating_add(count), Ordering::Release);
+    }
+
+    fn replace_locked(&self, values: Vec<T>) {
+        let retain_from = values.len().saturating_sub(self.capacity);
+        let retained = values.len() - retain_from;
+        let mut data = self.data.write().expect("Lock poisoned");
+        for slot in data.iter_mut() {
+            *slot = None;
+        }
+        for (slot, value) in data.iter_mut().zip(values.into_iter().skip(retain_from)) {
+            *slot = Some(value);
+        }
+        self.write_pos.store(retained, Ordering::Release);
+        self.total_written.store(retained as u64, Ordering::Release);
+        self.appended_since_render
+            .store(retained, Ordering::Release);
+        self.rendered_through.store(0, Ordering::Release);
+        self.clear_generation.fetch_add(1, Ordering::Release);
     }
 
     /// Get all valid data in order (oldest to newest)
@@ -1525,8 +1546,11 @@ impl<T: Clone> StreamingBuffer<T> {
         }
 
         let _data = self.data.read().expect("Lock poisoned");
+        let generation = self.clear_generation.load(Ordering::Acquire);
         let total = self.total_written.load(Ordering::Acquire);
         self.rendered_through.store(total, Ordering::Release);
+        self.rendered_clear_generation
+            .store(generation, Ordering::Release);
         self.appended_since_render.store(0, Ordering::Release);
     }
 
@@ -1541,6 +1565,8 @@ impl<T: Clone> StreamingBuffer<T> {
             .rendered_through
             .fetch_max(total, Ordering::AcqRel)
             .max(total);
+        self.rendered_clear_generation
+            .store(generation, Ordering::Release);
         let pending = current_total.saturating_sub(acknowledged.min(current_total));
         self.appended_since_render.store(
             usize::try_from(pending).unwrap_or(usize::MAX),
@@ -1554,6 +1580,12 @@ impl<T: Clone> StreamingBuffer<T> {
 
     /// Describe whether the current buffer changes can be rendered incrementally.
     pub fn render_state(&self) -> StreamingRenderState {
+        if self.clear_generation.load(Ordering::Acquire)
+            != self.rendered_clear_generation.load(Ordering::Acquire)
+        {
+            return StreamingRenderState::FullRedrawRequired;
+        }
+
         let appended = self.appended_since_render.load(Ordering::Acquire);
         if appended == 0 {
             return StreamingRenderState::Unchanged;
@@ -1690,6 +1722,7 @@ impl<T: Clone> Clone for StreamingBuffer<T> {
             write_pos: Arc::clone(&self.write_pos),
             total_written: Arc::clone(&self.total_written),
             clear_generation: Arc::clone(&self.clear_generation),
+            rendered_clear_generation: Arc::clone(&self.rendered_clear_generation),
             version: Arc::clone(&self.version),
             appended_since_render: Arc::clone(&self.appended_since_render),
             rendered_through: Arc::clone(&self.rendered_through),
@@ -1872,6 +1905,53 @@ impl StreamingXY {
         }
     }
 
+    /// Atomically replace the complete visible X/Y frame.
+    ///
+    /// The input is collected before mutation begins. If it exceeds the buffer
+    /// capacity, only the newest points are retained. Even an empty replacement
+    /// is a single paired mutation and requires a full redraw until the exact
+    /// replacement snapshot is acknowledged.
+    pub fn replace(&self, points: impl IntoIterator<Item = (f64, f64)>) {
+        let mut points: Vec<_> = points.into_iter().collect();
+        let retain_from = points.len().saturating_sub(self.x.capacity());
+        if retain_from > 0 {
+            points.drain(..retain_from);
+        }
+
+        let count = points.len();
+        let x = points.iter().map(|(x, _)| *x).collect();
+        let y = points.iter().map(|(_, y)| *y).collect();
+        let should_dispatch = {
+            let _gate = self.mutation_gate.lock().expect("Mutation gate poisoned");
+            self.reconcile_legacy_lanes_locked();
+            self.x.replace_locked(x);
+            self.run_pair_commit_hook();
+            self.y.replace_locked(y);
+            self.x.increment_version();
+            self.y.increment_version();
+
+            let mut paired_data = self.paired_data.lock().expect("Paired data lock poisoned");
+            paired_data.clear();
+            paired_data.extend(points);
+
+            let mut progress = self.progress.lock().expect("StreamingXY progress poisoned");
+            progress.sequence = progress.sequence.wrapping_add(1);
+            progress.total_written = count as u64;
+            progress.last_clear_sequence = Some(progress.sequence);
+            progress.synced_x_total = self.x.total_written();
+            progress.synced_y_total = self.y.total_written();
+            progress.synced_x_version = self.x.version();
+            progress.synced_y_version = self.y.version();
+            progress.synced_x_clear_generation = self.x.clear_generation.load(Ordering::Acquire);
+            progress.synced_y_clear_generation = self.y.clear_generation.load(Ordering::Acquire);
+            self.sync_lane_watermarks(&progress);
+            self.pair_notifications.queue()
+        };
+        if should_dispatch {
+            self.drain_pair_notifications();
+        }
+    }
+
     fn record_push_locked(&self, count: usize) {
         let mut progress = self.progress.lock().expect("StreamingXY progress poisoned");
         progress.sequence = progress.sequence.wrapping_add(count as u64);
@@ -1984,6 +2064,17 @@ impl StreamingXY {
             && !Self::sequence_after(sequence, progress.sequence)
         {
             progress.rendered_through = sequence;
+        }
+        if progress
+            .last_clear_sequence
+            .is_none_or(|clear| !Self::sequence_after(clear, progress.rendered_through))
+        {
+            self.x
+                .rendered_clear_generation
+                .store(progress.synced_x_clear_generation, Ordering::Release);
+            self.y
+                .rendered_clear_generation
+                .store(progress.synced_y_clear_generation, Ordering::Release);
         }
         self.sync_lane_watermarks(&progress);
     }

--- a/src/data/observable/tests.rs
+++ b/src/data/observable/tests.rs
@@ -714,11 +714,19 @@ fn test_streaming_buffer_clear() {
 
     buffer.push_many(vec![1.0, 2.0, 3.0]);
     assert_eq!(buffer.len(), 3);
+    buffer.mark_rendered();
 
     buffer.clear();
     assert!(buffer.is_empty());
     assert_eq!(buffer.len(), 0);
     assert!(buffer.read().is_empty());
+    assert_eq!(
+        buffer.render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+    let (_, captured) = buffer.snapshot_for_render();
+    captured.mark_rendered();
+    assert_eq!(buffer.render_state(), StreamingRenderState::Unchanged);
 }
 
 #[test]
@@ -789,6 +797,262 @@ fn test_streaming_xy_push_many() {
 
     assert_eq!(xy.read_x(), vec![1.0, 2.0, 3.0]);
     assert_eq!(xy.read_y(), vec![10.0, 20.0, 30.0]);
+}
+
+#[test]
+fn test_streaming_xy_replace_updates_the_full_frame_once() {
+    let xy = StreamingXY::new(8);
+    xy.push_many([(1.0, 10.0), (2.0, 20.0)]);
+    xy.mark_rendered();
+    let before = xy.snapshot();
+    let x_version = xy.x().version();
+    let y_version = xy.y().version();
+
+    let x_hits = Arc::new(AtomicUsize::new(0));
+    let y_hits = Arc::new(AtomicUsize::new(0));
+    let pair_hits = Arc::new(AtomicUsize::new(0));
+    for (lane, hits) in [(xy.x(), Arc::clone(&x_hits)), (xy.y(), Arc::clone(&y_hits))] {
+        lane.subscribe(move || {
+            hits.fetch_add(1, AtomicOrdering::Relaxed);
+        });
+    }
+    let pair_hits_for_callback = Arc::clone(&pair_hits);
+    xy.subscribe_paired(move || {
+        pair_hits_for_callback.fetch_add(1, AtomicOrdering::Relaxed);
+    });
+
+    xy.replace([(4.0, 40.0), (5.0, 50.0), (6.0, 60.0)]);
+
+    let replaced = xy.snapshot();
+    assert_eq!(replaced.x(), &[4.0, 5.0, 6.0]);
+    assert_eq!(replaced.y(), &[40.0, 50.0, 60.0]);
+    assert_eq!(replaced.sequence(), before.sequence().wrapping_add(1));
+    assert_eq!(xy.x().version(), x_version.wrapping_add(1));
+    assert_eq!(xy.y().version(), y_version.wrapping_add(1));
+    assert_eq!(x_hits.load(AtomicOrdering::Relaxed), 1);
+    assert_eq!(y_hits.load(AtomicOrdering::Relaxed), 1);
+    assert_eq!(pair_hits.load(AtomicOrdering::Relaxed), 1);
+    assert_eq!(
+        replaced.render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+    assert_eq!(
+        xy.x().render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+    assert_eq!(
+        xy.y().render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+
+    xy.mark_rendered_through(replaced.sequence());
+    assert_eq!(xy.render_state(), StreamingRenderState::Unchanged);
+    assert_eq!(xy.x().render_state(), StreamingRenderState::Unchanged);
+    assert_eq!(xy.y().render_state(), StreamingRenderState::Unchanged);
+}
+
+#[test]
+fn test_streaming_xy_replace_empty_is_one_atomic_clear() {
+    let xy = StreamingXY::new(8);
+    xy.push_many([(1.0, 10.0), (2.0, 20.0)]);
+    xy.mark_rendered();
+    let before = xy.snapshot();
+    let pair_hits = Arc::new(AtomicUsize::new(0));
+    let pair_hits_for_callback = Arc::clone(&pair_hits);
+    xy.subscribe_paired(move || {
+        pair_hits_for_callback.fetch_add(1, AtomicOrdering::Relaxed);
+    });
+
+    xy.replace(std::iter::empty());
+
+    let cleared = xy.snapshot();
+    assert!(cleared.x().is_empty());
+    assert!(cleared.y().is_empty());
+    assert_eq!(cleared.sequence(), before.sequence().wrapping_add(1));
+    assert_eq!(pair_hits.load(AtomicOrdering::Relaxed), 1);
+    assert_eq!(
+        cleared.render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+    assert_eq!(
+        xy.x().render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+    assert_eq!(
+        xy.y().render_state(),
+        StreamingRenderState::FullRedrawRequired
+    );
+    xy.mark_rendered_through(cleared.sequence());
+    assert_eq!(xy.render_state(), StreamingRenderState::Unchanged);
+    assert_eq!(xy.x().render_state(), StreamingRenderState::Unchanged);
+    assert_eq!(xy.y().render_state(), StreamingRenderState::Unchanged);
+}
+
+#[test]
+fn test_streaming_xy_replace_over_capacity_retains_newest_points() {
+    let xy = StreamingXY::new(3);
+
+    xy.replace((1..=5).map(|x| (f64::from(x), f64::from(x * 10))));
+
+    assert_eq!(xy.read_x(), vec![3.0, 4.0, 5.0]);
+    assert_eq!(xy.read_y(), vec![30.0, 40.0, 50.0]);
+    assert_eq!(xy.snapshot().x(), &[3.0, 4.0, 5.0]);
+    xy.push(6.0, 60.0);
+    assert_eq!(xy.read_x(), vec![4.0, 5.0, 6.0]);
+    assert_eq!(xy.read_y(), vec![40.0, 50.0, 60.0]);
+}
+
+#[test]
+fn test_streaming_xy_replace_collects_input_before_mutation_lock() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let xy = StreamingXY::new(8);
+    xy.push(1.0, 10.0);
+    let (collecting_tx, collecting_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let mut next = Some((2.0, 20.0));
+    let points = std::iter::from_fn(move || {
+        let point = next.take()?;
+        collecting_tx
+            .send(())
+            .expect("collection observer should remain alive");
+        release_rx
+            .recv()
+            .expect("input collection should be released");
+        Some(point)
+    });
+
+    let writer_xy = xy.clone();
+    let writer = thread::spawn(move || writer_xy.replace(points));
+    collecting_rx
+        .recv()
+        .expect("replacement should begin collecting input");
+
+    let (snapshot_tx, snapshot_rx) = mpsc::channel();
+    let reader_xy = xy.clone();
+    let reader = thread::spawn(move || {
+        let snapshot = reader_xy.snapshot();
+        snapshot_tx
+            .send((snapshot.x().to_vec(), snapshot.y().to_vec()))
+            .expect("snapshot observer should remain alive");
+    });
+    assert_eq!(
+        snapshot_rx
+            .recv_timeout(Duration::from_millis(250))
+            .expect("input collection must not hold the mutation gate"),
+        (vec![1.0], vec![10.0])
+    );
+
+    release_tx
+        .send(())
+        .expect("replacement collection should still be paused");
+    writer.join().expect("replacement writer should finish");
+    reader.join().expect("snapshot reader should finish");
+    assert_eq!(xy.snapshot().x(), &[2.0]);
+    assert_eq!(xy.snapshot().y(), &[20.0]);
+}
+
+#[test]
+fn test_streaming_xy_older_replace_ack_does_not_clear_newer_replace() {
+    let xy = StreamingXY::new(8);
+    xy.replace([(1.0, 10.0)]);
+    let older = xy.snapshot();
+    xy.replace([(2.0, 20.0), (3.0, 30.0)]);
+    let newer = xy.snapshot();
+
+    xy.mark_rendered_through(older.sequence());
+
+    assert_eq!(xy.render_state(), StreamingRenderState::FullRedrawRequired);
+    assert_eq!(xy.snapshot().rendered_through(), older.sequence());
+    xy.mark_rendered_through(newer.sequence());
+    assert_eq!(xy.render_state(), StreamingRenderState::Unchanged);
+}
+
+#[test]
+fn test_streaming_xy_replace_is_atomic_for_callbacks_and_concurrent_snapshots() {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let xy = StreamingXY::new(8);
+    xy.push(1.0, 10.0);
+    let callback_hits = Arc::new(AtomicUsize::new(0));
+    for lane in [xy.x(), xy.y()] {
+        let xy_for_callback = xy.clone();
+        let callback_hits = Arc::clone(&callback_hits);
+        lane.subscribe(move || {
+            let snapshot = xy_for_callback.snapshot();
+            assert_eq!(snapshot.x(), &[2.0, 3.0, 4.0]);
+            assert_eq!(snapshot.y(), &[20.0, 30.0, 40.0]);
+            assert_eq!(snapshot.x().len(), snapshot.y().len());
+            assert_eq!(xy_for_callback.read_x(), snapshot.x());
+            assert_eq!(xy_for_callback.read_y(), snapshot.y());
+            callback_hits.fetch_add(1, AtomicOrdering::Relaxed);
+        });
+    }
+    let xy_for_callback = xy.clone();
+    let callback_hits_for_pair = Arc::clone(&callback_hits);
+    xy.subscribe_paired(move || {
+        let snapshot = xy_for_callback.snapshot();
+        assert_eq!(snapshot.x().len(), snapshot.y().len());
+        assert_eq!(snapshot.x(), &[2.0, 3.0, 4.0]);
+        assert_eq!(snapshot.y(), &[20.0, 30.0, 40.0]);
+        assert_eq!(xy_for_callback.read_x(), snapshot.x());
+        assert_eq!(xy_for_callback.read_y(), snapshot.y());
+        callback_hits_for_pair.fetch_add(1, AtomicOrdering::Relaxed);
+    });
+
+    let (mid_commit_tx, mid_commit_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    xy.set_pair_commit_hook({
+        let release_rx = Arc::clone(&release_rx);
+        move || {
+            mid_commit_tx
+                .send(())
+                .expect("mid-commit receiver should remain alive");
+            release_rx
+                .lock()
+                .expect("release receiver lock poisoned")
+                .recv()
+                .expect("replacement should be released");
+        }
+    });
+
+    let writer_xy = xy.clone();
+    let writer = thread::spawn(move || {
+        writer_xy.replace([(2.0, 20.0), (3.0, 30.0), (4.0, 40.0)]);
+    });
+    mid_commit_rx
+        .recv()
+        .expect("replacement should pause between lane mutations");
+
+    let (snapshot_tx, snapshot_rx) = mpsc::channel();
+    let reader_xy = xy.clone();
+    let reader = thread::spawn(move || {
+        let snapshot = reader_xy.snapshot();
+        snapshot_tx
+            .send((snapshot.x().to_vec(), snapshot.y().to_vec()))
+            .expect("snapshot receiver should remain alive");
+    });
+    assert!(
+        snapshot_rx
+            .recv_timeout(Duration::from_millis(250))
+            .is_err(),
+        "paired snapshot must block until both replacement lanes commit"
+    );
+
+    release_tx
+        .send(())
+        .expect("replacement writer should still be paused");
+    let (x, y) = snapshot_rx
+        .recv()
+        .expect("snapshot should finish after replacement commits");
+    writer.join().expect("replacement writer should finish");
+    reader.join().expect("snapshot reader should finish");
+    assert_eq!(x, vec![2.0, 3.0, 4.0]);
+    assert_eq!(y, vec![20.0, 30.0, 40.0]);
+    assert_eq!(callback_hits.load(AtomicOrdering::Relaxed), 3);
 }
 
 #[test]


### PR DESCRIPTION
Closes #106
Part of #97

## Summary

Adds a one-call atomic replacement API to `StreamingXY`:

- `StreamingXY::replace(points)` collects input before locking, retains the newest `capacity` points, swaps both lanes and the paired storage under the existing mutation gate, bumps sequence/versions/watermarks, and dispatches a single logical notification cycle after locks are released. It does not compose the public `clear` + `push_many`.
- Replacement — including empty replacement — is a full redraw. Lanes track a `rendered_clear_generation`, so `render_state()` reports `FullRedrawRequired` until the exact replacement snapshot is acknowledged by `mark_rendered` / `mark_rendered_through`.
- Empty streaming plots stay renderable end to end: `validate_resolved_series` permits empty Line/Scatter series when both lanes are `PlotData::Streaming` (covers generic `line_source(x_stream, y_stream)` as well as paired streams), all three data-bounds paths fall back to `empty_cartesian_bounds()` instead of propagating infinite bounds, and the empty fallback is log-safe (`1.0..10.0` per log axis) so empty frames render on log scales and `viewport_snapshot()` works before the first point arrives.

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings` (only the known baseline MSRV mismatch warning: clippy.toml 1.87.0 vs Cargo.toml rust-version 1.92)
- Focused suites: `cargo test --lib -- streaming` (83), `-- observable` (89), `-- prepared` (31), `-- interactive` (66) — all green
- `cargo test --doc` (146 passed), `make check-docs`
- Runtime verifier: replace-with-data → empty replace on log/log axes renders valid frames with correct `FullRedrawRequired → Unchanged` transitions; initially-empty interactive stream on log axes yields finite positive base bounds (`x=[1,10] y=[1,10]`); generic `line_source` lanes render after `clear()`. Rendered PNGs inspected visually.
- Four rounds of independent Codex (gpt-5.6-sol) review; each round's findings fixed and re-verified.

## Known limitation (pre-existing)

The final review round noted that streaming acknowledgement watermarks (`rendered_through` / `appended_since_render`) are shared across clones of a stream, so two independent rendering consumers of the same `StreamingXY` can race acknowledgements and one may incrementally paint onto a stale base. This single-rendering-consumer assumption predates this PR (the same applies to plain `push_many` on main) and is not changed here; scoping acknowledgement per consumer is follow-up material.