### PR TITLE
Restore public layout struct constructibility

### DIFF
--- a/src/core/layout.rs
+++ b/src/core/layout.rs
@@ -15,6 +15,7 @@
 //! 4. **Center the plot** - Distribute extra space symmetrically
 
 use crate::core::{RenderScale, SpacingConfig, TypographyConfig};
+use std::ops::{Deref, DerefMut};
 
 // =============================================================================
 // Data Structures
@@ -76,9 +77,6 @@ impl LayoutRect {
 pub struct PlotLayout {
     /// The plotting area where data is drawn
     pub plot_area: LayoutRect,
-
-    /// Pre-measured and resolved legend bounds for an outside legend.
-    pub(crate) legend_rect: Option<LayoutRect>,
 
     /// Title position (top center point), None if no title
     pub title_pos: Option<TextPosition>,
@@ -179,7 +177,48 @@ pub struct MeasuredDimensions {
     pub xtick: Option<(f32, f32)>,
     pub ytick: Option<(f32, f32)>,
     pub right_margin: Option<f32>,
+}
+
+/// Crate-internal measurements used while resolving a complete render layout.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub(crate) struct LayoutMeasurements {
+    pub(crate) dimensions: MeasuredDimensions,
     pub(crate) legend: Option<(f32, f32)>,
+}
+
+impl Deref for LayoutMeasurements {
+    type Target = MeasuredDimensions;
+
+    fn deref(&self) -> &Self::Target {
+        &self.dimensions
+    }
+}
+
+impl DerefMut for LayoutMeasurements {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.dimensions
+    }
+}
+
+/// Crate-internal composition of the public layout and outside-legend state.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ResolvedLayout {
+    pub(crate) layout: PlotLayout,
+    pub(crate) legend_rect: Option<LayoutRect>,
+}
+
+impl Deref for ResolvedLayout {
+    type Target = PlotLayout;
+
+    fn deref(&self) -> &Self::Target {
+        &self.layout
+    }
+}
+
+impl DerefMut for ResolvedLayout {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.layout
+    }
 }
 
 // =============================================================================
