### PR TITLE
Add generic conditional builder combinator BuilderWhen

### DIFF
--- a/crates/ruviz-gpui/src/lib.rs
+++ b/crates/ruviz-gpui/src/lib.rs
@@ -1394,6 +1394,22 @@ mod platform_impl {
         }
 
         #[test]
+        fn test_builder_when_coexists_with_gpui_fluent_builder() {
+            // Both preludes export a `.when(...)` extension; ruviz's BuilderWhen
+            // is implemented only for ruviz builder families so neither call is
+            // ambiguous when both preludes are glob-imported.
+            use gpui::prelude::*;
+            use ruviz::prelude::*;
+
+            let _plot: Plot = Plot::new()
+                .when(true, |plot| plot.title("conditional"))
+                .line(&[0.0, 1.0], &[0.0, 1.0])
+                .when(true, |builder| builder.label("series"))
+                .into();
+            let _element = gpui::div().when(true, |div| div.flex());
+        }
+
+        #[test]
         fn test_rgba_to_bgra_conversion() {
             let mut pixels = vec![1, 2, 3, 255, 10, 20, 30, 128];
             rgba_to_bgra_in_place(&mut pixels);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -39,9 +39,9 @@ pub use legend::{
     LegendSpacingPixels, LegendStyle, find_best_position,
 };
 pub use plot::{
-    BackendFallbackReason, BackendOperation, BackendResolution, BackendType, DirtyDomain,
-    DirtyDomains, FramePacing, FrameStats, HitResult, Image, ImageTarget, InsetAnchor, InsetLayout,
-    InteractiveFrame, InteractiveFrameWithGeneration, InteractivePlotSession,
+    BackendFallbackReason, BackendOperation, BackendResolution, BackendType, BuilderWhen,
+    DirtyDomain, DirtyDomains, FramePacing, FrameStats, HitResult, Image, ImageTarget, InsetAnchor,
+    InsetLayout, InteractiveFrame, InteractiveFrameWithGeneration, InteractivePlotSession,
     InteractiveViewportSnapshot, IntoPlot, LayerRenderState, Plot, PlotBuilder, PlotInput,
     PlotInputEvent, PlotSource, PreparedPlot, QualityPolicy, ReactiveSubscription, ReactiveValue,
     RenderTargetKind, SeriesStyle, SurfaceCapability, SurfaceTarget, TextEngineMode, TickDirection,

--- a/src/core/plot/builder.rs
+++ b/src/core/plot/builder.rs
@@ -52,6 +52,46 @@
 use super::data::{PlotData, ReactiveValue};
 use crate::render::{Color, LineStyle, MarkerStyle};
 
+/// Extension trait providing a generic conditional combinator for fluent builders.
+///
+/// Implemented for ruviz's consuming builder families rather than as a blanket
+/// impl over all types so that `use ruviz::prelude::*` can coexist with other
+/// fluent-builder preludes (e.g. GPUI's `FluentBuilder::when`) without method
+/// ambiguity.
+pub trait BuilderWhen: Sized {
+    /// Apply `f` to `self` when `condition` is true; otherwise return `self` unchanged.
+    ///
+    /// The closure is not invoked when `condition` is false.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use ruviz::prelude::*;
+    ///
+    /// let x = vec![0.0, 1.0, 2.0];
+    /// let y = vec![0.0, 1.0, 0.5];
+    /// let show_label = true;
+    ///
+    /// let _plot = Plot::new()
+    ///     .line(&x, &y)
+    ///     .when(show_label, |builder| builder.label("series"))
+    ///     .into_plot();
+    /// ```
+    fn when(self, condition: bool, f: impl FnOnce(Self) -> Self) -> Self {
+        if condition { f(self) } else { self }
+    }
+}
+
+impl BuilderWhen for super::Plot {}
+impl<C> BuilderWhen for PlotBuilder<C> where C: crate::plots::PlotConfig + Clone {}
+impl BuilderWhen for super::series_builders::PlotSeriesBuilder {}
+impl BuilderWhen for super::series_builders::SeriesGroupBuilder {}
+impl BuilderWhen for crate::core::subplot::SubplotFigure {}
+impl BuilderWhen for crate::core::config::PlotConfigBuilder {}
+impl BuilderWhen for crate::render::theme::ThemeBuilder {}
+#[cfg(all(feature = "interactive", not(target_arch = "wasm32")))]
+impl BuilderWhen for crate::interactive::window::InteractiveWindowBuilder {}
+
 /// Trait for types that can be converted to a finalized [`Plot`](super::Plot)
 ///
 /// This trait enables uniform handling of all builder types (`Plot`, `PlotBuilder<C>`,

--- a/src/core/plot/builder/tests.rs
+++ b/src/core/plot/builder/tests.rs
@@ -9,6 +9,36 @@ struct TestConfig {
 impl crate::plots::PlotConfig for TestConfig {}
 
 #[test]
+fn builder_when_applies_true_branch() {
+    let builder = PlotBuilder::new(
+        super::super::Plot::new(),
+        PlotInput::Single(vec![1.0, 2.0, 3.0]),
+        TestConfig::default(),
+    )
+    .when(true, |builder| builder.label("conditional"));
+
+    assert_eq!(builder.style.label.as_deref(), Some("conditional"));
+}
+
+#[test]
+fn builder_when_skips_false_branch_and_preserves_builder() {
+    let mut closure_invoked = false;
+    let builder = PlotBuilder::new(
+        super::super::Plot::new(),
+        PlotInput::Single(vec![1.0, 2.0, 3.0]),
+        TestConfig::default(),
+    )
+    .label("original")
+    .when(false, |builder| {
+        closure_invoked = true;
+        builder.label("changed")
+    });
+
+    assert!(!closure_invoked);
+    assert_eq!(builder.style.label.as_deref(), Some("original"));
+}
+
+#[test]
 fn test_plot_builder_creation() {
     let plot = super::super::Plot::new();
     let input = PlotInput::Single(vec![1.0, 2.0, 3.0]);

--- a/src/core/plot/mod.rs
+++ b/src/core/plot/mod.rs
@@ -500,7 +500,7 @@ mod series_manager;
 mod tests;
 mod types;
 
-pub use builder::{IntoPlot, PlotBuilder, PlotInput, SeriesStyle};
+pub use builder::{BuilderWhen, IntoPlot, PlotBuilder, PlotInput, SeriesStyle};
 pub use config::{
     BackendFallbackReason, BackendOperation, BackendResolution, BackendType, GridMode,
     TickDirection, TickSides,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -823,14 +823,15 @@ pub mod animation;
 pub mod prelude {
     pub use crate::axes::AxisScale;
     pub use crate::core::{
-        Annotation, ArrowHead, ArrowStyle, BackendType, FillStyle, FramePacing, FrameStats,
-        GridSpec, HatchPattern, HitResult, Image, ImageTarget, InsetAnchor, InsetLayout,
-        InteractiveFrame, InteractivePlotSession, InteractiveViewportSnapshot, IntoPlot,
-        LayerRenderState, Legend, LegendAnchor, LegendItem, LegendItemType, LegendPosition, Plot,
-        PlotBuilder, PlotInput, PlotInputEvent, PlotSource, Position, PreparedPlot, QualityPolicy,
-        ReactiveSubscription, ReactiveValue, RenderTargetKind, Result, SeriesStyle, ShapeStyle,
-        SubplotFigure, SurfaceCapability, SurfaceTarget, TextAlign, TextStyle, TextVAlign,
-        TickDirection, TickSides, ViewportPoint, ViewportRect, subplots, subplots_default,
+        Annotation, ArrowHead, ArrowStyle, BackendType, BuilderWhen, FillStyle, FramePacing,
+        FrameStats, GridSpec, HatchPattern, HitResult, Image, ImageTarget, InsetAnchor,
+        InsetLayout, InteractiveFrame, InteractivePlotSession, InteractiveViewportSnapshot,
+        IntoPlot, LayerRenderState, Legend, LegendAnchor, LegendItem, LegendItemType,
+        LegendPosition, Plot, PlotBuilder, PlotInput, PlotInputEvent, PlotSource, Position,
+        PreparedPlot, QualityPolicy, ReactiveSubscription, ReactiveValue, RenderTargetKind, Result,
+        SeriesStyle, ShapeStyle, SubplotFigure, SurfaceCapability, SurfaceTarget, TextAlign,
+        TextStyle, TextVAlign, TickDirection, TickSides, ViewportPoint, ViewportRect, subplots,
+        subplots_default,
     };
     pub use crate::data::{
         Data1D, DataShader, DataShaderCanvas, NullPolicy, NumericData1D, NumericData2D,

--- a/tests/nonbreaking_plot_api_test.rs
+++ b/tests/nonbreaking_plot_api_test.rs
@@ -2,6 +2,48 @@ use ruviz::core::{BackendFallbackReason, BackendOperation};
 use ruviz::prelude::*;
 
 #[test]
+fn builder_when_compiles_across_public_builder_families() {
+    let x = vec![0.0, 1.0, 2.0];
+    let y = vec![0.0, 1.0, 0.5];
+    let data = vec![1.0, 2.0, 3.0, 4.0];
+
+    let _plot = Plot::new()
+        .when(true, |plot| plot.title("conditional title"))
+        .grid(false);
+
+    let _generic_builder = Plot::new()
+        .line(&x, &y)
+        .when(true, |builder| builder.label("line"))
+        .line_width(2.0);
+
+    let _series_builder = Plot::new()
+        .histogram(&data, None)
+        .when(true, |builder| builder.label("histogram"))
+        .width(2.0);
+
+    let _grouped_plot = Plot::new().group(|group| {
+        group
+            .when(true, |group| group.group_label("group"))
+            .line_width(2.0)
+            .line(&x, &y)
+    });
+
+    let figure = SubplotFigure::new(1, 1, 400, 300)
+        .expect("subplot figure should be constructed")
+        .when(true, |figure| figure.suptitle("conditional title"))
+        .margin(0.1);
+    assert_eq!(figure.grid_spec().total_subplots(), 1);
+}
+
+#[cfg(all(feature = "interactive", not(target_arch = "wasm32")))]
+#[test]
+fn builder_when_compiles_for_interactive_window_builder() {
+    let _builder = InteractiveWindowBuilder::new()
+        .when(true, |window| window.resizable(false))
+        .title("conditional");
+}
+
+#[test]
 fn high_level_step_area_and_stem_apis_render() {
     let x = vec![0.0, 1.0, 2.0, 3.0];
     let y = vec![1.0, 3.0, 2.0, 4.0];


### PR DESCRIPTION
Closes #107
Part of #97

## Summary

Adds a `BuilderWhen` extension trait with a single generic consuming combinator:

```rust
Plot::new()
    .line(&x, &y)
    .when(show_label, |builder| builder.label("series"))
```

- The closure runs only when the condition is true; otherwise the builder is returned unchanged and the closure is never invoked (asserted by test).
- Exported through the plot module and the prelude, with a doc example. No option-specific setters (`label_opt` etc.) were added.
- Implemented for ruviz's consuming builder families — `Plot`, `PlotBuilder<C>`, `PlotSeriesBuilder`, `SeriesGroupBuilder`, `SubplotFigure`, `PlotConfigBuilder`, `ThemeBuilder`, and the feature-gated `InteractiveWindowBuilder` — rather than as a blanket impl over all sized types. An independent review caught that a blanket impl makes GPUI's `FluentBuilder::when` ambiguous (E0034) whenever `gpui::prelude::*` and `ruviz::prelude::*` are both glob-imported, which the ruviz-gpui examples do. A ruviz-gpui test now locks in prelude coexistence.

## Validation

- `cargo fmt --all -- --check`; `cargo clippy --all-targets -- -D warnings` and `--features interactive` variant (only the known baseline MSRV mismatch warning: clippy.toml 1.87.0 vs Cargo.toml 1.92)
- `cargo test --lib -- builder_when` (2), `cargo test --test nonbreaking_plot_api_test` with (23) and without (22) the `interactive` feature — covers `Plot`, generic builder, series builder, group builder, `SubplotFigure`, and `InteractiveWindowBuilder` type inference
- `cargo test --doc when` (doc example), `cargo test -p ruviz-gpui` (22, incl. new prelude-coexistence test), `cargo check -p ruviz-gpui --examples`, `cargo clippy -p ruviz-gpui --all-targets -- -D warnings`
- Two rounds of independent Codex (gpt-5.6-sol) review: round 1 P1 (blanket-impl/GPUI ambiguity) fixed by restricting impls; round 2 P2 (missing `InteractiveWindowBuilder` coverage) fixed with a feature-gated impl + compile test.

## Note on scope

Deviating slightly from the issue's "blanket-implement for all sized builder values": the blanket impl is a compile-breaking hazard for the supported GPUI embedding, so the trait is implemented for each exported ruviz builder family instead. The acceptance criteria (one consistent `.when(...)`, false branch skipped, inference intact, no dummy-plot workarounds) all hold.