### PR TITLE
Add movable interactive annotations

### DIFF
--- a/crates/ruviz-gpui/examples/movable_annotation.rs
+++ b/crates/ruviz-gpui/examples/movable_annotation.rs
@@ -1,0 +1,108 @@
+mod support;
+
+use gpui::{
+    App, Bounds, Context, MouseButton, Render, Window, WindowBounds, WindowOptions, div,
+    prelude::*, px, rgb, size,
+};
+use ruviz::prelude::*;
+use ruviz_gpui::{InteractionOptions, PlotPointerEvent, RuvizPlot, plot_builder};
+use support::{application, exit_on_window_open_failure};
+
+struct MovableAnnotationDemo {
+    plot: gpui::Entity<RuvizPlot>,
+    annotation_id: AnnotationId,
+    annotation_x: f64,
+    _subscription: gpui::Subscription,
+}
+
+impl MovableAnnotationDemo {
+    fn new(_window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let x = (0..200)
+            .map(|index| index as f64 * 0.05)
+            .collect::<Vec<_>>();
+        let y = x.iter().map(|value| value.sin()).collect::<Vec<_>>();
+        let plot: Plot = Plot::new()
+            .line(&x, &y)
+            .title("Drag the red annotation")
+            .xlabel("Hold the left mouse button and move")
+            .into();
+        let interaction = InteractionOptions {
+            pan: false,
+            selection: false,
+            tooltips: false,
+            ..InteractionOptions::default()
+        };
+        let plot = plot_builder(plot)
+            .interactive()
+            .interaction_options(interaction)
+            .build(cx);
+        let annotation_x = 2.5;
+        let annotation_id = plot.update(cx, |plot, cx| {
+            plot.add_annotation(
+                Annotation::vline_styled(annotation_x, Color::RED, 2.5, LineStyle::Solid),
+                cx,
+            )
+            .expect("initial annotation should be valid")
+        });
+
+        let subscription = cx.subscribe(&plot, |this, _, event: &PlotPointerEvent, cx| {
+            if event.mouse_button != Some(MouseButton::Left) {
+                return;
+            }
+            let Some(position) = event.data_position else {
+                return;
+            };
+            let plot = this.plot.clone();
+            let annotation_id = this.annotation_id;
+            if plot
+                .update(cx, |plot, cx| {
+                    plot.update_annotation(
+                        annotation_id,
+                        Annotation::vline_styled(position.x, Color::RED, 2.5, LineStyle::Solid),
+                        cx,
+                    )
+                })
+                .is_ok()
+            {
+                this.annotation_x = position.x;
+                cx.notify();
+            }
+        });
+
+        Self {
+            plot,
+            annotation_id,
+            annotation_x,
+            _subscription: subscription,
+        }
+    }
+}
+
+impl Render for MovableAnnotationDemo {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .size_full()
+            .p_4()
+            .gap_2()
+            .bg(rgb(0xf6f7fb))
+            .child(format!("Dynamic annotation x = {:.3}", self.annotation_x))
+            .child(self.plot.clone())
+    }
+}
+
+fn main() {
+    application().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(900.0), px(640.0)), cx);
+        exit_on_window_open_failure(
+            cx.open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    ..Default::default()
+                },
+                |window, cx| cx.new(|cx| MovableAnnotationDemo::new(window, cx)),
+            ),
+            "movable annotation",
+        );
+        cx.activate(true);
+    });
+}

--- a/crates/ruviz-gpui/src/lib.rs
+++ b/crates/ruviz-gpui/src/lib.rs
@@ -105,10 +105,10 @@ mod platform_impl {
         axes::AxisScale,
         core::plot::Image as RuvizImage,
         core::{
-            FramePacing, FrameStats, HitResult, ImageTarget, InteractivePlotSession,
-            InteractiveViewportSnapshot, Plot, PlotInputEvent, PlottingError, PreparedPlot,
-            QualityPolicy, ReactiveSubscription, RenderTargetKind, Result, SurfaceCapability,
-            SurfaceTarget, ViewportPoint, ViewportRect,
+            Annotation, AnnotationId, FramePacing, FrameStats, HitResult, ImageTarget,
+            InteractivePlotSession, InteractiveViewportSnapshot, Plot, PlotInputEvent,
+            PlottingError, PreparedPlot, QualityPolicy, ReactiveSubscription, RenderTargetKind,
+            Result, SurfaceCapability, SurfaceTarget, ViewportPoint, ViewportRect,
         },
         export::write_rgba_png_atomic,
     };
@@ -918,6 +918,45 @@ mod platform_impl {
             self.session.prepared_plot()
         }
 
+        /// Adds a dynamic annotation to this plot's interactive overlay.
+        pub fn add_annotation(
+            &mut self,
+            annotation: Annotation,
+            cx: &mut Context<Self>,
+        ) -> Result<AnnotationId> {
+            let id = self.session.add_annotation(annotation)?;
+            cx.notify();
+            Ok(id)
+        }
+
+        /// Returns a copy of a dynamic annotation owned by this plot session.
+        pub fn annotation(&self, id: AnnotationId) -> Result<Annotation> {
+            self.session.annotation(id)
+        }
+
+        /// Replaces a dynamic annotation's complete value.
+        pub fn update_annotation(
+            &mut self,
+            id: AnnotationId,
+            annotation: Annotation,
+            cx: &mut Context<Self>,
+        ) -> Result<()> {
+            self.session.update_annotation(id, annotation)?;
+            cx.notify();
+            Ok(())
+        }
+
+        /// Removes a dynamic annotation from this plot session.
+        pub fn remove_annotation(
+            &mut self,
+            id: AnnotationId,
+            cx: &mut Context<Self>,
+        ) -> Result<bool> {
+            let removed = self.session.remove_annotation(id)?;
+            cx.notify();
+            Ok(removed)
+        }
+
         pub fn presentation_mode(&self) -> PresentationMode {
             self.options.presentation_mode
         }
