### PR TITLE
Track streaming acknowledgements per consumer

### DIFF
--- a/src/core/plot/construction.rs
+++ b/src/core/plot/construction.rs
@@ -1387,13 +1387,12 @@ impl Plot {
                 let snapshot_index = if let Some(index) = snapshot_index {
                     index
                 } else {
-                    let (x, y, sequence, render_state) = stream.snapshot().into_parts();
+                    let (x, y, watermark) = stream.snapshot().into_parts();
                     paired_acknowledgements.push(ResolvedStreamingPair {
                         source: stream.clone(),
                         x: Arc::from(x),
                         y: Arc::from(y),
-                        sequence,
-                        render_state,
+                        watermark,
                     });
                     paired_acknowledgements.len() - 1
                 };

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -956,6 +956,59 @@ struct InteractiveFrameCache {
     geometry: GeometrySnapshot,
     displayed_data: DisplayedFrameData,
     point_hit_index: LazyPointHitIndex,
+    streaming_watermarks: StreamingFrameWatermarks,
+}
+
+#[derive(Clone, Default)]
+struct StreamingFrameWatermarks {
+    generic: Vec<crate::data::StreamingBuffer<f64>>,
+    paired: Vec<PairedStreamingWatermark>,
+}
+
+impl std::fmt::Debug for StreamingFrameWatermarks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamingFrameWatermarks")
+            .field("generic_count", &self.generic.len())
+            .field("paired", &self.paired)
+            .finish()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct PairedStreamingWatermark {
+    source: crate::data::StreamingXY,
+    sequence: u64,
+}
+
+impl StreamingFrameWatermarks {
+    fn capture(frame: &ResolvedFrame<'_>) -> Self {
+        Self {
+            generic: frame.streaming_acknowledgements.clone(),
+            paired: frame
+                .paired_acknowledgements
+                .iter()
+                .map(|stream| PairedStreamingWatermark {
+                    source: stream.source.clone(),
+                    sequence: stream.watermark.sequence(),
+                })
+                .collect(),
+        }
+    }
+
+    fn generic_streams_allow_incremental(&self, frame: &ResolvedFrame<'_>) -> bool {
+        frame.streaming_acknowledgements.iter().all(|current| {
+            self.generic
+                .iter()
+                .find(|rendered| current.shares_source(rendered))
+                .is_some_and(|rendered| {
+                    matches!(
+                        current.render_state_since(rendered),
+                        crate::data::StreamingRenderState::Unchanged
+                            | crate::data::StreamingRenderState::AppendOnly { .. }
+                    )
+                })
+        })
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -2415,6 +2468,7 @@ impl InteractivePlotSession {
         let image = Arc::new(renderer.into_image());
         let displayed_data = DisplayedFrameData::capture(source_plot, frame);
         let point_hit_index = Arc::new(OnceLock::new());
+        let streaming_watermarks = StreamingFrameWatermarks::capture(frame);
 
         let generation = self.publish_base_cache_if_epoch(
             InteractiveFrameCache {
@@ -2424,6 +2478,7 @@ impl InteractivePlotSession {
                 geometry: geometry.clone(),
                 displayed_data,
                 point_hit_index,
+                streaming_watermarks,
             },
             epoch_before_render,
         )?;
@@ -2874,6 +2929,7 @@ impl InteractivePlotSession {
         let Some(draw_ops) = collect_streaming_draw_ops(
             source_plot,
             frame,
+            &cached.streaming_watermarks,
             state.size_px,
             state.scale_factor,
             state.time_seconds,
@@ -2893,6 +2949,7 @@ impl InteractivePlotSession {
         )?);
         let displayed_data = DisplayedFrameData::capture(source_plot, frame);
         let point_hit_index = Arc::new(OnceLock::new());
+        let streaming_watermarks = StreamingFrameWatermarks::capture(frame);
 
         let generation = self.publish_base_cache_if_epoch(
             InteractiveFrameCache {
@@ -2902,6 +2959,7 @@ impl InteractivePlotSession {
                 geometry: geometry.clone(),
                 displayed_data,
                 point_hit_index,
+                streaming_watermarks,
             },
             epoch_before_render,
         )?;

--- a/src/core/plot/interactive_session/helpers.rs
+++ b/src/core/plot/interactive_session/helpers.rs
@@ -21,10 +21,15 @@ pub(super) fn compose_images(base: &Image, overlay: &Image) -> Image {
 pub(super) fn collect_streaming_draw_ops(
     plot: &Plot,
     frame: &ResolvedFrame<'_>,
+    rendered_streams: &StreamingFrameWatermarks,
     size_px: (u32, u32),
     scale_factor: f32,
     _time_seconds: f64,
 ) -> Result<Option<Vec<StreamingDrawOp>>> {
+    if !rendered_streams.generic_streams_allow_incremental(frame) {
+        return Ok(None);
+    }
+
     if plot
         .display
         .title
@@ -76,6 +81,7 @@ pub(super) fn collect_streaming_draw_ops(
                     x_data,
                     y_data,
                     frame,
+                    rendered_streams,
                     StreamingDrawKind::Line,
                     color,
                     line_width_px,
@@ -98,6 +104,7 @@ pub(super) fn collect_streaming_draw_ops(
                     x_data,
                     y_data,
                     frame,
+                    rendered_streams,
                     StreamingDrawKind::Scatter,
                     color,
                     line_width_px,
@@ -127,6 +134,7 @@ pub(super) fn streaming_draw_op(
     x_data: &PlotData,
     y_data: &PlotData,
     frame: &ResolvedFrame<'_>,
+    rendered_streams: &StreamingFrameWatermarks,
     kind: StreamingDrawKind,
     color: Color,
     line_width_px: f32,
@@ -147,7 +155,15 @@ pub(super) fn streaming_draw_op(
     else {
         return Ok(None);
     };
-    let appended_count = match snapshot.render_state {
+    let Some(rendered_through) = rendered_streams.paired.iter().find_map(|rendered| {
+        rendered
+            .source
+            .shares_source(source)
+            .then_some(rendered.sequence)
+    }) else {
+        return Ok(None);
+    };
+    let appended_count = match snapshot.watermark.render_state_since(rendered_through) {
         crate::data::StreamingRenderState::AppendOnly { visible_appended } => visible_appended,
         _ => return Ok(None),
     };

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -2569,6 +2569,81 @@ fn test_streaming_surface_render_falls_back_and_acknowledges_replacement() {
 }
 
 #[test]
+fn test_two_streaming_sessions_keep_independent_acknowledgement_watermarks() {
+    let stream = StreamingXY::new(16);
+    stream.push_many([(0.0, 0.0), (1.0, 0.5), (2.0, 1.0)]);
+    let plot: Plot = Plot::new()
+        .line_streaming(&stream)
+        .xlim(0.0, 8.0)
+        .ylim(-1.0, 2.0)
+        .into();
+    let session_1 = plot.prepare_interactive();
+    let session_2 = plot.prepare_interactive();
+
+    session_1
+        .render_to_surface(render_target())
+        .expect("session 1 initial frame should render");
+    session_2
+        .render_to_surface(render_target())
+        .expect("session 2 initial frame should render");
+
+    stream.replace([(3.0, 1.25), (4.0, 0.75), (5.0, 0.25)]);
+    let session_1_replacement = session_1
+        .render_to_surface(render_target())
+        .expect("session 1 replacement frame should render");
+    assert!(!session_1_replacement.layer_state.used_incremental_data);
+
+    stream.push(6.0, 0.5);
+    assert_eq!(
+        stream.render_state(),
+        StreamingRenderState::AppendOnly {
+            visible_appended: 1
+        }
+    );
+    let session_2_frame = session_2
+        .render_to_surface(render_target())
+        .expect("session 2 stale frame should render");
+
+    assert!(session_2_frame.layer_state.base_dirty);
+    assert!(!session_2_frame.layer_state.used_incremental_data);
+}
+
+#[test]
+fn test_prepared_render_does_not_advance_interactive_stream_watermark() {
+    let stream = StreamingXY::new(16);
+    stream.push_many([(0.0, 0.0), (1.0, 0.5), (2.0, 1.0)]);
+    let plot: Plot = Plot::new()
+        .line_streaming(&stream)
+        .xlim(0.0, 8.0)
+        .ylim(-1.0, 2.0)
+        .into();
+    let prepared = plot.prepare();
+    let session = plot.prepare_interactive();
+
+    session
+        .render_to_surface(render_target())
+        .expect("initial interactive frame should render");
+
+    stream.replace([(3.0, 1.25), (4.0, 0.75), (5.0, 0.25)]);
+    prepared
+        .render_frame((320, 240), 1.0, 0.0)
+        .expect("prepared replacement frame should render");
+    stream.push(6.0, 0.5);
+    assert_eq!(
+        stream.render_state(),
+        StreamingRenderState::AppendOnly {
+            visible_appended: 1
+        }
+    );
+
+    let interactive_frame = session
+        .render_to_surface(render_target())
+        .expect("stale interactive frame should render");
+    assert!(interactive_frame.layer_state.base_dirty);
+    assert!(!interactive_frame.layer_state.used_incremental_data);
+}
+
+#[test]
 fn test_interactive_full_render_acknowledges_generic_streaming_buffers() {
     let x = StreamingBuffer::new(16);
     let y = StreamingBuffer::new(16);
@@ -3448,8 +3523,12 @@ fn test_incremental_stream_style_multiplies_intrinsic_and_series_alpha_once() {
         .color(Color::RED.with_alpha(0.5))
         .alpha(0.5)
         .into();
+    let rendered_frame = plot.resolve_frame(0.0).expect("frame should resolve");
+    let rendered_streams = StreamingFrameWatermarks::capture(&rendered_frame);
+    rendered_frame.acknowledge_rendered(&plot);
+    stream.push(2.0, 2.0);
     let frame = plot.resolve_frame(0.0).expect("frame should resolve");
-    let ops = collect_streaming_draw_ops(&plot, &frame, (320, 240), 1.0, 0.0)
+    let ops = collect_streaming_draw_ops(&plot, &frame, &rendered_streams, (320, 240), 1.0, 0.0)
         .expect("draw ops should resolve")
         .expect("stream should support incremental rendering");
 

--- a/src/core/plot/types.rs
+++ b/src/core/plot/types.rs
@@ -1337,8 +1337,7 @@ pub(crate) struct ResolvedStreamingPair {
     pub(super) source: StreamingXY,
     pub(super) x: Arc<[f64]>,
     pub(super) y: Arc<[f64]>,
-    pub(super) sequence: u64,
-    pub(super) render_state: crate::data::StreamingRenderState,
+    pub(super) watermark: crate::data::observable::StreamingXYRenderWatermark,
 }
 
 #[derive(Clone, Debug)]
@@ -1377,7 +1376,9 @@ impl ResolvedFrame<'_> {
             stream.mark_rendered();
         }
         for stream in &self.paired_acknowledgements {
-            stream.source.mark_rendered_through(stream.sequence);
+            stream
+                .source
+                .mark_rendered_through(stream.watermark.sequence());
         }
     }
 }

--- a/src/data/observable.rs
+++ b/src/data/observable.rs
@@ -1580,21 +1580,37 @@ impl<T: Clone> StreamingBuffer<T> {
 
     /// Describe whether the current buffer changes can be rendered incrementally.
     pub fn render_state(&self) -> StreamingRenderState {
-        if self.clear_generation.load(Ordering::Acquire)
-            != self.rendered_clear_generation.load(Ordering::Acquire)
-        {
+        let generation = self.clear_generation.load(Ordering::Acquire);
+        let rendered_generation = self.rendered_clear_generation.load(Ordering::Acquire);
+        let total_written = self.total_written.load(Ordering::Acquire);
+        let appended = self.appended_since_render.load(Ordering::Acquire);
+        Self::render_state_between(
+            rendered_generation,
+            generation,
+            total_written,
+            appended,
+            self.capacity,
+        )
+    }
+
+    fn render_state_between(
+        rendered_generation: u64,
+        generation: u64,
+        total_written: u64,
+        appended: usize,
+        capacity: usize,
+    ) -> StreamingRenderState {
+        if generation != rendered_generation {
             return StreamingRenderState::FullRedrawRequired;
         }
 
-        let appended = self.appended_since_render.load(Ordering::Acquire);
         if appended == 0 {
             return StreamingRenderState::Unchanged;
         }
 
-        let total_written = self.total_written.load(Ordering::Acquire);
-        let visible_after = std::cmp::min(total_written as usize, self.capacity);
+        let visible_after = std::cmp::min(total_written as usize, capacity);
         let total_before = total_written.saturating_sub(appended as u64);
-        let visible_before = std::cmp::min(total_before as usize, self.capacity);
+        let visible_before = std::cmp::min(total_before as usize, capacity);
 
         if visible_before == 0 {
             return StreamingRenderState::AppendOnly {
@@ -1602,13 +1618,34 @@ impl<T: Clone> StreamingBuffer<T> {
             };
         }
 
-        if visible_before.saturating_add(appended) <= self.capacity {
+        if visible_before.saturating_add(appended) <= capacity {
             return StreamingRenderState::AppendOnly {
                 visible_appended: appended,
             };
         }
 
         StreamingRenderState::FullRedrawRequired
+    }
+
+    pub(crate) fn render_state_since(&self, rendered: &Self) -> StreamingRenderState {
+        if !self.shares_source(rendered) {
+            return StreamingRenderState::FullRedrawRequired;
+        }
+        let Some((rendered_generation, rendered_through)) = rendered.acknowledge_through else {
+            return StreamingRenderState::FullRedrawRequired;
+        };
+        let Some((generation, total_written)) = self.acknowledge_through else {
+            return StreamingRenderState::FullRedrawRequired;
+        };
+        let appended =
+            usize::try_from(total_written.saturating_sub(rendered_through)).unwrap_or(usize::MAX);
+        Self::render_state_between(
+            rendered_generation,
+            generation,
+            total_written,
+            appended,
+            self.capacity,
+        )
     }
 
     /// Check if partial re-render is possible.
@@ -1742,6 +1779,35 @@ pub struct StreamingXYSnapshot {
     rendered_through: u64,
     render_state: StreamingRenderState,
     appended_start: usize,
+    total_written: u64,
+    last_clear_sequence: Option<u64>,
+    capacity: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct StreamingXYRenderWatermark {
+    sequence: u64,
+    total_written: u64,
+    last_clear_sequence: Option<u64>,
+    visible_after: usize,
+    capacity: usize,
+}
+
+impl StreamingXYRenderWatermark {
+    pub(crate) fn sequence(self) -> u64 {
+        self.sequence
+    }
+
+    pub(crate) fn render_state_since(self, rendered_through: u64) -> StreamingRenderState {
+        StreamingXY::render_state_between(
+            self.sequence,
+            rendered_through,
+            self.total_written,
+            self.last_clear_sequence,
+            self.visible_after,
+            self.capacity,
+        )
+    }
 }
 
 impl StreamingXYSnapshot {
@@ -1770,6 +1836,10 @@ impl StreamingXYSnapshot {
         self.render_state
     }
 
+    pub(crate) fn render_state_since(&self, rendered_through: u64) -> StreamingRenderState {
+        self.render_watermark().render_state_since(rendered_through)
+    }
+
     /// Aligned visible X tail that may be appended incrementally.
     pub fn appended_x(&self) -> &[f64] {
         &self.x[self.appended_start..]
@@ -1780,8 +1850,19 @@ impl StreamingXYSnapshot {
         &self.y[self.appended_start..]
     }
 
-    pub(crate) fn into_parts(self) -> (Vec<f64>, Vec<f64>, u64, StreamingRenderState) {
-        (self.x, self.y, self.sequence, self.render_state)
+    fn render_watermark(&self) -> StreamingXYRenderWatermark {
+        StreamingXYRenderWatermark {
+            sequence: self.sequence,
+            total_written: self.total_written,
+            last_clear_sequence: self.last_clear_sequence,
+            visible_after: self.x.len(),
+            capacity: self.capacity,
+        }
+    }
+
+    pub(crate) fn into_parts(self) -> (Vec<f64>, Vec<f64>, StreamingXYRenderWatermark) {
+        let watermark = self.render_watermark();
+        (self.x, self.y, watermark)
     }
 }
 
@@ -2160,6 +2241,9 @@ impl StreamingXY {
             rendered_through: progress.rendered_through,
             render_state,
             appended_start,
+            total_written: progress.total_written,
+            last_clear_sequence: progress.last_clear_sequence,
+            capacity: self.x.capacity(),
         }
     }
 
@@ -2274,19 +2358,36 @@ impl StreamingXY {
         visible_after: usize,
         capacity: usize,
     ) -> StreamingRenderState {
-        if progress.sequence == progress.rendered_through {
+        Self::render_state_between(
+            progress.sequence,
+            progress.rendered_through,
+            progress.total_written,
+            progress.last_clear_sequence,
+            visible_after,
+            capacity,
+        )
+    }
+
+    fn render_state_between(
+        sequence: u64,
+        rendered_through: u64,
+        total_written: u64,
+        last_clear_sequence: Option<u64>,
+        visible_after: usize,
+        capacity: usize,
+    ) -> StreamingRenderState {
+        if sequence == rendered_through {
             return StreamingRenderState::Unchanged;
         }
-        if progress
-            .last_clear_sequence
-            .is_some_and(|sequence| Self::sequence_after(sequence, progress.rendered_through))
+        if last_clear_sequence
+            .is_some_and(|sequence| Self::sequence_after(sequence, rendered_through))
         {
             return StreamingRenderState::FullRedrawRequired;
         }
 
-        let appended = Self::sequence_distance(progress.sequence, progress.rendered_through);
+        let appended = Self::sequence_distance(sequence, rendered_through);
         let appended = usize::try_from(appended).unwrap_or(usize::MAX);
-        let total_before = progress.total_written.saturating_sub(appended as u64);
+        let total_before = total_written.saturating_sub(appended as u64);
         let visible_before = usize::try_from(total_before)
             .unwrap_or(usize::MAX)
             .min(capacity);

--- a/src/data/observable/tests.rs
+++ b/src/data/observable/tests.rs
@@ -730,6 +730,33 @@ fn test_streaming_buffer_clear() {
 }
 
 #[test]
+fn test_streaming_buffer_render_state_since_is_per_consumer() {
+    let buffer = StreamingBuffer::<f64>::new(8);
+    buffer.push_many([1.0, 2.0]);
+
+    let (_, consumer_b) = buffer.snapshot_for_render();
+    consumer_b.mark_rendered();
+
+    buffer.clear();
+    buffer.push_many([10.0, 20.0]);
+    let (_, consumer_a) = buffer.snapshot_for_render();
+    consumer_a.mark_rendered();
+    buffer.push(30.0);
+
+    let (_, current) = buffer.snapshot_for_render();
+    assert_eq!(
+        current.render_state(),
+        StreamingRenderState::AppendOnly {
+            visible_appended: 1
+        }
+    );
+    assert_eq!(
+        current.render_state_since(&consumer_b),
+        StreamingRenderState::FullRedrawRequired
+    );
+}
+
+#[test]
 fn test_streaming_buffer_subscribers() {
     let buffer = StreamingBuffer::<f64>::new(10);
     let count = Arc::new(AtomicUsize::new(0));
@@ -886,6 +913,32 @@ fn test_streaming_xy_replace_empty_is_one_atomic_clear() {
     assert_eq!(xy.render_state(), StreamingRenderState::Unchanged);
     assert_eq!(xy.x().render_state(), StreamingRenderState::Unchanged);
     assert_eq!(xy.y().render_state(), StreamingRenderState::Unchanged);
+}
+
+#[test]
+fn test_streaming_xy_snapshot_render_state_since_is_per_consumer() {
+    let xy = StreamingXY::new(8);
+    xy.push_many([(1.0, 10.0), (2.0, 20.0)]);
+
+    let consumer_b = xy.snapshot();
+    xy.mark_rendered_through(consumer_b.sequence());
+
+    xy.replace([(4.0, 40.0), (5.0, 50.0)]);
+    let consumer_a = xy.snapshot();
+    xy.mark_rendered_through(consumer_a.sequence());
+    xy.push(6.0, 60.0);
+
+    let current = xy.snapshot();
+    assert_eq!(
+        current.render_state(),
+        StreamingRenderState::AppendOnly {
+            visible_appended: 1
+        }
+    );
+    assert_eq!(
+        current.render_state_since(consumer_b.sequence()),
+        StreamingRenderState::FullRedrawRequired
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #115

`StreamingBuffer` acknowledgement state (`rendered_through`, `appended_since_render`, `rendered_clear_generation`) lives in shared `Arc` atomics, so every clone of a stream shared one acknowledgement watermark. With two rendering consumers (two `InteractivePlotSession`s, or a session plus a `PreparedPlot` export), consumer A acknowledging a replace/clear let consumer B's next frame take the append-only incremental path and paint one new point onto B's pre-replacement cached base, leaving stale data visible.

## Fix

Cache-owned acknowledgement watermarks (option (b) from the issue): each `InteractiveFrameCache` records the exact stream generation/total (generic) and sequence (paired `StreamingXY`) its base image contains. Append-only eligibility is decided by recomputing render state relative to **that session's** cached watermark (`render_state_since`), not the shared acknowledged state. A replacement or clear after the cached watermark forces a full redraw regardless of what other consumers acknowledged. A missing prior watermark falls back conservatively to a full redraw.

The shared public acknowledgement API (`render_state()`, `mark_rendered*()`, `appended_since_mark()`) is unchanged, so documented single-consumer behavior and its existing tests are untouched. No public API removed; additions are internal or additive.

## Tests

- `test_streaming_buffer_render_state_since_is_per_consumer` and `test_streaming_xy_snapshot_render_state_since_is_per_consumer` — the exact issue scenario at the buffer level: a consumer that last rendered before a clear/replace sees `FullRedrawRequired` even though the shared state says `AppendOnly`.
- `test_two_streaming_sessions_keep_independent_acknowledgement_watermarks` — two sessions on one `StreamingXY`: after replace + acknowledgement by session 1 + a push, session 2's next frame has `base_dirty` and does not use incremental data.
- `test_prepared_render_does_not_advance_interactive_stream_watermark` — PreparedPlot export no longer poisons a live session's incremental path.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — 0 errors (known MSRV-config warning only)
- `cargo test --lib` — 1267 passed
- Focused: streaming 86 passed, observable 91 passed, interactive 91 passed
- Independent Codex review of the branch vs main: no actionable defects