### PR TITLE
Fix native adapter release publication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -629,6 +629,10 @@ jobs:
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Install Linux desktop build dependencies
+        if: steps.adapter-version.outputs.published != 'true'
+        uses: ./.github/actions/install-linux-desktop-build-deps
+
       - name: Publish adapter to crates.io
         if: steps.adapter-version.outputs.published != 'true'
         run: >-

--- a/scripts/test_verify_gui_adapter_packages.py
+++ b/scripts/test_verify_gui_adapter_packages.py
@@ -196,6 +196,19 @@ class WorkflowContractTests(unittest.TestCase):
         )[1].split("\n  publish-gui-adapters:", maxsplit=1)[0]
         self.assertIn(dependency_step, release_job)
 
+        publish_job = release.split(
+            "\n  publish-gui-adapters:", maxsplit=1
+        )[1].split("\n  publish-ruviz-web:", maxsplit=1)[0]
+        self.assertIn("- name: Install Linux desktop build dependencies", publish_job)
+        self.assertIn(
+            "uses: ./.github/actions/install-linux-desktop-build-deps",
+            publish_job,
+        )
+        self.assertIn(
+            "if: steps.adapter-version.outputs.published != 'true'",
+            publish_job,
+        )
+
     def test_pages_build_includes_adapter_and_gpui_rustdoc(self) -> None:
         workflow = (self.repository / ".github/workflows/docs.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- install the existing Linux desktop dependency bundle before publishing native GUI adapter crates
- skip the install when the adapter version is already present on crates.io
- extend the release workflow contract test to cover the publish job

## Why
The v0.6.0 `ruviz-slint` publish verification failed because `fontconfig.pc` was unavailable. The preceding packaged-adapter verification installs these dependencies, but the isolated publish matrix did not.

## Validation
- `uv run python -m unittest scripts.test_verify_gui_adapter_packages`
- release workflow YAML parse
- `git diff --check`
- pre-commit rustfmt and Clippy

After merge, the idempotent release workflow can be dispatched again for the existing `v0.6.0` tag; already-published artifacts will be skipped.