@@ -1513,6 +1552,49 @@ mod platform_impl {
         fn assert_window_points_close(actual: Point<Pixels>, expected: Point<Pixels>) {
             assert!((f64::from(actual.x) - f64::from(expected.x)).abs() < 1e-4);
             assert!((f64::from(actual.y) - f64::from(expected.y)).abs() < 1e-4);
+        }
+
+        #[test]
+        fn test_dynamic_annotation_wrappers_delegate_to_session() {
+            let cx = TestAppContext::single();
+            let plot: Plot = Plot::new().line(&[0.0, 1.0], &[0.0, 1.0]).into();
+            let view = cx.update(|cx| {
+                cx.new(move |cx| {
+                    RuvizPlot::from_options_impl(
+                        plot,
+                        RuvizPlotOptions::default(),
+                        None,
+                        PlotPointerEventHandlers::default(),
+                        cx,
+                    )
+                })
+            });
+
+            let id = cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    view.add_annotation(Annotation::vline(0.25), cx)
+                        .expect("wrapper add should succeed")
+                })
+            });
+            cx.read(|app| {
+                app.read_entity(&view, |view, _| {
+                    assert!(matches!(
+                        view.annotation(id).unwrap(),
+                        Annotation::VLine { x, .. } if x == 0.25
+                    ));
+                })
+            });
+            cx.update(|cx| {
+                view.update(cx, |view, cx| {
+                    view.update_annotation(id, Annotation::vline(0.75), cx)
+                        .expect("wrapper update should succeed");
+                    assert!(view.remove_annotation(id, cx).unwrap());
+                    assert!(matches!(
+                        view.annotation(id),
+                        Err(PlottingError::UnknownAnnotationId)
+                    ));
+                });
+            });
         }
 
         fn synchronize_test_frame(view: &mut RuvizPlot, request: RenderRequest) {

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -46,6 +46,10 @@ pub enum PlottingError {
     SystemError(String),
     /// Invalid input parameter
     InvalidInput(String),
+    /// Invalid dynamic annotation value or style geometry
+    InvalidAnnotation { reason: String },
+    /// Annotation ID does not belong to this session or is no longer present
+    UnknownAnnotationId,
     /// Data contains invalid values (NaN, Inf)
     InvalidData {
         message: String,
@@ -239,6 +243,12 @@ impl fmt::Display for PlottingError {
             }
             PlottingError::InvalidInput(msg) => {
                 write!(f, "Invalid input: {}", msg)
+            }
+            PlottingError::InvalidAnnotation { reason } => {
+                write!(f, "Invalid annotation: {}", reason)
+            }
+            PlottingError::UnknownAnnotationId => {
+                write!(f, "Unknown annotation ID for this interactive session")
             }
             PlottingError::InvalidData { message, position } => match position {
                 Some(pos) => write!(f, "Invalid data at position {}: {}", pos, message),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -39,7 +39,8 @@ pub use legend::{
     LegendSpacingPixels, LegendStyle, find_best_position,
 };
 pub use plot::{
-    BackendFallbackReason, BackendOperation, BackendResolution, BackendType, BuilderWhen,
+    AnnotationId, BackendFallbackReason, BackendOperation, BackendResolution, BackendType,
+    BuilderWhen,
     DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, Image, ImageTarget, InsetAnchor,
     InsetLayout, InteractiveFrame, InteractiveFrameWithGeneration, InteractivePlotSession,
     InteractiveViewportSnapshot, IntoPlot, LayerRenderState, Plot, PlotBuilder, PlotInput,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -40,13 +40,12 @@ pub use legend::{
 };
 pub use plot::{
     AnnotationId, BackendFallbackReason, BackendOperation, BackendResolution, BackendType,
-    BuilderWhen,
-    DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, Image, ImageTarget, InsetAnchor,
-    InsetLayout, InteractiveFrame, InteractiveFrameWithGeneration, InteractivePlotSession,
-    InteractiveViewportSnapshot, IntoPlot, LayerRenderState, Plot, PlotBuilder, PlotInput,
-    PlotInputEvent, PlotSource, PreparedPlot, QualityPolicy, ReactiveSubscription, ReactiveValue,
-    RenderTargetKind, SeriesStyle, SurfaceCapability, SurfaceTarget, TextEngineMode, TickDirection,
-    TickSides, ViewportPoint, ViewportRect,
+    BuilderWhen, DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, Image, ImageTarget,
+    InsetAnchor, InsetLayout, InteractiveFrame, InteractiveFrameWithGeneration,
+    InteractivePlotSession, InteractiveViewportSnapshot, IntoPlot, LayerRenderState, Plot,
+    PlotBuilder, PlotInput, PlotInputEvent, PlotSource, PreparedPlot, QualityPolicy,
+    ReactiveSubscription, ReactiveValue, RenderTargetKind, SeriesStyle, SurfaceCapability,
+    SurfaceTarget, TextEngineMode, TickDirection, TickSides, ViewportPoint, ViewportRect,
 };
 pub use position::Position;
 pub use style::PlotStyle;

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -1,15 +1,16 @@
 use super::{
     BackendOperation, Image, Plot, PlotData, PlotSeries, PreparedPlot, ReactiveSubscription,
-    ResolvedData, ResolvedFrame, ResolvedSeries, SeriesType,
+    ResolvedData, ResolvedFrame, ResolvedSeries, SeriesType, TextEngineMode,
 };
 use crate::{
     axes::{AxisScale, expand_degenerate_range},
     core::{
-        CoordinateTransform, LayoutCalculator, LayoutConfig, MarginConfig, PlotLayout,
-        PlottingError, REFERENCE_DPI, Result,
+        Annotation, CoordinateTransform, FillStyle, LayoutCalculator, LayoutConfig, MarginConfig,
+        PlotLayout, PlottingError, REFERENCE_DPI, RenderScale, Result, ShapeStyle,
     },
     render::{
-        Color, FontConfig, FontFamily, LineStyle, MarkerStyle, TextRenderer, skia::SkiaRenderer,
+        Color, FontConfig, FontFamily, LineStyle, MarkerStyle, TextRenderer, Theme,
+        skia::SkiaRenderer,
     },
 };
 use std::{
@@ -24,6 +25,55 @@ use std::{
 
 thread_local! {
     static ACTIVE_RENDER_SESSIONS: RefCell<HashSet<usize>> = RefCell::new(HashSet::new());
+}
+
+static NEXT_ANNOTATION_SESSION_TOKEN: AtomicU64 = AtomicU64::new(1);
+
+/// Opaque identifier for a dynamic annotation owned by one interactive session.
+///
+/// IDs remain valid only for the session that created them and until the
+/// annotation is removed.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct AnnotationId {
+    session_token: u64,
+    value: u64,
+}
+
+#[derive(Debug)]
+struct DynamicAnnotations {
+    session_token: u64,
+    next_id: u64,
+    revision: u64,
+    entries: std::collections::BTreeMap<u64, Annotation>,
+}
+
+impl DynamicAnnotations {
+    fn new() -> Self {
+        let session_token = NEXT_ANNOTATION_SESSION_TOKEN
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |token| {
+                token.checked_add(1)
+            })
+            .expect("interactive annotation session token space exhausted");
+        Self {
+            session_token,
+            next_id: 1,
+            revision: 0,
+            entries: std::collections::BTreeMap::new(),
+        }
+    }
+
+    fn require_local_id(&self, id: AnnotationId) -> Result<u64> {
+        if id.session_token != self.session_token || !self.entries.contains_key(&id.value) {
+            return Err(PlottingError::UnknownAnnotationId);
+        }
+        Ok(id.value)
+    }
+
+    fn next_revision(&self) -> Result<u64> {
+        self.revision.checked_add(1).ok_or_else(|| {
+            PlottingError::RenderError("dynamic annotation revision exhausted".to_string())
+        })
+    }
 }
 
 struct ActiveRenderGuard {
@@ -393,6 +443,7 @@ pub struct InteractivePlotSession {
 #[derive(Debug)]
 struct InteractivePlotSessionInner {
     prepared: PreparedPlot,
+    annotations: Mutex<DynamicAnnotations>,
     frame_pacing: Mutex<FramePacing>,
     quality_policy: Mutex<QualityPolicy>,
     prefer_gpu: Mutex<bool>,
@@ -910,6 +961,10 @@ struct InteractiveFrameCache {
 #[derive(Clone, Debug, PartialEq)]
 struct OverlayFrameKey {
     size_px: (u32, u32),
+    annotations_revision: u64,
+    /// Displayed data bounds as bit patterns so pan/zoom/temporal geometry
+    /// changes invalidate annotation pixels rendered under an older transform.
+    view_bounds_bits: Option<[u64; 4]>,
     plot_area: Option<ViewportRect>,
     hovered: Option<HitResult>,
     selected: Vec<HitResult>,
@@ -931,6 +986,10 @@ struct GeometrySnapshot {
     y_bounds: (f64, f64),
     x_scale: AxisScale,
     y_scale: AxisScale,
+    annotation_theme: Theme,
+    annotation_font_family: FontFamily,
+    annotation_render_scale: RenderScale,
+    annotation_text_engine: TextEngineMode,
     transform: CoordinateTransform,
 }
 
@@ -1186,6 +1245,7 @@ impl InteractivePlotSession {
         Self {
             inner: Arc::new(InteractivePlotSessionInner {
                 prepared,
+                annotations: Mutex::new(DynamicAnnotations::new()),
                 frame_pacing: Mutex::new(FramePacing::Display),
                 quality_policy: Mutex::new(QualityPolicy::Balanced),
                 prefer_gpu: Mutex::new(false),
@@ -1205,6 +1265,77 @@ impl InteractivePlotSession {
 
     pub fn prepared_plot(&self) -> &PreparedPlot {
         &self.inner.prepared
+    }
+
+    /// Adds a session-owned annotation to the interactive overlay.
+    pub fn add_annotation(&self, annotation: Annotation) -> Result<AnnotationId> {
+        validate_dynamic_annotation(&annotation)?;
+        let mut annotations = self
+            .inner
+            .annotations
+            .lock()
+            .expect("InteractivePlotSession annotations lock poisoned");
+        let value = annotations.next_id;
+        let next_id = value.checked_add(1).ok_or_else(|| {
+            PlottingError::RenderError("dynamic annotation ID space exhausted".to_string())
+        })?;
+        let revision = annotations.next_revision()?;
+        let id = AnnotationId {
+            session_token: annotations.session_token,
+            value,
+        };
+        annotations.entries.insert(value, annotation);
+        annotations.next_id = next_id;
+        annotations.revision = revision;
+        self.begin_mutation();
+        self.mark_dirty(DirtyDomain::Overlay);
+        Ok(id)
+    }
+
+    /// Returns a copy of a session-owned dynamic annotation.
+    pub fn annotation(&self, id: AnnotationId) -> Result<Annotation> {
+        let annotations = self
+            .inner
+            .annotations
+            .lock()
+            .expect("InteractivePlotSession annotations lock poisoned");
+        let value = annotations.require_local_id(id)?;
+        Ok(annotations.entries[&value].clone())
+    }
+
+    /// Replaces a session-owned annotation, including all geometry and style.
+    pub fn update_annotation(&self, id: AnnotationId, annotation: Annotation) -> Result<()> {
+        validate_dynamic_annotation(&annotation)?;
+        let mut annotations = self
+            .inner
+            .annotations
+            .lock()
+            .expect("InteractivePlotSession annotations lock poisoned");
+        let value = annotations.require_local_id(id)?;
+        let revision = annotations.next_revision()?;
+        annotations.entries.insert(value, annotation);
+        annotations.revision = revision;
+        self.begin_mutation();
+        self.mark_dirty(DirtyDomain::Overlay);
+        Ok(())
+    }
+
+    /// Removes a session-owned annotation.
+    ///
+    /// Foreign and stale IDs return [`PlottingError::UnknownAnnotationId`].
+    pub fn remove_annotation(&self, id: AnnotationId) -> Result<bool> {
+        let mut annotations = self
+            .inner
+            .annotations
+            .lock()
+            .expect("InteractivePlotSession annotations lock poisoned");
+        let value = annotations.require_local_id(id)?;
+        let revision = annotations.next_revision()?;
+        let removed = annotations.entries.remove(&value).is_some();
+        annotations.revision = revision;
+        self.begin_mutation();
+        self.mark_dirty(DirtyDomain::Overlay);
+        Ok(removed)
     }
 
     pub fn subscribe_reactive<F>(&self, callback: F) -> ReactiveSubscription
@@ -2303,6 +2434,14 @@ impl InteractivePlotSession {
         size_px: (u32, u32),
         dirty_before_render: DirtyDomains,
     ) -> Result<OverlayLayerResult> {
+        let (annotations_revision, annotations_empty) = {
+            let annotations = self
+                .inner
+                .annotations
+                .lock()
+                .expect("InteractivePlotSession annotations lock poisoned");
+            (annotations.revision, annotations.entries.is_empty())
+        };
         let state = self
             .inner
             .state
@@ -2311,6 +2450,15 @@ impl InteractivePlotSession {
             .clone();
         let overlay_key = OverlayFrameKey {
             size_px,
+            annotations_revision,
+            view_bounds_bits: state.base_cache.as_ref().map(|cache| {
+                [
+                    cache.geometry.x_bounds.0.to_bits(),
+                    cache.geometry.x_bounds.1.to_bits(),
+                    cache.geometry.y_bounds.0.to_bits(),
+                    cache.geometry.y_bounds.1.to_bits(),
+                ]
+            }),
             plot_area: state
                 .base_cache
                 .as_ref()
@@ -2326,7 +2474,8 @@ impl InteractivePlotSession {
         let overlay_is_empty = state.hovered.is_none()
             && state.selected.is_empty()
             && state.brushed_region.is_none()
-            && state.tooltip.is_none();
+            && state.tooltip.is_none()
+            && annotations_empty;
 
         {
             let state = self
@@ -2367,7 +2516,51 @@ impl InteractivePlotSession {
             });
         }
 
-        let mut pixels = vec![0u8; (size_px.0 * size_px.1 * 4) as usize];
+        // Clone annotation values only when a fresh raster is actually needed;
+        // FillBetween can own large vectors and cache hits above must stay cheap.
+        let annotations = {
+            let annotations = self
+                .inner
+                .annotations
+                .lock()
+                .expect("InteractivePlotSession annotations lock poisoned");
+            annotations.entries.values().cloned().collect::<Vec<_>>()
+        };
+        let mut pixels = if annotations.is_empty() {
+            vec![0u8; (size_px.0 * size_px.1 * 4) as usize]
+        } else {
+            let geometry = state
+                .base_cache
+                .as_ref()
+                .map(|cache| &cache.geometry)
+                .ok_or_else(displayed_geometry_unavailable)?;
+            let mut theme = geometry.annotation_theme.clone();
+            theme.background = Color::TRANSPARENT;
+            let mut renderer = SkiaRenderer::with_font_family(
+                size_px.0,
+                size_px.1,
+                theme,
+                geometry.annotation_font_family.clone(),
+            )?;
+            renderer.set_text_engine_mode(geometry.annotation_text_engine);
+            let render_scale = geometry.annotation_render_scale;
+            renderer.set_render_scale(render_scale);
+            renderer.draw_annotations_where_scaled(
+                &annotations,
+                geometry.plot_area,
+                geometry.x_bounds.0,
+                geometry.x_bounds.1,
+                geometry.y_bounds.0,
+                geometry.y_bounds.1,
+                render_scale.dpi(),
+                &geometry.x_scale,
+                &geometry.y_scale,
+                |_| true,
+            )?;
+            let mut image = renderer.into_image_demultiplied();
+            clip_overlay_to_plot_area(&mut image.pixels, size_px, geometry.plot_area);
+            image.pixels
+        };
         let hit_clip = state
             .base_cache
             .as_ref()
@@ -3115,6 +3308,205 @@ fn require_finite_point(point: ViewportPoint, label: &str) -> Result<()> {
     }
 }
 
+fn invalid_annotation(reason: impl Into<String>) -> PlottingError {
+    PlottingError::InvalidAnnotation {
+        reason: reason.into(),
+    }
+}
+
+fn require_finite_annotation_f64(value: f64, label: &str) -> Result<()> {
+    if value.is_finite() {
+        Ok(())
+    } else {
+        Err(invalid_annotation(format!("{label} must be finite")))
+    }
+}
+
+fn require_non_negative_annotation_f64(value: f64, label: &str) -> Result<()> {
+    require_finite_annotation_f64(value, label)?;
+    if value >= 0.0 {
+        Ok(())
+    } else {
+        Err(invalid_annotation(format!("{label} must be non-negative")))
+    }
+}
+
+fn require_non_negative_annotation_f32(value: f32, label: &str) -> Result<()> {
+    if value.is_finite() && value >= 0.0 {
+        Ok(())
+    } else {
+        Err(invalid_annotation(format!(
+            "{label} must be finite and non-negative"
+        )))
+    }
+}
+
+fn validate_annotation_line_style(style: &LineStyle, label: &str) -> Result<()> {
+    if let LineStyle::Custom(pattern) = style
+        && (!pattern.is_empty()
+            && (pattern.len() % 2 != 0
+                || pattern
+                    .iter()
+                    .any(|value| !value.is_finite() || *value <= 0.0)))
+    {
+        return Err(invalid_annotation(format!(
+            "{label} custom dash pattern must contain an even number of finite positive lengths"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_annotation_shape_style(style: &ShapeStyle, label: &str) -> Result<()> {
+    if !style.fill_alpha.is_finite() || !(0.0..=1.0).contains(&style.fill_alpha) {
+        return Err(invalid_annotation(format!(
+            "{label} fill alpha must be finite and between 0 and 1"
+        )));
+    }
+    require_non_negative_annotation_f32(style.edge_width, &format!("{label} edge width"))?;
+    validate_annotation_line_style(&style.edge_style, &format!("{label} edge style"))
+}
+
+fn validate_annotation_fill_style(style: &FillStyle) -> Result<()> {
+    if !style.alpha.is_finite() || !(0.0..=1.0).contains(&style.alpha) {
+        return Err(invalid_annotation(
+            "fill alpha must be finite and between 0 and 1",
+        ));
+    }
+    require_non_negative_annotation_f32(style.edge_width, "fill edge width")
+}
+
+fn validate_dynamic_annotation(annotation: &Annotation) -> Result<()> {
+    match annotation {
+        Annotation::Text { x, y, style, .. } => {
+            require_finite_annotation_f64(*x, "text x")?;
+            require_finite_annotation_f64(*y, "text y")?;
+            if !style.font_size.is_finite() || style.font_size <= 0.0 {
+                return Err(invalid_annotation(
+                    "text font size must be finite and positive",
+                ));
+            }
+            require_finite_annotation_f64(f64::from(style.rotation), "text rotation")?;
+            require_non_negative_annotation_f32(style.padding, "text padding")?;
+            require_non_negative_annotation_f32(style.border_width, "text border width")
+        }
+        Annotation::Arrow {
+            x1,
+            y1,
+            x2,
+            y2,
+            style,
+        } => {
+            for (value, label) in [
+                (*x1, "arrow x1"),
+                (*y1, "arrow y1"),
+                (*x2, "arrow x2"),
+                (*y2, "arrow y2"),
+            ] {
+                require_finite_annotation_f64(value, label)?;
+            }
+            require_non_negative_annotation_f32(style.line_width, "arrow line width")?;
+            require_non_negative_annotation_f32(style.head_length, "arrow head length")?;
+            require_non_negative_annotation_f32(style.head_width, "arrow head width")?;
+            validate_annotation_line_style(&style.line_style, "arrow line style")
+        }
+        Annotation::HLine {
+            y, style, width, ..
+        } => {
+            require_finite_annotation_f64(*y, "horizontal line y")?;
+            require_non_negative_annotation_f32(*width, "horizontal line width")?;
+            validate_annotation_line_style(style, "horizontal line style")
+        }
+        Annotation::VLine {
+            x, style, width, ..
+        } => {
+            require_finite_annotation_f64(*x, "vertical line x")?;
+            require_non_negative_annotation_f32(*width, "vertical line width")?;
+            validate_annotation_line_style(style, "vertical line style")
+        }
+        Annotation::Rectangle {
+            x,
+            y,
+            width,
+            height,
+            style,
+        } => {
+            require_finite_annotation_f64(*x, "rectangle x")?;
+            require_finite_annotation_f64(*y, "rectangle y")?;
+            require_non_negative_annotation_f64(*width, "rectangle width")?;
+            require_non_negative_annotation_f64(*height, "rectangle height")?;
+            require_finite_annotation_f64(*x + *width, "rectangle right edge")?;
+            require_finite_annotation_f64(*y + *height, "rectangle top edge")?;
+            validate_annotation_shape_style(style, "rectangle")
+        }
+        Annotation::FillBetween {
+            x, y1, y2, style, ..
+        } => {
+            if x.len() < 2 || x.len() != y1.len() || x.len() != y2.len() {
+                return Err(invalid_annotation(
+                    "FillBetween x, y1, and y2 must have equal lengths of at least 2",
+                ));
+            }
+            for (label, values) in [
+                ("FillBetween x", x),
+                ("FillBetween y1", y1),
+                ("FillBetween y2", y2),
+            ] {
+                if let Some(index) = values.iter().position(|value| !value.is_finite()) {
+                    return Err(invalid_annotation(format!(
+                        "{label} contains a non-finite value at index {index}"
+                    )));
+                }
+            }
+            validate_annotation_fill_style(style)
+        }
+        Annotation::HSpan {
+            x_min,
+            x_max,
+            style,
+        } => {
+            require_finite_annotation_f64(*x_min, "horizontal span x_min")?;
+            require_finite_annotation_f64(*x_max, "horizontal span x_max")?;
+            if x_min > x_max {
+                return Err(invalid_annotation(
+                    "horizontal span x_min must not exceed x_max",
+                ));
+            }
+            validate_annotation_shape_style(style, "horizontal span")
+        }
+        Annotation::VSpan {
+            y_min,
+            y_max,
+            style,
+        } => {
+            require_finite_annotation_f64(*y_min, "vertical span y_min")?;
+            require_finite_annotation_f64(*y_max, "vertical span y_max")?;
+            if y_min > y_max {
+                return Err(invalid_annotation(
+                    "vertical span y_min must not exceed y_max",
+                ));
+            }
+            validate_annotation_shape_style(style, "vertical span")
+        }
+    }
+}
+
+fn clip_overlay_to_plot_area(pixels: &mut [u8], size_px: (u32, u32), plot_area: tiny_skia::Rect) {
+    for y in 0..size_px.1 {
+        for x in 0..size_px.0 {
+            let center_x = x as f32 + 0.5;
+            let center_y = y as f32 + 0.5;
+            if center_x < plot_area.left()
+                || center_x > plot_area.right()
+                || center_y < plot_area.top()
+                || center_y > plot_area.bottom()
+            {
+                let index = ((y as usize * size_px.0 as usize) + x as usize) * 4;
+                pixels[index..index + 4].fill(0);
+            }
+        }
+    }
+}
+
 fn axis_accepts_value(scale: &AxisScale, value: f64) -> bool {
     match scale {
         AxisScale::Linear | AxisScale::SymLog { .. } => true,
@@ -3314,6 +3706,10 @@ fn sanitize_scale_factor(scale_factor: f32) -> f32 {
 
 struct ComputedSessionLayout {
     plot_area_rect: tiny_skia::Rect,
+    annotation_theme: Theme,
+    annotation_font_family: FontFamily,
+    annotation_render_scale: RenderScale,
+    annotation_text_engine: TextEngineMode,
 }
 
 fn geometry_snapshot_for_state(
@@ -3339,6 +3735,10 @@ fn geometry_snapshot_for_state(
         y_bounds: (visible.y_min, visible.y_max),
         x_scale: plot.layout.x_scale.clone(),
         y_scale: plot.layout.y_scale.clone(),
+        annotation_theme: layout.annotation_theme,
+        annotation_font_family: layout.annotation_font_family,
+        annotation_render_scale: layout.annotation_render_scale,
+        annotation_text_engine: layout.annotation_text_engine,
         transform: CoordinateTransform::new(
             visible.x_min..visible.x_max,
             visible.y_min..visible.y_max,
@@ -3477,7 +3877,13 @@ fn compute_plot_layout_from_frame(
         position: None,
     })?;
 
-    Ok(ComputedSessionLayout { plot_area_rect })
+    Ok(ComputedSessionLayout {
+        plot_area_rect,
+        annotation_theme: layout_plot.display.theme.clone(),
+        annotation_font_family: layout_plot.display.config.typography.family.clone(),
+        annotation_render_scale: layout_plot.render_scale(),
+        annotation_text_engine: layout_plot.display.text_engine,
+    })
 }
 
 mod helpers;

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -1269,7 +1269,10 @@ impl InteractivePlotSession {
 
     /// Adds a session-owned annotation to the interactive overlay.
     pub fn add_annotation(&self, annotation: Annotation) -> Result<AnnotationId> {
-        validate_dynamic_annotation(&annotation)?;
+        {
+            let layout = &self.inner.prepared.plot().layout;
+            validate_dynamic_annotation(&annotation, &layout.x_scale, &layout.y_scale)?;
+        }
         let mut annotations = self
             .inner
             .annotations
@@ -1305,7 +1308,10 @@ impl InteractivePlotSession {
 
     /// Replaces a session-owned annotation, including all geometry and style.
     pub fn update_annotation(&self, id: AnnotationId, annotation: Annotation) -> Result<()> {
-        validate_dynamic_annotation(&annotation)?;
+        {
+            let layout = &self.inner.prepared.plot().layout;
+            validate_dynamic_annotation(&annotation, &layout.x_scale, &layout.y_scale)?;
+        }
         let mut annotations = self
             .inner
             .annotations
@@ -3322,6 +3328,20 @@ fn require_finite_annotation_f64(value: f64, label: &str) -> Result<()> {
     }
 }
 
+fn require_annotation_coord_in_scale_domain(
+    value: f64,
+    scale: &crate::axes::AxisScale,
+    label: &str,
+) -> Result<()> {
+    require_finite_annotation_f64(value, label)?;
+    if matches!(scale, crate::axes::AxisScale::Log) && value <= 0.0 {
+        return Err(invalid_annotation(format!(
+            "{label} must be positive on a logarithmic axis"
+        )));
+    }
+    Ok(())
+}
+
 fn require_non_negative_annotation_f64(value: f64, label: &str) -> Result<()> {
     require_finite_annotation_f64(value, label)?;
     if value >= 0.0 {
@@ -3375,11 +3395,15 @@ fn validate_annotation_fill_style(style: &FillStyle) -> Result<()> {
     require_non_negative_annotation_f32(style.edge_width, "fill edge width")
 }
 
-fn validate_dynamic_annotation(annotation: &Annotation) -> Result<()> {
+fn validate_dynamic_annotation(
+    annotation: &Annotation,
+    x_scale: &crate::axes::AxisScale,
+    y_scale: &crate::axes::AxisScale,
+) -> Result<()> {
     match annotation {
         Annotation::Text { x, y, style, .. } => {
-            require_finite_annotation_f64(*x, "text x")?;
-            require_finite_annotation_f64(*y, "text y")?;
+            require_annotation_coord_in_scale_domain(*x, x_scale, "text x")?;
+            require_annotation_coord_in_scale_domain(*y, y_scale, "text y")?;
             if !style.font_size.is_finite() || style.font_size <= 0.0 {
                 return Err(invalid_annotation(
                     "text font size must be finite and positive",
@@ -3396,13 +3420,13 @@ fn validate_dynamic_annotation(annotation: &Annotation) -> Result<()> {
             y2,
             style,
         } => {
-            for (value, label) in [
-                (*x1, "arrow x1"),
-                (*y1, "arrow y1"),
-                (*x2, "arrow x2"),
-                (*y2, "arrow y2"),
+            for (value, scale, label) in [
+                (*x1, x_scale, "arrow x1"),
+                (*y1, y_scale, "arrow y1"),
+                (*x2, x_scale, "arrow x2"),
+                (*y2, y_scale, "arrow y2"),
             ] {
-                require_finite_annotation_f64(value, label)?;
+                require_annotation_coord_in_scale_domain(value, scale, label)?;
             }
             require_non_negative_annotation_f32(style.line_width, "arrow line width")?;
             require_non_negative_annotation_f32(style.head_length, "arrow head length")?;
@@ -3412,14 +3436,14 @@ fn validate_dynamic_annotation(annotation: &Annotation) -> Result<()> {
         Annotation::HLine {
             y, style, width, ..
         } => {
-            require_finite_annotation_f64(*y, "horizontal line y")?;
+            require_annotation_coord_in_scale_domain(*y, y_scale, "horizontal line y")?;
             require_non_negative_annotation_f32(*width, "horizontal line width")?;
             validate_annotation_line_style(style, "horizontal line style")
         }
         Annotation::VLine {
             x, style, width, ..
         } => {
-            require_finite_annotation_f64(*x, "vertical line x")?;
+            require_annotation_coord_in_scale_domain(*x, x_scale, "vertical line x")?;
             require_non_negative_annotation_f32(*width, "vertical line width")?;
             validate_annotation_line_style(style, "vertical line style")
         }
@@ -3430,8 +3454,8 @@ fn validate_dynamic_annotation(annotation: &Annotation) -> Result<()> {
             height,
             style,
         } => {
-            require_finite_annotation_f64(*x, "rectangle x")?;
-            require_finite_annotation_f64(*y, "rectangle y")?;
+            require_annotation_coord_in_scale_domain(*x, x_scale, "rectangle x")?;
+            require_annotation_coord_in_scale_domain(*y, y_scale, "rectangle y")?;
             require_non_negative_annotation_f64(*width, "rectangle width")?;
             require_non_negative_annotation_f64(*height, "rectangle height")?;
             require_finite_annotation_f64(*x + *width, "rectangle right edge")?;
@@ -3446,14 +3470,21 @@ fn validate_dynamic_annotation(annotation: &Annotation) -> Result<()> {
                     "FillBetween x, y1, and y2 must have equal lengths of at least 2",
                 ));
             }
-            for (label, values) in [
-                ("FillBetween x", x),
-                ("FillBetween y1", y1),
-                ("FillBetween y2", y2),
+            for (label, scale, values) in [
+                ("FillBetween x", x_scale, x),
+                ("FillBetween y1", y_scale, y1),
+                ("FillBetween y2", y_scale, y2),
             ] {
                 if let Some(index) = values.iter().position(|value| !value.is_finite()) {
                     return Err(invalid_annotation(format!(
                         "{label} contains a non-finite value at index {index}"
+                    )));
+                }
+                if matches!(scale, crate::axes::AxisScale::Log)
+                    && let Some(index) = values.iter().position(|value| *value <= 0.0)
+                {
+                    return Err(invalid_annotation(format!(
+                        "{label} contains a non-positive value at index {index} on a logarithmic axis"
                     )));
                 }
             }
@@ -3464,8 +3495,8 @@ fn validate_dynamic_annotation(annotation: &Annotation) -> Result<()> {
             x_max,
             style,
         } => {
-            require_finite_annotation_f64(*x_min, "horizontal span x_min")?;
-            require_finite_annotation_f64(*x_max, "horizontal span x_max")?;
+            require_annotation_coord_in_scale_domain(*x_min, x_scale, "horizontal span x_min")?;
+            require_annotation_coord_in_scale_domain(*x_max, x_scale, "horizontal span x_max")?;
             if x_min > x_max {
                 return Err(invalid_annotation(
                     "horizontal span x_min must not exceed x_max",
@@ -3478,8 +3509,8 @@ fn validate_dynamic_annotation(annotation: &Annotation) -> Result<()> {
             y_max,
             style,
         } => {
-            require_finite_annotation_f64(*y_min, "vertical span y_min")?;
-            require_finite_annotation_f64(*y_max, "vertical span y_max")?;
+            require_annotation_coord_in_scale_domain(*y_min, y_scale, "vertical span y_min")?;
+            require_annotation_coord_in_scale_domain(*y_max, y_scale, "vertical span y_max")?;
             if y_min > y_max {
                 return Err(invalid_annotation(
                     "vertical span y_min must not exceed y_max",

--- a/src/core/plot/interactive_session/helpers.rs
+++ b/src/core/plot/interactive_session/helpers.rs
@@ -497,6 +497,32 @@ pub(super) fn blend_channel(background: u8, foreground: u8, alpha: f32) -> u8 {
     ((bg * (1.0 - alpha) + fg * alpha) * 255.0) as u8
 }
 
+/// Straight-alpha source-over composition of `color` onto one RGBA pixel.
+///
+/// Unlike a plain channel blend that overwrites destination alpha, this
+/// preserves existing coverage (e.g. dynamic annotations underneath a brush
+/// or hover marker) so the base layer does not bleed through.
+fn blend_pixel_over(dst: &mut [u8], color: Color) {
+    let src_a = color.a as f32 / 255.0;
+    if src_a <= 0.0 {
+        return;
+    }
+    let dst_a = dst[3] as f32 / 255.0;
+    let out_a = src_a + dst_a * (1.0 - src_a);
+    if out_a <= 0.0 {
+        return;
+    }
+    let blend = |dst_c: u8, src_c: u8| -> u8 {
+        let d = dst_c as f32 / 255.0;
+        let s = src_c as f32 / 255.0;
+        (((s * src_a + d * dst_a * (1.0 - src_a)) / out_a) * 255.0).round() as u8
+    };
+    dst[0] = blend(dst[0], color.r);
+    dst[1] = blend(dst[1], color.g);
+    dst[2] = blend(dst[2], color.b);
+    dst[3] = (out_a * 255.0).round() as u8;
+}
+
 pub(super) fn draw_hit(
     pixels: &mut [u8],
     size_px: (u32, u32),
@@ -560,11 +586,7 @@ fn draw_circle_clipped(
                 continue;
             }
             let index = ((y * width + x) * 4) as usize;
-            let alpha = color.a as f32 / 255.0;
-            pixels[index] = blend_channel(pixels[index], color.r, alpha);
-            pixels[index + 1] = blend_channel(pixels[index + 1], color.g, alpha);
-            pixels[index + 2] = blend_channel(pixels[index + 2], color.b, alpha);
-            pixels[index + 3] = color.a;
+            blend_pixel_over(&mut pixels[index..index + 4], color);
         }
     }
 }
@@ -586,7 +608,6 @@ fn draw_rect_clipped(
     let y1 = rect.min.y.round() as i32;
     let x2 = rect.max.x.round() as i32;
     let y2 = rect.max.y.round() as i32;
-    let alpha = color.a as f32 / 255.0;
 
     let clip_x1 = clip.map_or(0, |clip| clip.min.x.ceil() as i32);
     let clip_y1 = clip.map_or(0, |clip| clip.min.y.ceil() as i32);
@@ -596,10 +617,7 @@ fn draw_rect_clipped(
     for y in y1.max(0).max(clip_y1)..y2.min(height).min(clip_y2) {
         for x in x1.max(0).max(clip_x1)..x2.min(width).min(clip_x2) {
             let index = ((y * width + x) * 4) as usize;
-            pixels[index] = blend_channel(pixels[index], color.r, alpha);
-            pixels[index + 1] = blend_channel(pixels[index + 1], color.g, alpha);
-            pixels[index + 2] = blend_channel(pixels[index + 2], color.b, alpha);
-            pixels[index + 3] = color.a;
+            blend_pixel_over(&mut pixels[index..index + 4], color);
         }
     }
 }
@@ -618,7 +636,6 @@ pub(super) fn draw_rect_outline(
     let x2 = rect.max.x.round() as i32;
     let y2 = rect.max.y.round() as i32;
     let thickness = thickness.max(1);
-    let alpha = color.a as f32 / 255.0;
 
     for y in y1.max(0)..=y2.min(height - 1) {
         for x in x1.max(0)..=x2.min(width - 1) {
@@ -631,10 +648,7 @@ pub(super) fn draw_rect_outline(
             }
             let index = ((y * width + x) * 4) as usize;
             if index + 3 < pixels.len() {
-                pixels[index] = blend_channel(pixels[index], color.r, alpha);
-                pixels[index + 1] = blend_channel(pixels[index + 1], color.g, alpha);
-                pixels[index + 2] = blend_channel(pixels[index + 2], color.b, alpha);
-                pixels[index + 3] = color.a;
+                blend_pixel_over(&mut pixels[index..index + 4], color);
             }
         }
     }

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -3724,3 +3724,386 @@ fn test_surface_frame_clips_series_pixels_to_plot_area_after_zoom() {
         geometry.plot_area
     );
 }
+
+fn annotation_test_session() -> InteractivePlotSession {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .xlim(0.0, 1.0)
+        .ylim(0.0, 1.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    plot.prepare_interactive()
+}
+
+fn dynamic_annotation_variants(offset: f64) -> Vec<Annotation> {
+    vec![
+        Annotation::text(0.2 + offset, 0.3, format!("label {offset}")),
+        Annotation::arrow(0.1 + offset, 0.2, 0.4 + offset, 0.5),
+        Annotation::hline(0.25 + offset),
+        Annotation::vline(0.25 + offset),
+        Annotation::rectangle(0.1 + offset, 0.2, 0.2, 0.3),
+        Annotation::fill_between(
+            vec![0.1 + offset, 0.3 + offset],
+            vec![0.2, 0.4],
+            vec![0.1, 0.2],
+        ),
+        Annotation::hspan(0.1 + offset, 0.3 + offset),
+        Annotation::vspan(0.2 + offset, 0.4 + offset),
+    ]
+}
+
+#[test]
+fn test_dynamic_annotations_support_every_variant_lifecycle() {
+    let session = annotation_test_session();
+    for (annotation, replacement) in dynamic_annotation_variants(0.0)
+        .into_iter()
+        .zip(dynamic_annotation_variants(0.05))
+    {
+        let expected_initial = std::mem::discriminant(&annotation);
+        let expected_replacement = std::mem::discriminant(&replacement);
+        let id = session.add_annotation(annotation).unwrap();
+        assert_eq!(
+            std::mem::discriminant(&session.annotation(id).unwrap()),
+            expected_initial
+        );
+        session.update_annotation(id, replacement).unwrap();
+        assert_eq!(
+            std::mem::discriminant(&session.annotation(id).unwrap()),
+            expected_replacement
+        );
+        assert!(session.remove_annotation(id).unwrap());
+        assert!(matches!(
+            session.annotation(id),
+            Err(PlottingError::UnknownAnnotationId)
+        ));
+    }
+}
+
+#[test]
+fn test_dynamic_annotation_ids_reject_foreign_and_stale_sessions() {
+    let first = annotation_test_session();
+    let second = annotation_test_session();
+    let id = first.add_annotation(Annotation::vline(0.25)).unwrap();
+    assert!(matches!(
+        second.annotation(id),
+        Err(PlottingError::UnknownAnnotationId)
+    ));
+    assert!(matches!(
+        second.update_annotation(id, Annotation::vline(0.5)),
+        Err(PlottingError::UnknownAnnotationId)
+    ));
+    assert!(matches!(
+        second.remove_annotation(id),
+        Err(PlottingError::UnknownAnnotationId)
+    ));
+    assert!(first.remove_annotation(id).unwrap());
+    assert!(matches!(
+        first.update_annotation(id, Annotation::vline(0.75)),
+        Err(PlottingError::UnknownAnnotationId)
+    ));
+    assert!(matches!(
+        first.remove_annotation(id),
+        Err(PlottingError::UnknownAnnotationId)
+    ));
+}
+
+#[test]
+fn test_dynamic_annotation_validation_happens_before_mutation() {
+    let session = annotation_test_session();
+    let invalid = [
+        Annotation::text(f64::NAN, 0.0, "nan"),
+        Annotation::hline(f64::INFINITY),
+        Annotation::rectangle(0.0, 0.0, -1.0, 1.0),
+        Annotation::fill_between(Vec::new(), Vec::new(), Vec::new()),
+        Annotation::fill_between(vec![0.5], vec![0.5], vec![0.5]),
+        Annotation::fill_between(vec![0.0, 1.0], vec![0.0], vec![0.0, 1.0]),
+        Annotation::FillBetween {
+            x: vec![0.0, 1.0],
+            y1: vec![0.0, f64::NEG_INFINITY],
+            y2: vec![0.0, 0.0],
+            style: FillStyle::default(),
+            where_positive: false,
+        },
+        Annotation::hspan(1.0, 0.0),
+        Annotation::VLine {
+            x: 0.5,
+            style: LineStyle::Solid,
+            color: Color::RED,
+            width: -1.0,
+        },
+    ];
+    for annotation in invalid {
+        assert!(matches!(
+            session.add_annotation(annotation),
+            Err(PlottingError::InvalidAnnotation { .. })
+        ));
+    }
+
+    let id = session.add_annotation(Annotation::vline(0.25)).unwrap();
+    let dirty_before = session.dirty_domains();
+    assert!(matches!(
+        session.update_annotation(id, Annotation::vline(f64::NAN)),
+        Err(PlottingError::InvalidAnnotation { .. })
+    ));
+    assert_eq!(session.dirty_domains(), dirty_before);
+    assert!(matches!(
+        session.annotation(id).unwrap(),
+        Annotation::VLine { x, .. } if x == 0.25
+    ));
+}
+
+#[test]
+fn test_dynamic_annotation_changes_dirty_only_overlay_and_reuse_base() {
+    let session = annotation_test_session();
+    let initial = session.render_to_surface(render_target()).unwrap();
+    assert_eq!(session.dirty_domains(), DirtyDomains::default());
+    let id = session.add_annotation(Annotation::vline(0.25)).unwrap();
+    assert_eq!(
+        session.dirty_domains(),
+        DirtyDomains {
+            overlay: true,
+            ..DirtyDomains::default()
+        }
+    );
+    let added = session.render_to_surface(render_target()).unwrap();
+    assert!(!added.layer_state.base_dirty);
+    assert!(added.layer_state.overlay_dirty);
+    assert!(Arc::ptr_eq(&initial.layers.base, &added.layers.base));
+
+    session
+        .update_annotation(id, Annotation::vline(0.75))
+        .unwrap();
+    let updated = session.render_to_surface(render_target()).unwrap();
+    assert!(!updated.layer_state.base_dirty);
+    assert!(updated.layer_state.overlay_dirty);
+    assert!(Arc::ptr_eq(&added.layers.base, &updated.layers.base));
+
+    session.remove_annotation(id).unwrap();
+    let removed = session.render_to_surface(render_target()).unwrap();
+    assert!(!removed.layer_state.base_dirty);
+    assert!(removed.layer_state.overlay_dirty);
+    assert!(Arc::ptr_eq(&updated.layers.base, &removed.layers.base));
+    assert!(removed.layers.overlay.is_none());
+}
+
+fn red_overlay_centroid_x(image: &Image) -> Option<f64> {
+    let mut total_x = 0.0;
+    let mut count = 0_u64;
+    for (index, pixel) in image.pixels.chunks_exact(4).enumerate() {
+        if pixel[0] > 180 && pixel[1] < 80 && pixel[2] < 80 && pixel[3] > 0 {
+            total_x += (index as u32 % image.width) as f64 + 0.5;
+            count += 1;
+        }
+    }
+    (count > 0).then_some(total_x / count as f64)
+}
+
+#[test]
+fn test_dynamic_annotation_tracks_current_zoom_transform() {
+    let session = annotation_test_session();
+    session.render_to_surface(render_target()).unwrap();
+    let id = session
+        .add_annotation(Annotation::vline_styled(
+            0.25,
+            Color::RED,
+            3.0,
+            LineStyle::Solid,
+        ))
+        .unwrap();
+    let before = session.render_to_surface(render_target()).unwrap();
+    let before_expected = session
+        .data_to_screen(ViewportPoint::new(0.25, 0.5))
+        .unwrap()
+        .unwrap()
+        .x;
+    let before_actual = red_overlay_centroid_x(before.layers.overlay.as_ref().unwrap()).unwrap();
+    assert!((before_actual - before_expected).abs() < 2.0);
+
+    let center = session
+        .data_to_screen(ViewportPoint::new(0.5, 0.5))
+        .unwrap()
+        .unwrap();
+    session.apply_input(PlotInputEvent::Zoom {
+        factor: 1.5,
+        center_px: center,
+    });
+    let after = session.render_to_surface(render_target()).unwrap();
+    let after_expected = session
+        .data_to_screen(ViewportPoint::new(0.25, 0.5))
+        .unwrap()
+        .unwrap()
+        .x;
+    let after_actual = red_overlay_centroid_x(after.layers.overlay.as_ref().unwrap()).unwrap();
+    assert!((after_actual - after_expected).abs() < 2.0);
+    assert!((after_actual - before_actual).abs() > 5.0);
+    assert!(matches!(
+        session.annotation(id).unwrap(),
+        Annotation::VLine { x, .. } if x == 0.25
+    ));
+}
+
+#[test]
+fn test_dynamic_annotations_are_clipped_to_displayed_plot_area() {
+    let session = annotation_test_session();
+    session.render_to_surface(render_target()).unwrap();
+    session
+        .add_annotation(Annotation::Rectangle {
+            x: -1.0,
+            y: -1.0,
+            width: 3.0,
+            height: 3.0,
+            style: ShapeStyle::default().fill(Color::RED),
+        })
+        .unwrap();
+    let frame = session.render_to_surface(render_target()).unwrap();
+    let overlay = frame.layers.overlay.as_ref().unwrap();
+    let plot_area = session.viewport_snapshot().unwrap().plot_area;
+
+    for (index, pixel) in overlay.pixels.chunks_exact(4).enumerate() {
+        if pixel[3] == 0 {
+            continue;
+        }
+        let x = (index as u32 % overlay.width) as f64 + 0.5;
+        let y = (index as u32 / overlay.width) as f64 + 0.5;
+        assert!(
+            plot_area.contains(ViewportPoint::new(x, y)),
+            "dynamic annotation pixel leaked outside plot area at ({x}, {y})"
+        );
+    }
+}
+
+#[test]
+fn test_dynamic_annotations_appear_and_move_in_image_capture() {
+    let session = annotation_test_session();
+    let target = ImageTarget {
+        size_px: (320, 240),
+        scale_factor: 1.0,
+        time_seconds: 0.0,
+    };
+    let base = session.render_to_image(target).unwrap();
+    let id = session
+        .add_annotation(Annotation::vline_styled(
+            0.25,
+            Color::RED,
+            4.0,
+            LineStyle::Solid,
+        ))
+        .unwrap();
+    let added = session.render_to_image(target).unwrap();
+    session
+        .update_annotation(
+            id,
+            Annotation::vline_styled(0.75, Color::RED, 4.0, LineStyle::Solid),
+        )
+        .unwrap();
+    let moved = session.render_to_image(target).unwrap();
+
+    assert_ne!(base.image.pixels, added.image.pixels);
+    assert_ne!(added.image.pixels, moved.image.pixels);
+    assert!(Arc::ptr_eq(&base.layers.base, &added.layers.base));
+    assert!(Arc::ptr_eq(&added.layers.base, &moved.layers.base));
+}
+
+#[test]
+fn test_dynamic_annotation_mutations_are_thread_safe() {
+    let session = annotation_test_session();
+    let threads = (0..8)
+        .map(|thread_index| {
+            let session = session.clone();
+            std::thread::spawn(move || {
+                for iteration in 0..32 {
+                    let x = (thread_index * 32 + iteration) as f64 / 512.0;
+                    let id = session.add_annotation(Annotation::vline(x)).unwrap();
+                    session
+                        .update_annotation(id, Annotation::vline(x + 0.01))
+                        .unwrap();
+                    assert!(session.remove_annotation(id).unwrap());
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    for thread in threads {
+        thread.join().expect("annotation mutation thread panicked");
+    }
+    let frame = session.render_to_surface(render_target()).unwrap();
+    assert!(frame.layers.overlay.is_none());
+}
+
+#[test]
+fn test_dynamic_spans_render_on_reversed_axes() {
+    let plot: Plot = Plot::new()
+        .line(&[0.0, 1.0], &[0.0, 1.0])
+        .xlim(1.0, 0.0)
+        .ylim(1.0, 0.0)
+        .ticks(false)
+        .grid(false)
+        .into();
+    let session = plot.prepare_interactive();
+    session.render_to_surface(render_target()).unwrap();
+    session
+        .add_annotation(Annotation::HSpan {
+            x_min: 0.2,
+            x_max: 0.6,
+            style: ShapeStyle::default().fill(Color::RED).fill_alpha(1.0),
+        })
+        .unwrap();
+    session
+        .add_annotation(Annotation::VSpan {
+            y_min: 0.2,
+            y_max: 0.6,
+            style: ShapeStyle::default().fill(Color::RED).fill_alpha(1.0),
+        })
+        .unwrap();
+    let frame = session.render_to_surface(render_target()).unwrap();
+    let overlay = frame
+        .layers
+        .overlay
+        .as_ref()
+        .expect("span overlay should render");
+    let opaque_pixels = overlay
+        .pixels
+        .chunks_exact(4)
+        .filter(|pixel| pixel[3] > 0)
+        .count();
+    assert!(
+        opaque_pixels > 0,
+        "reversed-axis spans must produce overlay pixels"
+    );
+}
+
+#[test]
+fn test_translucent_dynamic_annotation_composes_with_straight_alpha() {
+    let session = annotation_test_session();
+    let target = ImageTarget {
+        size_px: (320, 240),
+        scale_factor: 1.0,
+        time_seconds: 0.0,
+    };
+    session.render_to_image(target).unwrap();
+    session
+        .add_annotation(Annotation::VSpan {
+            y_min: 0.0,
+            y_max: 1.0,
+            style: ShapeStyle::default().fill(Color::RED).fill_alpha(0.5),
+        })
+        .unwrap();
+    let frame = session.render_to_image(target).unwrap();
+    let overlay = frame
+        .layers
+        .overlay
+        .as_ref()
+        .expect("translucent overlay should render");
+    let translucent_pixel = overlay
+        .pixels
+        .chunks_exact(4)
+        .find(|pixel| pixel[3] > 0 && pixel[3] < 255)
+        .expect("half-alpha span should produce translucent pixels");
+    // Straight (non-premultiplied) alpha: color channels must exceed the
+    // alpha-scaled value a premultiplied buffer would carry.
+    assert!(
+        translucent_pixel[0] > 200,
+        "red channel should stay near full intensity in straight alpha, got {:?}",
+        translucent_pixel
+    );
+}

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -3854,6 +3854,51 @@ fn test_dynamic_annotation_validation_happens_before_mutation() {
 }
 
 #[test]
+fn test_dynamic_annotation_rejects_nonpositive_coords_on_log_axes() {
+    let plot: Plot = Plot::new()
+        .line(&[1.0, 100.0], &[1.0, 100.0])
+        .xscale(crate::axes::AxisScale::Log)
+        .yscale(crate::axes::AxisScale::Log)
+        .into();
+    let session = plot.prepare_interactive();
+
+    let invalid = [
+        Annotation::text(-5.0, 1.0, "negative x"),
+        Annotation::text(5.0, 0.0, "zero y"),
+        Annotation::hline(0.0),
+        Annotation::vline(-1.0),
+        Annotation::rectangle(0.0, 1.0, 2.0, 2.0),
+        Annotation::hspan(0.0, 10.0),
+        Annotation::vspan(-2.0, 10.0),
+        Annotation::arrow(1.0, 1.0, 10.0, 0.0),
+        Annotation::fill_between(vec![1.0, 10.0], vec![0.0, 2.0], vec![3.0, 4.0]),
+    ];
+    for annotation in invalid {
+        assert!(matches!(
+            session.add_annotation(annotation),
+            Err(PlottingError::InvalidAnnotation { .. })
+        ));
+    }
+
+    let id = session
+        .add_annotation(Annotation::vline(5.0))
+        .expect("positive coordinates are valid on log axes");
+    assert!(matches!(
+        session.update_annotation(id, Annotation::vline(0.0)),
+        Err(PlottingError::InvalidAnnotation { .. })
+    ));
+
+    // Linear axes still accept zero/negative coordinates.
+    let linear = annotation_test_session();
+    linear
+        .add_annotation(Annotation::hline(0.0))
+        .expect("zero is valid on linear axes");
+    linear
+        .add_annotation(Annotation::text(-5.0, 0.0, "negative"))
+        .expect("negative coords are valid on linear axes");
+}
+
+#[test]
 fn test_dynamic_annotation_changes_dirty_only_overlay_and_reuse_base() {
     let session = annotation_test_session();
     let initial = session.render_to_surface(render_target()).unwrap();

--- a/src/core/plot/mod.rs
+++ b/src/core/plot/mod.rs
@@ -509,10 +509,10 @@ pub use configuration::{PlotConfiguration, TextEngineMode};
 pub use data::{IntoPlotData, PlotData, PlotSource, PlotText, ReactiveValue};
 pub use image::Image;
 pub use interactive_session::{
-    DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, ImageTarget, InteractiveFrame,
-    InteractiveFrameWithGeneration, InteractivePlotSession, InteractiveViewBoundsSnapshot,
-    InteractiveViewportSnapshot, LayerRenderState, PlotInputEvent, QualityPolicy, RenderTargetKind,
-    SurfaceCapability, SurfaceTarget, ViewportPoint, ViewportRect,
+    AnnotationId, DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, ImageTarget,
+    InteractiveFrame, InteractiveFrameWithGeneration, InteractivePlotSession,
+    InteractiveViewBoundsSnapshot, InteractiveViewportSnapshot, LayerRenderState, PlotInputEvent,
+    QualityPolicy, RenderTargetKind, SurfaceCapability, SurfaceTarget, ViewportPoint, ViewportRect,
 };
 pub use layout_manager::LayoutManager;
 pub use prepared::{PreparedPlot, ReactiveSubscription};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -824,15 +824,14 @@ pub mod prelude {
     pub use crate::axes::AxisScale;
     pub use crate::core::{
         Annotation, AnnotationId, ArrowHead, ArrowStyle, BackendType, BuilderWhen, FillStyle,
-        FramePacing,
-        FrameStats, GridSpec, HatchPattern, HitResult, Image, ImageTarget, InsetAnchor,
-        InsetLayout, InteractiveFrame, InteractivePlotSession, InteractiveViewportSnapshot,
-        IntoPlot, LayerRenderState, Legend, LegendAnchor, LegendItem, LegendItemType,
-        LegendPosition, Plot, PlotBuilder, PlotInput, PlotInputEvent, PlotSource, Position,
-        PreparedPlot, QualityPolicy, ReactiveSubscription, ReactiveValue, RenderTargetKind, Result,
-        SeriesStyle, ShapeStyle, SubplotFigure, SurfaceCapability, SurfaceTarget, TextAlign,
-        TextStyle, TextVAlign, TickDirection, TickSides, ViewportPoint, ViewportRect, subplots,
-        subplots_default,
+        FramePacing, FrameStats, GridSpec, HatchPattern, HitResult, Image, ImageTarget,
+        InsetAnchor, InsetLayout, InteractiveFrame, InteractivePlotSession,
+        InteractiveViewportSnapshot, IntoPlot, LayerRenderState, Legend, LegendAnchor, LegendItem,
+        LegendItemType, LegendPosition, Plot, PlotBuilder, PlotInput, PlotInputEvent, PlotSource,
+        Position, PreparedPlot, QualityPolicy, ReactiveSubscription, ReactiveValue,
+        RenderTargetKind, Result, SeriesStyle, ShapeStyle, SubplotFigure, SurfaceCapability,
+        SurfaceTarget, TextAlign, TextStyle, TextVAlign, TickDirection, TickSides, ViewportPoint,
+        ViewportRect, subplots, subplots_default,
     };
     pub use crate::data::{
         Data1D, DataShader, DataShaderCanvas, NullPolicy, NumericData1D, NumericData2D,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,7 +823,8 @@ pub mod animation;
 pub mod prelude {
     pub use crate::axes::AxisScale;
     pub use crate::core::{
-        Annotation, ArrowHead, ArrowStyle, BackendType, BuilderWhen, FillStyle, FramePacing,
+        Annotation, AnnotationId, ArrowHead, ArrowStyle, BackendType, BuilderWhen, FillStyle,
+        FramePacing,
         FrameStats, GridSpec, HatchPattern, HitResult, Image, ImageTarget, InsetAnchor,
         InsetLayout, InteractiveFrame, InteractivePlotSession, InteractiveViewportSnapshot,
         IntoPlot, LayerRenderState, Legend, LegendAnchor, LegendItem, LegendItemType,

--- a/src/render/skia.rs
+++ b/src/render/skia.rs
@@ -3035,6 +3035,19 @@ impl SkiaRenderer {
         }
     }
 
+    /// Consume the renderer and convert to an `Image` with straight-alpha
+    /// (demultiplied) RGBA pixels.
+    ///
+    /// Use this when the buffer will be composed by straight-alpha blenders
+    /// (e.g. the interactive overlay compositor) rather than tiny-skia.
+    pub fn into_image_demultiplied(self) -> Image {
+        Image {
+            width: self.width,
+            height: self.height,
+            pixels: self.pixmap.take_demultiplied(),
+        }
+    }
+
     /// Save the current pixmap as a PNG with straight-alpha RGBA encoding.
     pub fn save_png<P: AsRef<Path>>(&self, path: P) -> Result<()> {
         crate::export::write_bytes_atomic(path, &self.encode_png_bytes()?)

--- a/src/render/skia/annotations.rs
+++ b/src/render/skia/annotations.rs
@@ -714,8 +714,13 @@ impl SkiaRenderer {
         style: &crate::core::ShapeStyle,
         transform: &AnnotationTransform<'_>,
     ) -> Result<()> {
-        let px_min = transform.x_pixel(span_x_min);
-        let px_max = transform.x_pixel(span_x_max);
+        // Reversed axis limits can map ordered data endpoints to decreasing
+        // pixel coordinates; sort before clamping so the span still renders.
+        let (px_min, px_max) = {
+            let a = transform.x_pixel(span_x_min);
+            let b = transform.x_pixel(span_x_max);
+            (a.min(b), a.max(b))
+        };
 
         // Clamp to plot area
         let left = px_min
@@ -753,8 +758,13 @@ impl SkiaRenderer {
         style: &crate::core::ShapeStyle,
         transform: &AnnotationTransform<'_>,
     ) -> Result<()> {
-        let py_max = transform.y_pixel(span_y_min);
-        let py_min = transform.y_pixel(span_y_max);
+        // Reversed axis limits can map ordered data endpoints to decreasing
+        // pixel coordinates; sort before clamping so the span still renders.
+        let (py_min, py_max) = {
+            let a = transform.y_pixel(span_y_min);
+            let b = transform.y_pixel(span_y_max);
+            (a.min(b), a.max(b))
+        };
 
         // Clamp to plot area
         let top = py_min


### PR DESCRIPTION
Closes #104
Part of #97

## Summary

Adds session-owned dynamic annotations to `InteractivePlotSession` so every existing `Annotation` variant (`Text`, `Arrow`, `HLine`, `VLine`, `Rectangle`, `FillBetween`, `HSpan`, `VSpan`) can be added, queried, updated/moved, and removed without rebuilding the prepared plot.

- **Opaque `AnnotationId`** carries a per-session token; foreign IDs (minted by another session) and stale IDs (after removal) are rejected with `PlottingError::UnknownAnnotationId`.
- **Validation before mutation**: finite coordinates, `FillBetween` equal vector lengths (>= 2 samples), non-negative widths/sizes, alpha in [0, 1], valid dash patterns (`PlottingError::InvalidAnnotation`).
- **Overlay-only invalidation**: annotation changes mark only `DirtyDomain::Overlay`; base geometry/layout/data caches are reused (tests assert `Arc::ptr_eq` on the base layer across add/update/remove).
- **Renderer reuse**: the dynamic overlay renders through the existing skia `draw_annotations_where_scaled` path using the displayed view bounds, DPI/render scale, and text engine, clipped to the plot area. Annotations follow pan/zoom, appear in `render_to_image` captures, and compose with the GPUI surface path.
- **Cache correctness**: the overlay cache key includes an annotations revision counter and the displayed view bounds, so pan/zoom/temporal geometry changes invalidate stale annotation pixels; annotation values are only cloned when a fresh raster is needed.
- **Compositing fixes** (from independent review): the annotation raster is demultiplied before straight-alpha blending, interaction overlay primitives (hover/brush/tooltip) now composite with straight-alpha source-over so they preserve annotation coverage underneath, and `HSpan`/`VSpan` renderers normalize pixel endpoints so spans render on reversed axes.
- **GPUI**: thin `add_annotation`/`annotation`/`update_annotation`/`remove_annotation` wrappers on `RuvizPlot` that delegate to the session and `cx.notify()`, plus a new `movable_annotation` example with a draggable vertical line driven by plot pointer events.

No `unsafe` code; storage is a `Mutex`-guarded map on the session.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean (known baseline: clippy.toml 1.87.0 vs Cargo.toml rust-version 1.92 MSRV mismatch warning)
- `cargo test --lib` — 1227 passed, 0 failed (includes new tests: all 8 variants lifecycle, foreign/stale IDs, invalid values, overlay-only invalidation + base cache reuse, zoom transform tracking, plot-area clipping, image capture, 8-thread concurrency, reversed-axis spans, straight-alpha composition)
- `cargo test -p ruviz-gpui` — 44 passed (includes new wrapper delegation test)
- `cargo check -p ruviz-gpui --examples` — clean
- `cargo clippy -p ruviz-gpui --all-targets -- -D warnings` — clean
- Independent Codex review (`codex review --base origin/gpui/set-plot-keep-view`), 3 rounds: 6 findings fixed (premultiplied-alpha composition, reversed-axis spans, single-sample FillBetween, stale overlay after temporal geometry change, overlay coverage loss under interaction primitives, per-frame annotation cloning); final round clean.