@@ -400,7 +439,6 @@ impl LayoutCalculator {
 
         PlotLayout {
             plot_area,
-            legend_rect: None,
             title_pos,
             xlabel_pos,
             ylabel_pos,
@@ -564,7 +602,6 @@ mod tests {
             xtick: None,
             ytick: None,
             right_margin: None,
-            legend: None,
         };
         let measured = calculator.compute(
             (640, 480),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,6 +32,7 @@ pub use layout::{
     ComputedMarginsPixels, LayoutCalculator, LayoutConfig, LayoutRect, MeasuredDimensions,
     PlotContent, PlotLayout, TextPosition,
 };
+pub(crate) use layout::{LayoutMeasurements, ResolvedLayout};
 #[allow(deprecated)]
 pub use legend::LegendFrame; // Deprecated alias for backward compatibility
 pub use legend::{

--- a/src/core/plot/mod.rs
+++ b/src/core/plot/mod.rs
@@ -524,10 +524,11 @@ pub use types::{InsetAnchor, InsetLayout, Plot};
 use crate::{
     axes::AxisScale,
     core::{
-        Annotation, ArrowStyle, FillStyle, GridStyle, LayoutCalculator, LayoutConfig, Legend,
-        LegendItem, LegendItemType, LegendPosition, MarginConfig, MeasuredDimensions, PlotConfig,
-        PlotContent, PlotLayout, PlotStyle, PlottingError, Position, REFERENCE_DPI, RenderScale,
-        Result, ShapeStyle, StyleResolver, TextStyle, pt_to_px,
+        Annotation, ArrowStyle, FillStyle, GridStyle, LayoutCalculator, LayoutConfig,
+        LayoutMeasurements, Legend, LegendItem, LegendItemType, LegendPosition, MarginConfig,
+        MeasuredDimensions, PlotConfig, PlotContent, PlotLayout, PlotStyle, PlottingError,
+        Position, REFERENCE_DPI, RenderScale, ResolvedLayout, Result, ShapeStyle, StyleResolver,
+        TextStyle, pt_to_px,
     },
     data::{
         Data1D, DataShader, NullPolicy, NumericData1D, NumericData2D, StreamingXY,

--- a/src/core/plot/render.rs
+++ b/src/core/plot/render.rs
@@ -1280,14 +1280,14 @@ impl Plot {
         renderer: &SkiaRenderer,
         content: &PlotContent,
         dpi: f32,
-    ) -> Result<Option<MeasuredDimensions>> {
+    ) -> Result<Option<LayoutMeasurements>> {
         let render_scale = RenderScale::new(dpi);
         let title_size_px =
             render_scale.points_to_pixels(self.display.config.typography.title_size());
         let label_size_px =
             render_scale.points_to_pixels(self.display.config.typography.label_size());
 
-        let mut measurements = MeasuredDimensions::default();
+        let mut measurements = LayoutMeasurements::default();
 
         if let Some(title) = content.title.as_deref() {
             measurements.title = Some(renderer.measure_text_with_weight(
@@ -1313,7 +1313,7 @@ impl Plot {
         dpi: f32,
         x_tick_labels: &[String],
         y_tick_labels: &[String],
-    ) -> Result<Option<MeasuredDimensions>> {
+    ) -> Result<Option<LayoutMeasurements>> {
         let tick_size_px =
             RenderScale::new(dpi).points_to_pixels(self.display.config.typography.tick_size());
         let mut measurements = self
@@ -1381,8 +1381,9 @@ impl Plot {
         canvas_size: (u32, u32),
         content: &PlotContent,
         dpi: f32,
-        measurements: Option<&MeasuredDimensions>,
-    ) -> PlotLayout {
+        measurements: Option<&LayoutMeasurements>,
+    ) -> ResolvedLayout {
+        let measured_dimensions = measurements.map(|m| &m.dimensions);
         let layout = match &self.display.config.margins {
             MarginConfig::ContentDriven {
                 edge_buffer,
@@ -1398,24 +1399,35 @@ impl Plot {
                 &self.display.config.typography,
                 &self.display.config.spacing,
                 dpi,
-                measurements,
+                measured_dimensions,
             ),
             MarginConfig::Fixed { .. }
             | MarginConfig::Auto { .. }
-            | MarginConfig::Proportional { .. } => {
-                self.compute_layout_with_explicit_margins(canvas_size, content, dpi, measurements)
-            }
+            | MarginConfig::Proportional { .. } => self.compute_layout_with_explicit_margins(
+                canvas_size,
+                content,
+                dpi,
+                measured_dimensions,
+            ),
         };
-        self.reserve_outside_legend(layout, canvas_size, dpi, measurements)
+        self.reserve_outside_legend(
+            ResolvedLayout {
+                layout,
+                legend_rect: None,
+            },
+            canvas_size,
+            dpi,
+            measurements,
+        )
     }
 
     fn reserve_outside_legend(
         &self,
-        mut layout: PlotLayout,
+        mut layout: ResolvedLayout,
         canvas_size: (u32, u32),
         dpi: f32,
-        measurements: Option<&MeasuredDimensions>,
-    ) -> PlotLayout {
+        measurements: Option<&LayoutMeasurements>,
+    ) -> ResolvedLayout {
         let Some((legend_width, legend_height)) = measurements.and_then(|m| m.legend) else {
             return layout;
         };
@@ -1656,7 +1668,6 @@ impl Plot {
 
         PlotLayout {
             plot_area,
-            legend_rect: None,
             title_pos: content
                 .title
                 .as_ref()
@@ -1733,7 +1744,7 @@ impl Plot {
         x_max: f64,
         y_min: f64,
         y_max: f64,
-    ) -> Result<(PlotLayout, Vec<f64>, Vec<f64>)> {
+    ) -> Result<(ResolvedLayout, Vec<f64>, Vec<f64>)> {
         if !content.show_tick_labels {
             let measurements =
                 self.measure_layout_text_with_ticks(renderer, content, dpi, &[], &[])?;

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -628,7 +628,7 @@ fn compute_render_plot_area(plot: &Plot) -> tiny_skia::Rect {
     Plot::plot_area_from_layout(&layout).expect("valid plot area")
 }
 
-fn compute_render_layout(plot: &Plot) -> PlotLayout {
+fn compute_render_layout(plot: &Plot) -> ResolvedLayout {
     let (x_min, x_max, y_min, y_max) = plot
         .calculate_data_bounds()
         .expect("data bounds should be available");
@@ -708,7 +708,7 @@ fn compute_render_tick_probe_points(plot: &Plot) -> ((u32, u32), (u32, u32)) {
     (top_probe, right_probe)
 }
 
-fn compute_layout_without_tick_measurements(plot: &Plot) -> PlotLayout {
+fn compute_layout_without_tick_measurements(plot: &Plot) -> ResolvedLayout {
     let (x_min, x_max, y_min, y_max) = plot
         .calculate_data_bounds()
         .expect("data bounds should be available");
@@ -2981,9 +2981,9 @@ fn test_render_to_svg_uses_layout_positions_for_title_and_labels() {
         measured_dimensions.as_ref(),
     );
 
-    let title_pos = layout.title_pos.expect("title position");
-    let xlabel_pos = layout.xlabel_pos.expect("xlabel position");
-    let ylabel_pos = layout.ylabel_pos.expect("ylabel position");
+    let title_pos = layout.title_pos.as_ref().expect("title position");
+    let xlabel_pos = layout.xlabel_pos.as_ref().expect("xlabel position");
+    let ylabel_pos = layout.ylabel_pos.as_ref().expect("ylabel position");
     let text_renderer = TextRenderer::new();
     let title_metrics = text_renderer
         .measure_text_placement(
@@ -3338,9 +3338,9 @@ fn test_render_to_svg_typst_uses_layout_anchor_contract() {
         measured_dimensions.as_ref(),
     );
 
-    let title_pos = layout.title_pos.expect("title position");
-    let xlabel_pos = layout.xlabel_pos.expect("xlabel position");
-    let ylabel_pos = layout.ylabel_pos.expect("ylabel position");
+    let title_pos = layout.title_pos.as_ref().expect("title position");
+    let xlabel_pos = layout.xlabel_pos.as_ref().expect("xlabel position");
+    let ylabel_pos = layout.ylabel_pos.as_ref().expect("ylabel position");
 
     let typst_groups = extract_typst_group_boxes(&svg);
     assert!(

--- a/tests/nonbreaking_plot_api_test.rs
+++ b/tests/nonbreaking_plot_api_test.rs
@@ -1,5 +1,47 @@
-use ruviz::core::{BackendFallbackReason, BackendOperation};
+use ruviz::core::{
+    BackendFallbackReason, BackendOperation, ComputedMarginsPixels, LayoutRect, MeasuredDimensions,
+    PlotLayout, TextPosition,
+};
 use ruviz::prelude::*;
+
+#[test]
+fn layout_structs_support_exhaustive_external_construction() {
+    let plot_area = LayoutRect {
+        left: 10.0,
+        top: 20.0,
+        right: 310.0,
+        bottom: 220.0,
+    };
+    let layout = PlotLayout {
+        plot_area,
+        title_pos: Some(TextPosition {
+            x: 160.0,
+            y: 5.0,
+            size: 18.0,
+        }),
+        xlabel_pos: None,
+        ylabel_pos: None,
+        xtick_baseline_y: 225.0,
+        ytick_right_x: 5.0,
+        margins: ComputedMarginsPixels {
+            left: 10.0,
+            right: 10.0,
+            top: 20.0,
+            bottom: 20.0,
+        },
+    };
+    let measured = MeasuredDimensions {
+        title: Some((100.0, 20.0)),
+        xlabel: None,
+        ylabel: None,
+        xtick: Some((30.0, 12.0)),
+        ytick: Some((24.0, 12.0)),
+        right_margin: Some(10.0),
+    };
+
+    assert_eq!(layout.plot_area, plot_area);
+    assert_eq!(measured.title, Some((100.0, 20.0)));
+}
 
 #[test]
 fn builder_when_compiles_across_public_builder_families() {


### PR DESCRIPTION
Closes #122

PR #118 added `pub(crate) legend_rect` to `PlotLayout` and `pub(crate) legend` to `MeasuredDimensions`. Both structs are publicly exported with otherwise all-public fields, so downstream crates constructing them with exhaustive struct literals stopped compiling — a semver break that could not ship as 0.4.21.

## Fix

Legend placement state is moved out of the public structs into crate-internal composition types in `src/core/layout.rs`:

- `LayoutMeasurements` = public `MeasuredDimensions` + measured legend size
- `ResolvedLayout` = public `PlotLayout` + resolved outside-legend rectangle

Both deref to their public payloads, so the raster, SVG, parallel, subplot, and interactive render paths are unchanged apart from consuming the resolved wrapper. The outside-legend reservation algorithm (all four `Outside*` branches) is untouched except for where the rectangle is stored.

`PlotLayout` and `MeasuredDimensions` now match their v0.4.20 field sets exactly (verified against `git show v0.4.20:src/core/layout.rs`), with every field `pub`.

## Regression guard

`tests/nonbreaking_plot_api_test.rs` gains a test that constructs both structs with exhaustive struct literals from an external-crate context — exactly the downstream pattern that broke — so reintroducing a required or private field fails CI.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — 0 errors (known MSRV-config warning only)
- `cargo test --lib` — 1263 passed
- `cargo test --lib -- legend` — 34 passed
- `cargo test --test nonbreaking_plot_api_test` — 23 passed
- `cargo test -p ruviz-gpui` — 45 passed