### PR TITLE
Prepare v0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+_None yet._
+
+## [0.6.0] - 2026-07-28
+
 ### Breaking
 
 - Removed the unreachable 2D series-parallel renderer. `Plot::with_parallel`, `Plot::parallel_threshold`, `ruviz::render::{ParallelRenderer, ParallelConfig, SeriesRenderData, PerformanceStats, DetailedPerformanceInfo}` and `RenderPipeline::{parallel_renderer, parallel_renderer_mut}` are gone. No public `render()`/`save()` could reach that path, and `.backend(BackendType::Parallel)` still resolves to Skia with an explicit `UnsupportedOperation` fallback reason (previously `FeatureDisabled` without the `parallel` feature).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-ruviz = "0.5.0"
+ruviz = "0.6.0"
 ```
 
 Create and save a PNG:

--- a/crates/ruviz-web/README.md
+++ b/crates/ruviz-web/README.md
@@ -21,7 +21,7 @@ Add the bridge crate to your Cargo manifest:
 
 ```toml
 [dependencies]
-ruviz-web = "0.5.0"
+ruviz-web = "0.6.0"
 ```
 
 Build for `wasm32-unknown-unknown` and generate bindings with your preferred

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,15 +2,16 @@
 
 Get started with ruviz in less than 5 minutes!
 
-## What's New in v0.5.0
+## What's New in v0.6.0
 
-- Streaming data can be replaced atomically with `StreamingXY::replace`, and acknowledgement watermarks are tracked per consumer so shared streams never composite stale frames.
-- Outside legend positions (`OutsideRight`, `OutsideLeft`, `OutsideUpper`, `OutsideLower`) are honored across PNG, SVG, interactive, and subplot rendering.
-- Interactive annotations can be added, updated, and removed at runtime, and heatmaps accept a configurable row origin.
-- Builders gain a conditional `.when(...)` combinator, and the GPUI adapter gains coordinate mapping, pointer events, and view-preserving plot replacement.
+- First-class 3D plotting now spans Rust, Python, WebAssembly, GPUI, egui, Iced, and Slint.
+- Native adapters support static and interactive 2D/3D plots with responsive HiDPI rendering and nonblocking reactive updates.
+- CPU and GPU 3D paths share corrected lighting, alpha, clipping, camera, legend, and picking behavior.
+- Legend layout and styling are unified across 2D and 3D raster and SVG output.
 
 See full details:
-- [Release notes for v0.5.0](releases/v0.5.0.md)
+
+- [Release notes for v0.6.0](releases/v0.6.0.md)
 - [Project changelog](../CHANGELOG.md)
 
 ## Installation
@@ -24,7 +25,7 @@ cd my_plot
 2. **Add ruviz to your `Cargo.toml`**:
 ```toml
 [dependencies]
-ruviz = "0.5.0"
+ruviz = "0.6.0"
 ```
 
 3. **Write your first plot** in `src/main.rs`:
@@ -63,8 +64,8 @@ an embedded interactive plot view:
 
 ```toml
 [dependencies]
-ruviz = "0.5.0"
-ruviz-gpui = "0.5.0"
+ruviz = "0.6.0"
+ruviz-gpui = "0.6.0"
 ```
 
 `ruviz-gpui` is supported on Linux, macOS, and Windows. On Windows, prefer the

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -62,7 +62,7 @@ Add ruviz to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruviz = "0.5.0"
+ruviz = "0.6.0"
 ```
 
 Or with specific features:
@@ -79,7 +79,7 @@ ruviz uses feature flags to enable optional functionality. Choose based on your 
 ### Default Features
 
 ```toml
-ruviz = "0.5.0"  # Includes: ndarray_support, parallel
+ruviz = "0.6.0"  # Includes: ndarray_support, parallel
 ```
 
 **Enabled by default**:
@@ -282,7 +282,7 @@ rustup update
 
 ### Feature Conflicts
 
-**Problem**: `error: package ruviz v0.5.0 cannot be built because it requires rustc 1.92 or newer`
+**Problem**: `error: package ruviz v0.6.0 cannot be built because it requires rustc 1.92 or newer`
 
 **Solution**: Update Rust:
 ```bash

--- a/docs/guide/03_first_plot.md
+++ b/docs/guide/03_first_plot.md
@@ -166,7 +166,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = "0.5.0"
+ruviz = "0.6.0"
 ```
 
 ## Customization Basics

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -48,7 +48,7 @@ at `t`.
 
 ```toml
 [dependencies]
-ruviz = "0.5.0"
+ruviz = "0.6.0"
 ```
 
 Useful opt-in features:

--- a/docs/migration/matplotlib.md
+++ b/docs/migration/matplotlib.md
@@ -416,7 +416,7 @@ let viridis_like = Theme::builder()
 ## Migration Checklist
 
 - [ ] Install Rust and cargo
-- [ ] Add `ruviz = "0.5.0"` to `Cargo.toml`
+- [ ] Add `ruviz = "0.6.0"` to `Cargo.toml`
 - [ ] Convert numpy arrays to `Vec<f64>` or `ndarray`
 - [ ] Replace `plt.plot()` with `Plot::new().line()`
 - [ ] Change `plt.savefig()` to `.save()?`

--- a/docs/releases/v0.6.0.md
+++ b/docs/releases/v0.6.0.md
@@ -1,0 +1,93 @@
+# ruviz v0.6.0
+
+Released: 2026-07-28
+
+## Highlights
+
+- Added first-class 3D plotting across Rust, Python, WebAssembly, and native
+  desktop integrations, including line, scatter, surface, and wireframe plots;
+  static output; interactive orbit, pan, zoom, picking, and reset; CPU
+  rasterization; and optional GPU rendering.
+- Added separately packaged `ruviz-egui`, `ruviz-iced`, and `ruviz-slint`
+  adapters. Each supports static and interactive 2D/3D plots, responsive
+  fractional-HiDPI rendering, reactive updates, multiple widgets, replacement
+  with optional view preservation, and framework-native events.
+- Upgraded `ruviz-gpui` with a 3D builder aligned with its 2D API, background
+  latest-wins rendering, static and interactive modes, fitted input mapping,
+  and pick, camera, and error callbacks.
+- Unified legend layout and styling between 2D and 3D, including data-aware
+  `LegendPosition::Best`, outside placement, Unicode-aware measurement, and
+  consistent raster/SVG behavior.
+
+## Version Alignment
+
+The published packages share version `0.6.0`:
+
+- crates.io: `ruviz`, `ruviz-web`, `ruviz-gpui`, `ruviz-egui`, `ruviz-iced`,
+  and `ruviz-slint`
+- npm: `ruviz`
+- PyPI: `ruviz`
+
+## Native GUI Adapters
+
+- All four adapters use retained, nonblocking rendering with one active request
+  and one coalesced latest request per plot. They preserve the last good frame,
+  reject stale completions and stale-frame input, and never render inside UI
+  paint or view callbacks.
+- The common adapter contract provides plot/session conversion, logical and
+  fitted-image geometry, opaque scheduling identifiers, explicit straight and
+  premultiplied alpha conversion, stamped 2D frames, retained 3D jobs, and
+  unified reactive change subscriptions.
+- Linux, macOS, and Windows run default, 3D, and all-feature behavioral suites.
+  Linux additionally builds and runtime-smokes all 15 native examples under
+  Xvfb with software rendering.
+- Slint applications can import the packaged `@Ruviz` component library and
+  drive multiple plot slots through the retained Rust controller.
+
+## 3D Rendering And Interaction
+
+- `Plot3D` supports consistent layout, styling, legends, camera framing,
+  picking, and static or interactive presentation.
+- CPU and GPU rendering now agree on linear-space lighting and straight-alpha
+  composition. Surface normals account for axis aspect, edge markers clip
+  correctly, and triangle markers use the same orientation across backends.
+- GPU scene resources use a bounded LRU cache, translucent pipelines blend
+  correctly, and `RenderDiagnostics3D::buffer_evictions` exposes cache
+  pressure.
+- Background jobs retain resolved scene data and reusable worker resources
+  instead of rebuilding render state for every frame.
+
+## Compatibility
+
+This release includes intentional breaking cleanup:
+
+- Removed unreachable 2D series-parallel rendering APIs and inert pooled
+  rendering knobs.
+- Removed duplicate animation features and implicit optional-dependency feature
+  leakage.
+- `window` now enables the interactive desktop surface it previously failed to
+  gate.
+- Rendered `Image` values now consistently use straight-alpha RGBA; callers
+  that treated `SkiaRenderer::into_image()` as premultiplied must convert
+  explicitly.
+- `PlottingError` gains the non-exhaustive `RenderSuperseded` variant for typed
+  cancellation of obsolete background work.
+
+See the [0.6 builder migration guide](../migration/0.6-builder-api.md) and the
+[full changelog](../../CHANGELOG.md) for API details.
+
+## Quality And Validation
+
+- Rust 1.92 MSRV, strict Clippy, rustfmt, docs, package consumers, deterministic
+  golden images, WebAssembly, Python, npm, Linux/macOS/Windows/FreeBSD builds,
+  Vulkan software-GPU tests, and the complete all-target/all-feature matrix pass
+  on the release commit.
+- Release packaging verifies registry-sourced external consumers and VCS
+  provenance before publishing downstream crates and adapters.
+
+## References
+
+- Previous release notes: [`v0.5.0`](./v0.5.0.md)
+- Native adapter plan: [`native-gui-adapters-plan.md`](../roadmaps/native-gui-adapters-plan.md)
+- 3D implementation plan: [`ruviz-3d-implementation-plan.md`](../roadmaps/ruviz-3d-implementation-plan.md)
+- Release workflow: [`.github/workflows/release.yml`](../../.github/workflows/release.yml)


### PR DESCRIPTION
## Summary

- finalize the 0.6.0 changelog section
- add versioned GitHub release notes
- update remaining public dependency snippets to 0.6.0

## Validation

- 19 documentation checker unit tests
- 169 Markdown files and 50 checked code fences
- release workflow YAML parsing
- package version alignment across Rust, npm, and Python
- pre-commit rustfmt, Clippy, and documentation hooks