### PR TITLE
Harden animation and GPU reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,9 +657,11 @@ jobs:
       - name: Run direct 3D GPU suite with a required adapter
         run: |
           mkdir -p generated/tests/render
+          cargo test --no-default-features --features gpu --test gpu_backend_test
           cargo test --no-default-features --features 3d,gpu --test three_d_gpu_test --test three_d_parity_test
         env:
           LIBGL_ALWAYS_SOFTWARE: "1"
+          RUVIZ_REQUIRE_GPU_TESTS: "1"
           RUVIZ_3D_GPU_TEST_OUTPUT: generated/tests/render/three_d_gpu_required_adapter.png
           WGPU_BACKEND: vulkan
 
@@ -706,6 +708,9 @@ jobs:
 
       - name: Run heavy validation suites
         run: cargo test --test performance_validation --verbose
+
+      - name: Run large library rendering validations
+        run: cargo test --lib test_large_ -- --ignored
 
   msrv:
     name: MSRV (1.92)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,24 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aligned"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
-dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "aligned-vec"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
-dependencies = [
- "equator",
-]
-
-[[package]]
 name = "alloca"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,12 +184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-
-[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,17 +201,6 @@ dependencies = [
  "percent-encoding",
  "windows-sys 0.60.2",
  "x11rb",
-]
-
-[[package]]
-name = "arg_enum_proc_macro"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -270,15 +235,6 @@ name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
-
-[[package]]
-name = "as-slice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
-dependencies = [
- "stable_deref_trait",
-]
 
 [[package]]
 name = "ash"
@@ -366,54 +322,6 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "av-scenechange"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
-dependencies = [
- "aligned",
- "anyhow",
- "arg_enum_proc_macro",
- "arrayvec",
- "log",
- "num-rational",
- "num-traits",
- "pastey",
- "rayon",
- "thiserror 2.0.18",
- "v_frame 0.3.9",
- "y4m",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom",
- "num-rational",
- "v_frame 0.3.9",
-]
-
-[[package]]
-name = "av1-grain"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c799433bc1f0ed14d949885186738de9976cfcaefef0e3ab7103fe5c630cb2b"
-dependencies = [
- "anyhow",
- "arrayvec",
- "log",
- "nom",
- "num-rational",
- "v_frame 0.5.1",
-]
 
 [[package]]
 name = "az"
@@ -515,15 +423,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitstream-io"
-version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60d4bd9d1db2c6bdf285e223a7fa369d5ce98ec767dec949c6ca62863ce61757"
-dependencies = [
- "core2",
-]
-
-[[package]]
 name = "blake3"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,12 +467,6 @@ name = "boxcar"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36f64beae40a84da1b4b26ff2761a5b895c12adc41dc25aaee1c4f2bbfe97a6e"
-
-[[package]]
-name = "built"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
 
 [[package]]
 name = "bumpalo"
@@ -1033,15 +926,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "core_maths"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1485,26 +1369,6 @@ dependencies = [
  "env_filter",
  "jiff",
  "log",
-]
-
-[[package]]
-name = "equator"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
-dependencies = [
- "equator-macro",
-]
-
-[[package]]
-name = "equator-macro"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2793,17 +2657,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interpolate_name"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2978,16 +2831,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libfuzzer-sys"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5037190e1f70cbeef565bd267599242926f724d3b8a9f510fd7e0b540cfa4404"
-dependencies = [
- "arbitrary",
- "cc",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3124,15 +2967,6 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
-]
-
-[[package]]
-name = "maybe-rayon"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -3317,27 +3151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nom"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
 name = "now"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3372,17 +3185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
-name = "num-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3410,16 +3212,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -3923,12 +3715,6 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
-name = "pastey"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
 name = "pdf-writer"
@@ -4761,19 +4547,6 @@ name = "profiling"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eb8486b569e12e2c32ad3e204dbaba5e4b5b216e9367044f25f1dba42341773"
-dependencies = [
- "profiling-procmacros",
-]
-
-[[package]]
-name = "profiling-procmacros"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
-dependencies = [
- "quote",
- "syn",
-]
 
 [[package]]
 name = "proptest"
@@ -5100,40 +4873,6 @@ name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
-
-[[package]]
-name = "rav1e"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
-dependencies = [
- "aligned-vec",
- "arbitrary",
- "arg_enum_proc_macro",
- "arrayvec",
- "av-scenechange",
- "av1-grain 0.2.5",
- "bitstream-io",
- "built",
- "cfg-if",
- "interpolate_name",
- "itertools 0.14.0",
- "libc",
- "libfuzzer-sys",
- "log",
- "maybe-rayon",
- "new_debug_unreachable",
- "noop_proc_macro",
- "num-derive",
- "num-traits",
- "paste",
- "profiling",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "simd_helpers",
- "thiserror 2.0.18",
- "v_frame 0.3.9",
-]
 
 [[package]]
 name = "raw-cpuid"
@@ -5596,7 +5335,6 @@ dependencies = [
  "anyhow",
  "approx",
  "arboard",
- "av1-grain 0.4.1",
  "base64",
  "bytemuck",
  "color_quant",
@@ -5612,14 +5350,12 @@ dependencies = [
  "log",
  "nalgebra",
  "ndarray",
- "num_cpus",
  "palette",
  "plotters",
  "polars",
  "pollster",
  "proptest",
  "rand 0.10.0",
- "rav1e",
  "raw-window-handle",
  "rayon",
  "regex",
@@ -5917,15 +5653,6 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
-name = "simd_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
-dependencies = [
- "quote",
-]
 
 [[package]]
 name = "simdutf8"
@@ -7385,29 +7112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "v_frame"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "v_frame"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50ca82950482a3877e88aac250a2aa8fbc6719a36d499e2200eb8ba11b6bc61"
-dependencies = [
- "aligned-vec",
- "num-traits",
- "thiserror 2.0.18",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "version-compare"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8615,12 +8319,6 @@ name = "xxhash-rust"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
-
-[[package]]
-name = "y4m"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,6 @@ svg2pdf = { version = "0.13", optional = true }  # Uses usvg 0.43 internally
 
 # Error handling
 thiserror = "2.0"
-anyhow = "1.0"
 
 # Serialization (for themes/configs)
 serde = { version = "1.0", features = ["derive"], optional = true }
@@ -112,7 +111,6 @@ serde_json = { version = "1.0", optional = true }
 
 # Performance optimization
 rayon = { version = "1.11", optional = true }
-num_cpus = "1.17"
 
 # GPU acceleration (optional)
 wgpu = { version = "29.0", optional = true }
@@ -145,10 +143,6 @@ gif = { version = "0.14", optional = true }
 color_quant = { version = "1.1", optional = true }
 crossbeam-channel = { version = "0.5", optional = true }
 
-# Pure Rust video encoding (optional)
-rav1e = { version = "0.8", optional = true, default-features = false }
-av1-grain = { version = "0.4", optional = true }
-
 # FreeBSD support
 [target.'cfg(target_os = "freebsd")'.dependencies]
 ctor = "0.8"
@@ -173,6 +167,7 @@ windows-sys = { version = "0.61", features = ["Win32_Storage_FileSystem"] }
 rfd = { version = "0.15", optional = true, default-features = false }
 
 [dev-dependencies]
+anyhow = "1.0"
 criterion = { version = "0.8", features = ["html_reports"] }
 approx = "0.5"
 tempfile = "3.27"
@@ -250,7 +245,10 @@ typst-math = ["dep:typst", "dep:typst-svg", "dep:typst-render", "dep:typst-kit"]
 # (which pulled the C-building `gifski` crate that no code referenced) were
 # removed in 2026-07: neither gated a single line.
 animation = ["dep:gif", "dep:color_quant", "dep:crossbeam-channel"]
-animation-video = ["animation", "dep:rav1e", "dep:av1-grain"]
+# Compatibility aggregate retained for manifests that selected the historical
+# name. Ruviz currently ships GIF animation only; AV1 also needs a supported
+# container/muxing implementation before this feature can promise video output.
+animation-video = ["animation"]
 
 # Full feature set
 full = ["3d", "ndarray_support", "polars_support", "nalgebra_support", "serde", "performance", "gpu", "pdf", "interactive-gpu", "animation", "typst-math"]

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Default features are `ndarray_support` and `parallel`.
 | `pdf` | PDF export via SVG-to-PDF |
 | `typst-math` | Typst-backed text rendering |
 | `animation` | GIF recording support |
-| `animation-video` | `animation` + AV1 video encoding |
+| `animation-video` | compatibility alias for `animation`; AV1 video is not currently available |
 | `svg` | no-op, retained for compatibility (see below) |
 | `full` | broad feature set for native builds |
 

--- a/crates/gui-adapters/Cargo.lock
+++ b/crates/gui-adapters/Cargo.lock
@@ -3864,16 +3864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi 0.5.2",
- "libc",
-]
-
-[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5215,7 +5205,6 @@ dependencies = [
 name = "ruviz"
 version = "0.6.0"
 dependencies = [
- "anyhow",
  "base64",
  "bytemuck",
  "cosmic-text 0.16.0",
@@ -5225,7 +5214,6 @@ dependencies = [
  "image",
  "log",
  "ndarray",
- "num_cpus",
  "palette",
  "pollster",
  "rayon",

--- a/crates/ruviz-gpui/Cargo.lock
+++ b/crates/ruviz-gpui/Cargo.lock
@@ -5122,7 +5122,6 @@ dependencies = [
 name = "ruviz"
 version = "0.6.0"
 dependencies = [
- "anyhow",
  "base64",
  "bytemuck",
  "cosmic-text 0.16.0",
@@ -5132,7 +5131,6 @@ dependencies = [
  "image",
  "log",
  "ndarray",
- "num_cpus",
  "palette",
  "pollster 0.4.0",
  "rayon",

--- a/examples/doc_surface3d_animation.rs
+++ b/examples/doc_surface3d_animation.rs
@@ -53,7 +53,7 @@ fn main() -> PlotResult<()> {
     let (x, y, z) = surface_data(41);
 
     let mut encoder =
-        GifEncoder::new(&output, Quality::Medium)?.with_framerate(FRAMES_PER_SECOND as f64);
+        GifEncoder::new(&output, Quality::Medium)?.with_framerate(FRAMES_PER_SECOND as f64)?;
     encoder.init(640, 480)?;
 
     for frame_index in 0..FRAME_COUNT {

--- a/src/animation/encoders/gif.rs
+++ b/src/animation/encoders/gif.rs
@@ -69,11 +69,16 @@ impl GifEncoder {
     }
 
     /// Set frame delay from framerate
-    pub fn with_framerate(mut self, fps: f64) -> Self {
+    pub fn with_framerate(mut self, fps: f64) -> Result<Self> {
+        if !fps.is_finite() || fps <= 0.0 {
+            return Err(PlottingError::InvalidInput(
+                "GIF framerate must be finite and greater than zero".into(),
+            ));
+        }
         // Convert FPS to centiseconds delay
         // 30 FPS = 33.3ms = 3.33 centiseconds ≈ 3
         self.frame_delay = ((100.0 / fps).round() as u16).max(1);
-        self
+        Ok(self)
     }
 
     /// Quantize RGB data to indexed color
@@ -121,8 +126,23 @@ impl Encoder for GifEncoder {
             ));
         }
 
-        self.width = width as u16;
-        self.height = height as u16;
+        self.width = u16::try_from(width).map_err(|_| {
+            PlottingError::InvalidInput(format!(
+                "GIF width {width} exceeds the format maximum of {} pixels",
+                u16::MAX
+            ))
+        })?;
+        self.height = u16::try_from(height).map_err(|_| {
+            PlottingError::InvalidInput(format!(
+                "GIF height {height} exceeds the format maximum of {} pixels",
+                u16::MAX
+            ))
+        })?;
+        if self.width == 0 || self.height == 0 {
+            return Err(PlottingError::InvalidInput(
+                "GIF dimensions must be greater than zero".into(),
+            ));
+        }
 
         if let Some(parent) = self.path.parent()
             && !parent.as_os_str().is_empty()
@@ -221,15 +241,46 @@ mod tests {
 
         let encoder = GifEncoder::new(&path, Quality::Medium)
             .unwrap()
-            .with_framerate(30.0);
+            .with_framerate(30.0)
+            .unwrap();
 
         assert_eq!(encoder.frame_delay, 3);
 
         let encoder60 = GifEncoder::new(&path, Quality::Medium)
             .unwrap()
-            .with_framerate(60.0);
+            .with_framerate(60.0)
+            .unwrap();
 
         assert_eq!(encoder60.frame_delay, 2);
+    }
+
+    #[test]
+    fn test_gif_encoder_rejects_invalid_framerates() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.gif");
+
+        assert!(
+            GifEncoder::new(&path, Quality::Medium)
+                .unwrap()
+                .with_framerate(0.0)
+                .is_err()
+        );
+        assert!(
+            GifEncoder::new(&path, Quality::Medium)
+                .unwrap()
+                .with_framerate(f64::NAN)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_gif_encoder_rejects_unrepresentable_dimensions() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("test.gif");
+        let mut encoder = GifEncoder::new(&path, Quality::Medium).unwrap();
+
+        assert!(encoder.init(u16::MAX as u32 + 1, 100).is_err());
+        assert!(encoder.init(0, 100).is_err());
     }
 
     #[test]

--- a/src/animation/encoders/mod.rs
+++ b/src/animation/encoders/mod.rs
@@ -6,7 +6,9 @@
 //! # Available Encoders
 //!
 //! - `GifEncoder` - Animated GIF (always available with `animation` feature)
-//! - `Av1Encoder` - AV1 video via rav1e (requires `animation-video` feature)
+//!
+//! AV1/container output is represented by [`Codec::Av1`] for API compatibility,
+//! but is not currently implemented.
 
 mod gif;
 
@@ -32,8 +34,13 @@ pub enum Quality {
 }
 
 impl Quality {
-    /// Convert to rav1e speed preset (0-10, higher = faster)
+    /// Convert to the historical rav1e speed preset (0-10, higher = faster).
+    ///
+    /// Ruviz does not currently ship an AV1 encoder. This method remains so
+    /// code compiled with the compatibility `animation-video` feature keeps
+    /// building while the container/encoder contract is redesigned.
     #[cfg(feature = "animation-video")]
+    #[deprecated(note = "AV1 video output is not currently implemented")]
     pub fn to_rav1e_speed(self) -> u8 {
         match self {
             Quality::Low => 10,
@@ -59,7 +66,7 @@ impl Quality {
 pub enum Codec {
     /// Animated GIF
     Gif,
-    /// AV1 codec (pure Rust via rav1e)
+    /// AV1 codec (reserved; currently unsupported)
     Av1,
     /// Auto-detect from file extension
     #[default]
@@ -167,30 +174,41 @@ pub trait Encoder: Send {
 /// A boxed encoder ready for initialization, or an error if the format
 /// is not supported.
 pub fn create_encoder(path: &Path, quality: Quality) -> Result<Box<dyn Encoder>> {
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("gif");
+    let Some(extension) = path.extension() else {
+        return Ok(Box::new(GifEncoder::new(path, quality)?));
+    };
+    let ext = extension
+        .to_str()
+        .ok_or_else(|| PlottingError::UnsupportedFormat("non-UTF-8 extension".into()))?;
 
     match Codec::from_extension(ext) {
-        Some(Codec::Gif) | None => Ok(Box::new(GifEncoder::new(path, quality)?)),
-        Some(Codec::Av1) => {
-            #[cfg(feature = "animation-video")]
-            {
-                // TODO: Implement AV1 encoder
-                Err(PlottingError::RenderError(
-                    "AV1 encoder not yet implemented".into(),
-                ))
-            }
-            #[cfg(not(feature = "animation-video"))]
-            {
-                Err(PlottingError::RenderError(
-                    "AV1 encoding requires 'animation-video' feature".into(),
-                ))
-            }
-        }
+        Some(Codec::Gif) => Ok(Box::new(GifEncoder::new(path, quality)?)),
+        Some(Codec::Av1) => unsupported_av1(),
         Some(Codec::Auto) => {
             // Default to GIF
             Ok(Box::new(GifEncoder::new(path, quality)?))
         }
+        None => Err(PlottingError::UnsupportedFormat(ext.to_string())),
     }
+}
+
+pub(super) fn create_encoder_for_codec(
+    path: &Path,
+    quality: Quality,
+    codec: Codec,
+) -> Result<Box<dyn Encoder>> {
+    match codec {
+        Codec::Auto => create_encoder(path, quality),
+        Codec::Gif => Ok(Box::new(GifEncoder::new(path, quality)?)),
+        Codec::Av1 => unsupported_av1(),
+    }
+}
+
+fn unsupported_av1<T>() -> Result<T> {
+    Err(PlottingError::UnsupportedOperation {
+        operation: "AV1 animation encoding",
+        reason: "no AV1 container/muxing implementation is currently shipped".into(),
+    })
 }
 
 #[cfg(test)]
@@ -217,5 +235,34 @@ mod tests {
     fn test_codec_default_extension() {
         assert_eq!(Codec::Gif.default_extension(), "gif");
         assert_eq!(Codec::Av1.default_extension(), "mp4");
+    }
+
+    #[test]
+    fn unknown_extensions_are_rejected_instead_of_writing_gif_data() {
+        let result = create_encoder(Path::new("animation.unknown"), Quality::Medium);
+        assert!(
+            matches!(result, Err(PlottingError::UnsupportedFormat(extension)) if extension == "unknown")
+        );
+    }
+
+    #[test]
+    fn explicit_gif_codec_does_not_depend_on_the_path_extension() {
+        assert!(
+            create_encoder_for_codec(Path::new("animation.custom"), Quality::Medium, Codec::Gif)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn av1_is_reported_as_an_unsupported_operation() {
+        let result =
+            create_encoder_for_codec(Path::new("animation.webm"), Quality::Medium, Codec::Av1);
+        assert!(matches!(
+            result,
+            Err(PlottingError::UnsupportedOperation {
+                operation: "AV1 animation encoding",
+                ..
+            })
+        ));
     }
 }

--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! - **Tick-based timing**: Deterministic frame timing with `Tick` struct
 //! - **Macro-based recording**: `record!` for frame count, duration, and config-driven capture
-//! - **Multiple formats**: GIF (default), MP4/WebM via AV1 (optional)
+//! - **GIF export**: deterministic frame capture and GIF encoding
 //! - **Observable integration**: Reactive animations with `AnimatedObservable`
 //! - **Smooth transitions**: Easing functions and plot morphing
 //! - **Compatibility wrappers**: Deprecated `record_*` helpers remain available for older code
@@ -71,7 +71,7 @@
 //! # Feature Flags
 //!
 //! - `animation` - Core animation system with GIF export
-//! - `animation-video` - MP4/WebM via pure Rust AV1 (rav1e)
+//! - `animation-video` - compatibility alias for `animation`; AV1 video is not currently available
 
 mod builder;
 mod interpolation;

--- a/src/animation/recorder.rs
+++ b/src/animation/recorder.rs
@@ -459,7 +459,7 @@ where
     let video_config = config.to_video_config();
     let mut stream = VideoStream::new(&path, video_config)?;
     let (actual_width, actual_height) = config.actual_dimensions();
-    let mut capture = FrameCapture::new(actual_width, actual_height);
+    let mut capture = FrameCapture::new(actual_width, actual_height)?;
     let mut ticker = TickGenerator::new(config.framerate as f64);
 
     // Determine figure parameters for capture (includes pre-calculated DPI)
@@ -609,7 +609,7 @@ where
     let video_config = config.to_video_config();
     let mut stream = VideoStream::new(&path, video_config)?;
     let (actual_width, actual_height) = config.actual_dimensions();
-    let mut capture = FrameCapture::new(actual_width, actual_height);
+    let mut capture = FrameCapture::new(actual_width, actual_height)?;
     let mut ticker = TickGenerator::new(config.framerate as f64);
 
     // Determine figure parameters for capture (includes pre-calculated DPI)
@@ -738,7 +738,7 @@ where
     let video_config = config.to_video_config();
     let mut stream = VideoStream::new(&path, video_config)?;
     let (actual_width, actual_height) = config.actual_dimensions();
-    let mut capture = FrameCapture::new(actual_width, actual_height);
+    let mut capture = FrameCapture::new(actual_width, actual_height)?;
     let mut ticker = TickGenerator::new(config.framerate as f64);
 
     // Determine figure parameters for capture (includes pre-calculated DPI)
@@ -814,8 +814,8 @@ pub fn record_plot_with_config<P: AsRef<Path>>(
 
     let video_config = config.to_video_config();
     let mut stream = VideoStream::new(&path, video_config)?;
-    let (width, height) = (config.width, config.height);
-    let mut capture = FrameCapture::new(width, height);
+    let (width, height) = config.actual_dimensions();
+    let mut capture = FrameCapture::new(width, height)?;
     let mut ticker = TickGenerator::new(config.framerate as f64);
 
     for frame in 0..frame_count {
@@ -826,8 +826,9 @@ pub fn record_plot_with_config<P: AsRef<Path>>(
         let sized_plot = frame_plot_for_config(plot, &config);
         let image = sized_plot.render_at(time)?;
 
-        // Convert to frame data and record
-        stream.record_frame_sized(&image.pixels, width, height, &tick)?;
+        // Convert the rendered RGBA image to the RGB format encoders accept.
+        let rgb = capture.copy_rgba(image.width, image.height, &image.pixels)?;
+        stream.record_frame_sized(rgb, width, height, &tick)?;
     }
 
     stream.save()
@@ -836,11 +837,8 @@ pub fn record_plot_with_config<P: AsRef<Path>>(
 fn frame_plot_for_config(plot: &Plot, config: &RecordConfig) -> Plot {
     let (width, height) = (config.width, config.height);
 
-    if config.preserve_figure {
-        let dpi = (width as f32 / config.figure_width).max(height as f32 / config.figure_height);
-        plot.clone()
-            .size(config.figure_width, config.figure_height)
-            .dpi(dpi as u32)
+    if let Some((figure_width, figure_height, dpi)) = config.figure_params() {
+        plot.clone().size(figure_width, figure_height).dpi(dpi)
     } else {
         plot.clone().set_output_pixels(width, height)
     }
@@ -1045,6 +1043,21 @@ mod tests {
     }
 
     #[test]
+    fn test_frame_plot_for_config_matches_rounded_preserve_figure_dimensions() {
+        let plot = Plot::new().line(&[0.0, 1.0], &[1.0, 2.0]).into();
+        let config = RecordConfig::new()
+            .dimensions(801, 601)
+            .preserve_figure_size();
+
+        let sized_plot = frame_plot_for_config(&plot, &config);
+
+        assert_eq!(
+            sized_plot.get_config().canvas_size(),
+            config.actual_dimensions()
+        );
+    }
+
+    #[test]
     fn test_frame_plot_for_config_non_preserve_reuses_plot_dpi() {
         let plot = Plot::new()
             .size(6.4, 4.8)
@@ -1245,5 +1258,18 @@ mod tests {
         assert_eq!(values.len(), 10);
         assert!((values[0] - 0.0).abs() < 1e-10);
         assert!((values[5] - 50.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_record_plot_converts_rendered_rgba_to_encoder_rgb() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("reactive.gif");
+        let plot: Plot = Plot::new().line(&[0.0, 1.0], &[0.0, 1.0]).into();
+        let config = RecordConfig::new().dimensions(100, 100).framerate(1);
+
+        record_plot_with_config(&path, &plot, 1.0, config).unwrap();
+
+        let bytes = std::fs::read(path).unwrap();
+        assert!(bytes.starts_with(b"GIF"));
     }
 }

--- a/src/animation/stream.rs
+++ b/src/animation/stream.rs
@@ -4,7 +4,7 @@
 
 use std::path::Path;
 
-use super::encoders::{Codec, Encoder, Quality, create_encoder};
+use super::encoders::{Codec, Encoder, Quality, create_encoder_for_codec};
 use super::tick::Tick;
 use crate::core::{Plot, PlottingError, Result};
 
@@ -76,7 +76,7 @@ impl VideoConfig {
             .and_then(|e| e.to_str())
             .unwrap_or("gif");
 
-        let codec = Codec::from_extension(ext).unwrap_or(Codec::Gif);
+        let codec = Codec::from_extension(ext).unwrap_or(Codec::Auto);
 
         Self {
             codec,
@@ -84,15 +84,59 @@ impl VideoConfig {
         }
     }
 
+    /// Validate dimensions, timing, and format-specific constraints.
+    pub fn validate(&self) -> Result<()> {
+        checked_rgb_len(self.width, self.height)?;
+        if self.framerate == 0 {
+            return Err(PlottingError::InvalidInput(
+                "Animation framerate must be greater than zero".into(),
+            ));
+        }
+        if matches!(self.codec, Codec::Gif)
+            && (self.width > u16::MAX as u32 || self.height > u16::MAX as u32)
+        {
+            return Err(PlottingError::InvalidInput(format!(
+                "GIF dimensions must not exceed {}x{} pixels",
+                u16::MAX,
+                u16::MAX
+            )));
+        }
+        Ok(())
+    }
+
     /// Get frame delay in centiseconds (for GIF)
     pub fn frame_delay_cs(&self) -> u16 {
+        if self.framerate == 0 {
+            return 0;
+        }
         ((100.0 / self.framerate as f64).round() as u16).max(1)
     }
 
     /// Get frame duration in seconds
     pub fn frame_duration(&self) -> f64 {
-        1.0 / self.framerate as f64
+        if self.framerate == 0 {
+            0.0
+        } else {
+            1.0 / self.framerate as f64
+        }
     }
+}
+
+fn checked_rgb_len(width: u32, height: u32) -> Result<usize> {
+    checked_pixel_count(width, height)?
+        .checked_mul(3)
+        .ok_or_else(|| PlottingError::InvalidInput("Animation RGB buffer size overflow".into()))
+}
+
+fn checked_pixel_count(width: u32, height: u32) -> Result<usize> {
+    if width == 0 || height == 0 {
+        return Err(PlottingError::InvalidInput(
+            "Animation dimensions must be greater than zero".into(),
+        ));
+    }
+    (width as usize)
+        .checked_mul(height as usize)
+        .ok_or_else(|| PlottingError::InvalidInput("Animation dimensions overflow".into()))
 }
 
 /// Captures rendered frames from plots
@@ -106,7 +150,7 @@ impl VideoConfig {
 /// use ruviz::animation::FrameCapture;
 /// use ruviz::prelude::*;
 ///
-/// let mut capture = FrameCapture::new(800, 600);
+/// let mut capture = FrameCapture::new(800, 600)?;
 ///
 /// let plot = Plot::new().line(&[0.0, 1.0], &[0.0, 1.0]);
 /// let frame_data = capture.capture(&plot)?;
@@ -120,13 +164,13 @@ pub struct FrameCapture {
 
 impl FrameCapture {
     /// Create a new frame capture with the given dimensions
-    pub fn new(width: u32, height: u32) -> Self {
-        let buffer_size = (width * height * 3) as usize;
-        Self {
+    pub fn new(width: u32, height: u32) -> Result<Self> {
+        let buffer_size = checked_rgb_len(width, height)?;
+        Ok(Self {
             width,
             height,
             buffer: vec![0u8; buffer_size],
-        }
+        })
     }
 
     /// Get the capture dimensions
@@ -135,13 +179,14 @@ impl FrameCapture {
     }
 
     /// Resize the capture buffer
-    pub fn resize(&mut self, width: u32, height: u32) {
+    pub fn resize(&mut self, width: u32, height: u32) -> Result<()> {
         if self.width != width || self.height != height {
+            let buffer_size = checked_rgb_len(width, height)?;
             self.width = width;
             self.height = height;
-            let buffer_size = (width * height * 3) as usize;
             self.buffer.resize(buffer_size, 0);
         }
+        Ok(())
     }
 
     /// Capture a frame from the plot
@@ -154,18 +199,7 @@ impl FrameCapture {
 
         // Render plot to RGBA buffer
         let image = sized_plot.render()?;
-        let rgba_data = &image.pixels;
-
-        // Convert RGBA to RGB
-        let pixels = (self.width * self.height) as usize;
-        for i in 0..pixels {
-            self.buffer[i * 3] = rgba_data[i * 4]; // R
-            self.buffer[i * 3 + 1] = rgba_data[i * 4 + 1]; // G
-            self.buffer[i * 3 + 2] = rgba_data[i * 4 + 2]; // B
-            // Alpha is discarded
-        }
-
-        Ok(&self.buffer)
+        self.copy_rgba(image.width, image.height, &image.pixels)
     }
 
     /// Capture a frame with figure-preserving mode
@@ -203,40 +237,44 @@ impl FrameCapture {
 
         // Render plot to RGBA buffer
         let image = sized_plot.render()?;
-        let rgba_data = &image.pixels;
-
-        // Use actual rendered dimensions
-        let actual_pixels = (image.width * image.height) as usize;
-
-        // Resize buffer if needed (safety check - dimensions should match)
-        let required_size = actual_pixels * 3;
-        if self.buffer.len() != required_size {
-            self.buffer.resize(required_size, 0);
-            self.width = image.width;
-            self.height = image.height;
-        }
-
-        // Convert RGBA to RGB
-        for i in 0..actual_pixels {
-            self.buffer[i * 3] = rgba_data[i * 4]; // R
-            self.buffer[i * 3 + 1] = rgba_data[i * 4 + 1]; // G
-            self.buffer[i * 3 + 2] = rgba_data[i * 4 + 2]; // B
-        }
-
-        Ok(&self.buffer)
+        self.resize(image.width, image.height)?;
+        self.copy_rgba(image.width, image.height, &image.pixels)
     }
 
     /// Capture with explicit dimensions
     ///
     /// Resizes if necessary before capturing.
     pub fn capture_sized(&mut self, plot: &Plot, width: u32, height: u32) -> Result<&[u8]> {
-        self.resize(width, height);
+        self.resize(width, height)?;
         self.capture(plot)
     }
 
     /// Get a copy of the buffer (for async encoding)
     pub fn buffer_copy(&self) -> Vec<u8> {
         self.buffer.clone()
+    }
+
+    pub(crate) fn copy_rgba(&mut self, width: u32, height: u32, rgba: &[u8]) -> Result<&[u8]> {
+        if width != self.width || height != self.height {
+            return Err(PlottingError::RenderError(format!(
+                "Animation frame rendered at {width}x{height}, expected {}x{}",
+                self.width, self.height
+            )));
+        }
+        let pixels = checked_pixel_count(width, height)?;
+        let expected_rgba = pixels.checked_mul(4).ok_or_else(|| {
+            PlottingError::InvalidInput("Animation RGBA buffer size overflow".into())
+        })?;
+        if rgba.len() != expected_rgba {
+            return Err(PlottingError::RenderError(format!(
+                "Animation RGBA buffer has {} bytes, expected {expected_rgba}",
+                rgba.len()
+            )));
+        }
+        for (destination, source) in self.buffer.chunks_exact_mut(3).zip(rgba.chunks_exact(4)) {
+            destination.copy_from_slice(&source[..3]);
+        }
+        Ok(&self.buffer)
     }
 }
 
@@ -271,7 +309,8 @@ pub struct VideoStream {
 impl VideoStream {
     /// Create a new video stream with the given output path and config
     pub fn new<P: AsRef<Path>>(path: P, config: VideoConfig) -> Result<Self> {
-        let encoder = create_encoder(path.as_ref(), config.quality)?;
+        config.validate()?;
+        let encoder = create_encoder_for_codec(path.as_ref(), config.quality, config.codec)?;
 
         Ok(Self {
             encoder,
@@ -392,16 +431,35 @@ mod tests {
 
     #[test]
     fn test_frame_capture_new() {
-        let capture = FrameCapture::new(100, 50);
+        let capture = FrameCapture::new(100, 50).unwrap();
         assert_eq!(capture.dimensions(), (100, 50));
         assert_eq!(capture.buffer.len(), 100 * 50 * 3);
     }
 
     #[test]
     fn test_frame_capture_resize() {
-        let mut capture = FrameCapture::new(100, 100);
-        capture.resize(200, 150);
+        let mut capture = FrameCapture::new(100, 100).unwrap();
+        capture.resize(200, 150).unwrap();
         assert_eq!(capture.dimensions(), (200, 150));
         assert_eq!(capture.buffer.len(), 200 * 150 * 3);
+    }
+
+    #[test]
+    fn video_config_rejects_zero_values_and_overflowing_buffers() {
+        assert!(VideoConfig::new().framerate(0).validate().is_err());
+        assert!(VideoConfig::new().dimensions(0, 100).validate().is_err());
+        assert!(FrameCapture::new(u32::MAX, u32::MAX).is_err());
+    }
+
+    #[test]
+    fn video_stream_honors_an_explicit_codec() {
+        let config = VideoConfig::new().codec(Codec::Gif);
+        assert!(VideoStream::new("animation.custom", config).is_ok());
+
+        let config = VideoConfig::new().codec(Codec::Av1);
+        assert!(matches!(
+            VideoStream::new("animation.gif", config),
+            Err(PlottingError::UnsupportedOperation { .. })
+        ));
     }
 }

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -3166,6 +3166,7 @@ fn test_unsupported_surface_series_fall_back_to_image_capability() {
 }
 
 #[test]
+#[ignore = "large rendering validation runs in the scheduled heavy lane"]
 fn test_large_dataset_surface_frames_render_without_blackout() {
     let x: Vec<f64> = (0..100_000).map(|index| index as f64 * 0.0001).collect();
     let y: Vec<f64> = x

--- a/src/core/plot/tests.rs
+++ b/src/core/plot/tests.rs
@@ -4298,6 +4298,7 @@ fn test_render_to_renderer_matches_reference_render_output_for_large_scatter() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
+#[ignore = "large rendering validation runs in the scheduled heavy lane"]
 fn test_large_xy_family_png_and_save_paths_stay_visually_sane() {
     let (x, y) = large_xy_data();
     let (error_x, error_y) = large_error_bar_xy_data();
@@ -4349,6 +4350,7 @@ fn test_large_xy_family_png_and_save_paths_stay_visually_sane() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
+#[ignore = "large rendering validation runs in the scheduled heavy lane"]
 fn test_large_distribution_and_categorical_png_and_save_paths_stay_visually_sane() {
     let samples = large_scalar_samples();
     let (categories, values) = large_bar_data();
@@ -4398,6 +4400,7 @@ fn test_large_distribution_and_categorical_png_and_save_paths_stay_visually_sane
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
+#[ignore = "large rendering validation runs in the scheduled heavy lane"]
 fn test_large_grid_family_png_and_save_paths_stay_visually_sane() {
     let heatmap_values = large_heatmap_matrix();
     let (contour_x, contour_y, contour_z) = large_contour_axes();

--- a/src/data/platform/mod.rs
+++ b/src/data/platform/mod.rs
@@ -103,7 +103,7 @@ fn detect_platform_info() -> Result<PlatformInfo, crate::core::error::PlottingEr
     let os_type = detect_os_type();
     let total_memory = platform::get_total_memory()?;
     let available_memory = platform::get_available_memory()?;
-    let cpu_cores = num_cpus::get();
+    let cpu_cores = available_cpu_cores();
     let numa_nodes = platform::get_numa_nodes();
     let supports_hugepages = platform::check_hugepage_support();
     let supports_memory_mapping = platform::check_memory_mapping_support()?;
@@ -192,7 +192,7 @@ pub fn get_platform_optimizer() -> &'static PlatformOptimizer {
                 os_type: detect_os_type(),
                 total_memory: 8 * 1024 * 1024 * 1024,
                 available_memory: 4 * 1024 * 1024 * 1024,
-                cpu_cores: num_cpus::get(),
+                cpu_cores: available_cpu_cores(),
                 cache_line_size: 64,
                 page_size: 4096,
                 numa_nodes: 1,
@@ -224,6 +224,12 @@ pub fn get_platform_optimizer() -> &'static PlatformOptimizer {
             })),
         })
     })
+}
+
+fn available_cpu_cores() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(1)
 }
 
 pub fn initialize_platform_optimization() -> Result<(), crate::core::error::PlottingError> {

--- a/src/render/gpu/buffer.rs
+++ b/src/render/gpu/buffer.rs
@@ -4,7 +4,10 @@ use crate::core::error::PlottingError;
 use crate::data::platform::PerformanceHints;
 use crate::render::gpu::{BufferStats, GpuCapabilities, GpuDevice};
 use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use wgpu::util::DeviceExt;
 
 /// GPU buffer usage patterns for optimization
@@ -28,7 +31,11 @@ impl BufferUsage {
     /// Convert to wgpu buffer usage flags
     pub fn to_wgpu_usage(self) -> wgpu::BufferUsages {
         match self {
-            BufferUsage::Static => wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::INDEX,
+            BufferUsage::Static => {
+                wgpu::BufferUsages::VERTEX
+                    | wgpu::BufferUsages::INDEX
+                    | wgpu::BufferUsages::COPY_DST
+            }
             BufferUsage::Dynamic => wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
             BufferUsage::Compute => {
                 wgpu::BufferUsages::STORAGE
@@ -49,8 +56,10 @@ pub struct GpuBuffer {
     size: u64,
     usage: BufferUsage,
     label: String,
-    mapped: bool,
+    mapped: Arc<AtomicBool>,
     pool_id: Option<usize>,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
 }
 
 impl GpuBuffer {
@@ -80,8 +89,10 @@ impl GpuBuffer {
             size,
             usage,
             label: label.to_string(),
-            mapped: false,
+            mapped: Arc::new(AtomicBool::new(false)),
             pool_id: None,
+            device: Arc::clone(device.device()),
+            queue: Arc::clone(device.queue()),
         })
     }
 
@@ -112,8 +123,10 @@ impl GpuBuffer {
             size,
             usage,
             label: label.to_string(),
-            mapped: false,
+            mapped: Arc::new(AtomicBool::new(false)),
             pool_id: None,
+            device: Arc::clone(device.device()),
+            queue: Arc::clone(device.queue()),
         })
     }
 
@@ -139,44 +152,75 @@ impl GpuBuffer {
 
     /// Check if buffer is mapped
     pub fn is_mapped(&self) -> bool {
-        self.mapped
+        self.mapped.load(Ordering::Acquire)
     }
 
     /// Map buffer for reading
-    pub async fn map_read(&mut self) -> Result<&[u8], PlottingError> {
-        if self.mapped {
+    pub async fn map_read(&mut self) -> Result<Vec<u8>, PlottingError> {
+        if !self
+            .usage
+            .to_wgpu_usage()
+            .contains(wgpu::BufferUsages::MAP_READ)
+        {
+            return Err(PlottingError::BufferError(
+                "Buffer was not created with MAP_READ usage".to_string(),
+            ));
+        }
+        if self.mapped.swap(true, Ordering::AcqRel) {
             return Err(PlottingError::BufferError(
                 "Buffer already mapped".to_string(),
             ));
         }
 
         let slice = self.buffer.slice(..);
-        slice.map_async(wgpu::MapMode::Read, |result| {
-            if let Err(e) = result {
-                log::error!("Failed to map buffer for reading: {}", e);
-            }
+        let (sender, receiver) = futures_intrusive::channel::shared::oneshot_channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = sender.send(result);
         });
+        let submission = self.queue.submit(std::iter::empty());
+        if let Err(error) = self.device.poll(wgpu::PollType::Wait {
+            submission_index: Some(submission),
+            timeout: None,
+        }) {
+            self.mapped.store(false, Ordering::Release);
+            self.buffer.unmap();
+            return Err(PlottingError::BufferError(format!(
+                "Failed to poll mapped buffer: {error}"
+            )));
+        }
+        let Some(map_result) = receiver.receive().await else {
+            self.mapped.store(false, Ordering::Release);
+            self.buffer.unmap();
+            return Err(PlottingError::BufferError(
+                "Buffer mapping callback was dropped".to_string(),
+            ));
+        };
+        if let Err(error) = map_result {
+            self.mapped.store(false, Ordering::Release);
+            self.buffer.unmap();
+            return Err(PlottingError::BufferError(format!(
+                "Failed to map buffer for reading: {error}"
+            )));
+        }
 
-        // TODO: Handle async mapping properly
-        self.mapped = true;
-
-        // This is a placeholder - proper async handling would be needed
-        Err(PlottingError::BufferError(
-            "Async mapping not fully implemented".to_string(),
-        ))
+        let bytes = slice.get_mapped_range().to_vec();
+        self.unmap();
+        Ok(bytes)
     }
 
     /// Unmap buffer
     pub fn unmap(&mut self) {
-        if self.mapped {
+        if self.mapped.swap(false, Ordering::AcqRel) {
             self.buffer.unmap();
-            self.mapped = false;
         }
     }
 
     /// Write data to buffer
     pub fn write(&self, device: &GpuDevice, offset: u64, data: &[u8]) -> Result<(), PlottingError> {
-        if offset + data.len() as u64 > self.size {
+        let end = offset.checked_add(data.len() as u64).ok_or_else(|| {
+            PlottingError::BufferError("Buffer write offset overflowed".to_string())
+        })?;
+        if end > self.size {
             return Err(PlottingError::BufferError(format!(
                 "Write would exceed buffer size: {}+{} > {}",
                 offset,
@@ -187,12 +231,6 @@ impl GpuBuffer {
 
         device.write_buffer(&self.buffer, offset, data);
         Ok(())
-    }
-}
-
-impl Drop for GpuBuffer {
-    fn drop(&mut self) {
-        self.unmap();
     }
 }
 
@@ -224,7 +262,8 @@ impl BufferPool {
         device: &GpuDevice,
         size: u64,
         label: &str,
-    ) -> Result<(usize, GpuBuffer), PlottingError> {
+        max_new_bytes: u64,
+    ) -> Result<(usize, u64, u64), PlottingError> {
         // Try to reuse existing buffer of appropriate size
         if let Some(mut buffer) = self.find_suitable_buffer(size) {
             buffer.label = format!("{} (reused)", label);
@@ -232,7 +271,15 @@ impl BufferPool {
             self.next_id += 1;
             self.in_use.insert(id, buffer);
             self.reuse_count += 1;
-            return Ok((id, self.in_use.get(&id).unwrap().clone()));
+            let actual_size = self.in_use.get(&id).map_or(size, |buffer| buffer.size);
+            return Ok((id, actual_size, 0));
+        }
+
+        if size > max_new_bytes {
+            return Err(PlottingError::GpuMemoryError {
+                requested: size as usize,
+                available: Some(max_new_bytes as usize),
+            });
         }
 
         // Create new buffer
@@ -244,26 +291,29 @@ impl BufferPool {
         self.total_allocated += size;
 
         self.in_use.insert(id, buffer);
-        Ok((id, self.in_use.get(&id).unwrap().clone()))
+        Ok((id, size, size))
     }
 
     /// Return buffer to pool
-    fn deallocate(&mut self, id: usize) -> bool {
+    fn deallocate(&mut self, id: usize) -> Option<u64> {
         if let Some(buffer) = self.in_use.remove(&id) {
             // Only keep buffer if it's reasonably sized and pool isn't too full
             if buffer.size <= 64 * 1024 * 1024 && self.available.len() < 16 {
                 self.available.push_back(buffer);
+                Some(0)
+            } else {
+                self.total_allocated = self.total_allocated.saturating_sub(buffer.size);
+                Some(buffer.size)
             }
-            true
         } else {
-            false
+            None
         }
     }
 
     /// Find suitable buffer for reuse
     fn find_suitable_buffer(&mut self, required_size: u64) -> Option<GpuBuffer> {
         // Look for buffer that's at least the required size but not too much larger
-        let max_size = required_size * 2; // Don't waste more than 2x memory
+        let max_size = required_size.saturating_mul(2); // Don't waste more than 2x memory
 
         for i in 0..self.available.len() {
             if self.available[i].size >= required_size && self.available[i].size <= max_size {
@@ -314,10 +364,23 @@ impl BufferManager {
         capabilities: &GpuCapabilities,
         hints: &PerformanceHints,
     ) -> Result<Self, PlottingError> {
-        // Calculate memory limit (80% of max buffer size or platform hint)
-        let memory_limit = capabilities.max_buffer_size.min(
-            hints.optimal_chunk_size as u64 * 1024, // Conservative limit
-        );
+        Self::with_memory_limit_fraction(device, capabilities, hints, 0.8)
+    }
+
+    /// Create a buffer manager with an explicit fraction of the adapter limit.
+    pub fn with_memory_limit_fraction(
+        _device: &GpuDevice,
+        capabilities: &GpuCapabilities,
+        hints: &PerformanceHints,
+        memory_limit_fraction: f32,
+    ) -> Result<Self, PlottingError> {
+        if !memory_limit_fraction.is_finite() || !(0.0..=1.0).contains(&memory_limit_fraction) {
+            return Err(PlottingError::InvalidInput(
+                "GPU memory_limit_fraction must be finite and between 0 and 1".into(),
+            ));
+        }
+        let memory_limit =
+            (capabilities.max_buffer_size as f64 * memory_limit_fraction as f64) as u64;
 
         let mut pools = HashMap::new();
 
@@ -352,26 +415,24 @@ impl BufferManager {
         usage: BufferUsage,
         label: &str,
     ) -> Result<BufferHandle, PlottingError> {
-        // Check memory limits
-        if self.total_memory + size > self.memory_limit {
-            return Err(PlottingError::GpuMemoryError {
-                requested: size as usize,
-                available: Some((self.memory_limit - self.total_memory) as usize),
-            });
-        }
-
         let pool = self.pools.get_mut(&usage).ok_or_else(|| {
             PlottingError::BufferError(format!("No pool for usage type: {:?}", usage))
         })?;
 
-        let (id, buffer) = pool.allocate(device, size, label)?;
-        self.total_memory += size;
+        let available = self.memory_limit.saturating_sub(self.total_memory);
+        let (id, actual_size, newly_allocated) = pool.allocate(device, size, label, available)?;
+        self.total_memory = self.total_memory.checked_add(newly_allocated).ok_or(
+            PlottingError::GpuMemoryError {
+                requested: newly_allocated as usize,
+                available: Some(available as usize),
+            },
+        )?;
         self.allocation_count += 1;
 
         Ok(BufferHandle {
             id,
             usage,
-            size,
+            size: actual_size,
             _phantom: std::marker::PhantomData,
         })
     }
@@ -382,14 +443,15 @@ impl BufferManager {
             PlottingError::BufferError(format!("No pool for usage type: {:?}", handle.usage))
         })?;
 
-        if pool.deallocate(handle.id) {
-            self.total_memory = self.total_memory.saturating_sub(handle.size);
-            self.deallocation_count += 1;
-            Ok(())
-        } else {
-            Err(PlottingError::BufferError(
+        match pool.deallocate(handle.id) {
+            Some(freed) => {
+                self.total_memory = self.total_memory.saturating_sub(freed);
+                self.deallocation_count += 1;
+                Ok(())
+            }
+            None => Err(PlottingError::BufferError(
                 "Buffer not found in pool".to_string(),
-            ))
+            )),
         }
     }
 
@@ -406,8 +468,15 @@ impl BufferManager {
         usage: BufferUsage,
         label: &str,
     ) -> Result<(BufferHandle, GpuBuffer), PlottingError> {
+        if !usage.to_wgpu_usage().contains(wgpu::BufferUsages::COPY_DST) {
+            return Err(PlottingError::BufferError(format!(
+                "Buffer usage {usage:?} cannot be initialized with queue writes"
+            )));
+        }
         let handle = self.allocate(device, data.len() as u64, usage, label)?;
-        let buffer = self.get_buffer(&handle).unwrap().clone();
+        let buffer = self.get_buffer(&handle).cloned().ok_or_else(|| {
+            PlottingError::BufferError("Newly allocated buffer was not retained".to_string())
+        })?;
         buffer.write(device, 0, data)?;
         Ok((handle, buffer))
     }
@@ -418,6 +487,7 @@ impl BufferManager {
             // Keep only recent buffers in available pool
             while pool.available.len() > 8 {
                 if let Some(buffer) = pool.available.pop_front() {
+                    pool.total_allocated = pool.total_allocated.saturating_sub(buffer.size);
                     self.total_memory = self.total_memory.saturating_sub(buffer.size);
                 }
             }
@@ -465,6 +535,7 @@ impl BufferManager {
             if stats.reuse_count < stats.available_buffers / 4 {
                 while pool.available.len() > 4 {
                     if let Some(buffer) = pool.available.pop_front() {
+                        pool.total_allocated = pool.total_allocated.saturating_sub(buffer.size);
                         self.total_memory = self.total_memory.saturating_sub(buffer.size);
                     }
                 }
@@ -498,5 +569,4 @@ impl BufferHandle {
     }
 }
 
-// Note: GpuBuffer doesn't implement Clone as wgpu::Buffer doesn't support cloning
-// This is intentional to prevent accidental duplication of GPU resources
+// Handles are move-only; cloned `GpuBuffer` values share the same physical buffer.

--- a/src/render/gpu/device.rs
+++ b/src/render/gpu/device.rs
@@ -2,7 +2,10 @@
 
 use crate::core::error::PlottingError;
 use crate::render::gpu::GpuConfig;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use wgpu::util::DeviceExt;
 
 /// GPU device wrapper with enhanced functionality
@@ -11,6 +14,7 @@ pub struct GpuDevice {
     queue: Arc<wgpu::Queue>,
     adapter: wgpu::Adapter,
     info: GpuDeviceInfo,
+    lost: Arc<AtomicBool>,
 }
 
 /// Information about the GPU device
@@ -42,7 +46,7 @@ impl Default for DeviceSelector {
             required_features: wgpu::Features::empty(),
             required_limits: wgpu::Limits::default(),
             prefer_integrated: false,
-            prefer_discrete: true, // Prefer discrete GPU for plotting
+            prefer_discrete: false,
         }
     }
 }
@@ -102,6 +106,8 @@ impl DeviceSelector {
             })
             .collect();
 
+        scored_adapters.retain(|(_, _, score)| *score >= 0);
+
         // Sort by score (highest first)
         scored_adapters.sort_by(|a, b| b.2.cmp(&a.2));
 
@@ -121,8 +127,18 @@ impl DeviceSelector {
 
         // Device type preference
         match info.device_type {
-            wgpu::DeviceType::DiscreteGpu if self.prefer_discrete => score += 100,
-            wgpu::DeviceType::IntegratedGpu if self.prefer_integrated => score += 100,
+            wgpu::DeviceType::DiscreteGpu if self.prefer_discrete => score += 120,
+            wgpu::DeviceType::IntegratedGpu if self.prefer_integrated => score += 120,
+            wgpu::DeviceType::DiscreteGpu
+                if self.power_preference == wgpu::PowerPreference::HighPerformance =>
+            {
+                score += 100;
+            }
+            wgpu::DeviceType::IntegratedGpu
+                if self.power_preference == wgpu::PowerPreference::LowPower =>
+            {
+                score += 100;
+            }
             wgpu::DeviceType::DiscreteGpu => score += 50,
             wgpu::DeviceType::IntegratedGpu => score += 30,
             wgpu::DeviceType::VirtualGpu => score += 10,
@@ -156,8 +172,11 @@ impl DeviceSelector {
         }
 
         // Bonus for additional useful features
-        if features.contains(wgpu::Features::empty()) {
-            // TODO: Check for actual compute shader feature
+        if adapter
+            .get_downlevel_capabilities()
+            .flags
+            .contains(wgpu::DownlevelFlags::COMPUTE_SHADERS)
+        {
             score += 30;
         }
         if features.contains(wgpu::Features::STORAGE_RESOURCE_BINDING_ARRAY) {
@@ -172,6 +191,9 @@ impl DeviceSelector {
 
         // Check limits
         let limits = adapter.limits();
+        if !self.required_limits.check_limits(&limits) {
+            return -1000;
+        }
 
         // Prefer larger texture sizes
         if limits.max_texture_dimension_2d >= 16384 {
@@ -240,6 +262,12 @@ impl GpuDevice {
         device.on_uncaptured_error(Arc::new(|error| {
             log::error!("GPU Error: {}", error);
         }));
+        let lost = Arc::new(AtomicBool::new(false));
+        let lost_callback = Arc::clone(&lost);
+        device.set_device_lost_callback(move |reason, message| {
+            lost_callback.store(true, Ordering::Release);
+            log::error!("GPU device lost ({reason:?}): {message}");
+        });
 
         let info = GpuDeviceInfo {
             name: adapter_info.name.clone(),
@@ -261,6 +289,7 @@ impl GpuDevice {
             queue: Arc::new(queue),
             adapter,
             info,
+            lost,
         })
     }
 
@@ -296,8 +325,7 @@ impl GpuDevice {
 
     /// Check if device is still valid
     pub fn is_valid(&self) -> bool {
-        // wgpu doesn't have is_lost() method in this version, assume valid
-        true
+        !self.lost.load(Ordering::Acquire)
     }
 
     /// Create buffer with device extension utility

--- a/src/render/gpu/memory.rs
+++ b/src/render/gpu/memory.rs
@@ -17,6 +17,7 @@ pub struct GpuBuffer {
     size: u64,
     usage: wgpu::BufferUsages,
     label: Option<String>,
+    accounting: Option<Arc<MemoryAccounting>>,
 }
 
 impl GpuBuffer {
@@ -38,6 +39,7 @@ impl GpuBuffer {
             size: data.len() as u64,
             usage,
             label: label.map(|s| s.to_string()),
+            accounting: None,
         }
     }
 
@@ -60,6 +62,7 @@ impl GpuBuffer {
             size,
             usage,
             label: label.map(|s| s.to_string()),
+            accounting: None,
         }
     }
 
@@ -76,6 +79,31 @@ impl GpuBuffer {
     /// Get buffer usage flags
     pub fn usage(&self) -> wgpu::BufferUsages {
         self.usage
+    }
+
+    fn with_accounting(mut self, accounting: Arc<MemoryAccounting>) -> Self {
+        self.accounting = Some(accounting);
+        self
+    }
+}
+
+impl Drop for GpuBuffer {
+    fn drop(&mut self) {
+        let Some(accounting) = &self.accounting else {
+            return;
+        };
+        let mut total_allocated = accounting
+            .total_allocated
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *total_allocated = total_allocated.saturating_sub(self.size);
+        drop(total_allocated);
+
+        let mut stats = accounting
+            .stats
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        stats.total_allocated = stats.total_allocated.saturating_sub(self.size);
     }
 }
 
@@ -94,6 +122,7 @@ pub struct GpuMemoryPool {
     alignment: u64,
     /// Statistics
     stats: Arc<Mutex<GpuMemoryStats>>,
+    accounting: Arc<MemoryAccounting>,
 }
 
 /// GPU memory usage statistics
@@ -107,6 +136,11 @@ pub struct GpuMemoryStats {
     pub memory_limit: u64,
 }
 
+struct MemoryAccounting {
+    total_allocated: Arc<Mutex<u64>>,
+    stats: Arc<Mutex<GpuMemoryStats>>,
+}
+
 impl GpuMemoryPool {
     /// Create a new GPU memory pool
     pub fn new(
@@ -114,23 +148,46 @@ impl GpuMemoryPool {
         queue: Arc<wgpu::Queue>,
         capabilities: &GpuCapabilities,
     ) -> Result<Self> {
-        // Calculate memory limit (80% of max buffer size as approximation)
-        let memory_limit = (capabilities.max_buffer_size as f64 * 0.8) as u64;
+        Self::with_memory_limit_fraction(device, queue, capabilities, 0.8)
+    }
+
+    /// Create a GPU memory pool with an explicit fraction of the adapter limit.
+    pub fn with_memory_limit_fraction(
+        device: Arc<wgpu::Device>,
+        queue: Arc<wgpu::Queue>,
+        capabilities: &GpuCapabilities,
+        memory_limit_fraction: f32,
+    ) -> Result<Self> {
+        if !memory_limit_fraction.is_finite() || !(0.0..=1.0).contains(&memory_limit_fraction) {
+            return Err(PlottingError::InvalidInput(
+                "GPU memory_limit_fraction must be finite and between 0 and 1".into(),
+            ));
+        }
+        let memory_limit =
+            (capabilities.max_buffer_size as f64 * memory_limit_fraction as f64) as u64;
 
         // Get buffer alignment from limits
         let alignment = device.limits().min_uniform_buffer_offset_alignment as u64;
+
+        let total_allocated = Arc::new(Mutex::new(0));
+        let stats = Arc::new(Mutex::new(GpuMemoryStats {
+            memory_limit,
+            ..Default::default()
+        }));
+        let accounting = Arc::new(MemoryAccounting {
+            total_allocated: Arc::clone(&total_allocated),
+            stats: Arc::clone(&stats),
+        });
 
         Ok(Self {
             device,
             queue,
             buffer_cache: Arc::new(Mutex::new(HashMap::new())),
-            total_allocated: Arc::new(Mutex::new(0)),
+            total_allocated,
             memory_limit,
             alignment,
-            stats: Arc::new(Mutex::new(GpuMemoryStats {
-                memory_limit,
-                ..Default::default()
-            })),
+            stats,
+            accounting,
         })
     }
 
@@ -150,7 +207,10 @@ impl GpuMemoryPool {
         count: usize,
         usage: wgpu::BufferUsages,
     ) -> Result<GpuBuffer> {
-        let size = (count * std::mem::size_of::<T>()) as u64;
+        let size = count
+            .checked_mul(std::mem::size_of::<T>())
+            .and_then(|size| u64::try_from(size).ok())
+            .ok_or_else(|| PlottingError::InvalidInput("GPU buffer size overflow".into()))?;
         let aligned_size = self.align_buffer_size(size);
         self.create_buffer_empty_bytes(aligned_size, usage, None)
     }
@@ -165,20 +225,11 @@ impl GpuMemoryPool {
         let size = data.len() as u64;
         let aligned_size = self.align_buffer_size(size);
 
-        // Check memory limit
-        {
-            let total_allocated = self.total_allocated.lock().unwrap();
-            if *total_allocated + aligned_size > self.memory_limit {
-                return Err(PlottingError::GpuMemoryError {
-                    requested: aligned_size as usize,
-                    available: Some((self.memory_limit - *total_allocated) as usize),
-                });
-            }
-        }
-
         // Try to reuse existing buffer from cache
         let cache_key = (aligned_size, usage);
-        if let Some(buffer) = self.try_reuse_buffer(&cache_key) {
+        if usage.contains(wgpu::BufferUsages::COPY_DST)
+            && let Some(buffer) = self.try_reuse_buffer(&cache_key)
+        {
             // Update buffer data
             self.queue.write_buffer(buffer.buffer(), 0, data);
 
@@ -192,6 +243,21 @@ impl GpuMemoryPool {
             return Ok(buffer);
         }
 
+        // Check memory limit only when a new physical allocation is required.
+        {
+            let total_allocated = self
+                .total_allocated
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let available = self.memory_limit.saturating_sub(*total_allocated);
+            if aligned_size > available {
+                return Err(PlottingError::GpuMemoryError {
+                    requested: aligned_size as usize,
+                    available: Some(available as usize),
+                });
+            }
+        }
+
         // Create new buffer
         let buffer = if data.is_empty() {
             GpuBuffer::new_empty(&self.device, aligned_size, usage, label)
@@ -200,7 +266,8 @@ impl GpuMemoryPool {
             let mut padded_data = data.to_vec();
             padded_data.resize(aligned_size as usize, 0);
             GpuBuffer::new(&self.device, &padded_data, usage, label)
-        };
+        }
+        .with_accounting(Arc::clone(&self.accounting));
 
         // Update memory tracking
         {
@@ -231,16 +298,18 @@ impl GpuMemoryPool {
         // Check memory limit
         {
             let total_allocated = self.total_allocated.lock().unwrap();
-            if *total_allocated + aligned_size > self.memory_limit {
+            let available = self.memory_limit.saturating_sub(*total_allocated);
+            if aligned_size > available {
                 return Err(PlottingError::GpuMemoryError {
                     requested: aligned_size as usize,
-                    available: Some((self.memory_limit - *total_allocated) as usize),
+                    available: Some(available as usize),
                 });
             }
         }
 
         // Create empty buffer with proper size
-        let buffer = GpuBuffer::new_empty(&self.device, aligned_size, usage, label);
+        let buffer = GpuBuffer::new_empty(&self.device, aligned_size, usage, label)
+            .with_accounting(Arc::clone(&self.accounting));
 
         // Update memory tracking
         {
@@ -291,7 +360,7 @@ impl GpuMemoryPool {
 
         // Fast path: try zero-copy cast (works when aligned)
         if let Ok(aligned) = try_cast_slice::<u8, T>(bytes) {
-            return aligned.to_vec();
+            return aligned[..element_count].to_vec();
         }
 
         // Slow path: manual byte-by-byte reconstruction for unaligned data
@@ -302,13 +371,7 @@ impl GpuMemoryPool {
             let offset = i * element_size;
             let element_bytes = &bytes[offset..offset + element_size];
 
-            // Create properly aligned temporary storage (heap allocation guarantees alignment)
-            let mut aligned_bytes = vec![0u8; element_size];
-            aligned_bytes.copy_from_slice(element_bytes);
-
-            // Safe because aligned_bytes is properly aligned
-            let element: &T = bytemuck::from_bytes(&aligned_bytes);
-            result.push(*element);
+            result.push(bytemuck::pod_read_unaligned(element_bytes));
         }
 
         result
@@ -323,6 +386,11 @@ impl GpuMemoryPool {
         }
 
         let element_size = std::mem::size_of::<T>();
+        if element_size == 0 {
+            return Err(GpuError::OperationFailed(
+                "Zero-sized types cannot be read from GPU buffers".to_string(),
+            ));
+        }
         let element_count = (buffer.size() as usize) / element_size;
 
         // Create staging buffer for readback
@@ -415,24 +483,30 @@ impl GpuMemoryPool {
 
     /// Clear buffer cache and reset memory tracking
     pub fn clear_cache(&self) {
-        let mut cache = self.buffer_cache.lock().unwrap();
-        let mut total_allocated = self.total_allocated.lock().unwrap();
-
-        cache.clear();
-        *total_allocated = 0;
-
-        // Reset stats
-        let mut stats = self.stats.lock().unwrap();
-        *stats = GpuMemoryStats {
-            memory_limit: stats.memory_limit,
-            ..Default::default()
+        let cached_buffers = {
+            let mut cache = self
+                .buffer_cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *cache)
         };
+        drop(cached_buffers);
+
+        // Keep live-allocation counters; reset cache activity only.
+        let mut stats = self.stats.lock().unwrap();
+        stats.cache_hits = 0;
+        stats.cache_misses = 0;
+        stats.buffers_reused = 0;
     }
 
     /// Get current memory usage as fraction of limit
     pub fn memory_usage_fraction(&self) -> f32 {
         let total_allocated = *self.total_allocated.lock().unwrap();
-        total_allocated as f32 / self.memory_limit as f32
+        if self.memory_limit == 0 {
+            0.0
+        } else {
+            total_allocated as f32 / self.memory_limit as f32
+        }
     }
 
     /// Check if GPU memory is under pressure

--- a/src/render/gpu/mod.rs
+++ b/src/render/gpu/mod.rs
@@ -79,7 +79,10 @@ pub struct GpuConfig {
     pub enable_gpu: bool,
     /// Preferred backend (Vulkan, Metal, DX12, GL)
     pub preferred_backend: Option<wgpu::Backends>,
-    /// Memory usage limit as fraction of total GPU memory
+    /// Pool limit as a fraction of the adapter's maximum buffer size.
+    ///
+    /// Wgpu does not expose total device memory portably, so this is a
+    /// conservative allocation-budget approximation rather than a VRAM ratio.
     pub memory_limit_fraction: f32,
     /// Enable debug validation layers
     pub enable_validation: bool,
@@ -136,7 +139,12 @@ impl GpuBackend {
         // Initialize buffer manager with platform-optimized settings
         let platform_optimizer = get_platform_optimizer();
         let hints = platform_optimizer.get_performance_hints();
-        let buffer_manager = BufferManager::new(&device, &capabilities, &hints)?;
+        let buffer_manager = BufferManager::with_memory_limit_fraction(
+            &device,
+            &capabilities,
+            &hints,
+            config.memory_limit_fraction,
+        )?;
 
         // Initialize pipeline cache
         let pipeline_cache = PipelineCache::new();
@@ -195,8 +203,12 @@ impl GpuBackend {
                 limits.max_compute_workgroups_per_dimension,
                 limits.max_compute_workgroups_per_dimension,
             ],
-            memory_size: None,      // wgpu doesn't expose memory info directly
-            supports_compute: true, // Assume compute shader support for now
+            memory_size: None, // wgpu doesn't expose memory info directly
+            supports_compute: device
+                .adapter()
+                .get_downlevel_capabilities()
+                .flags
+                .contains(wgpu::DownlevelFlags::COMPUTE_SHADERS),
             supports_storage_textures: features
                 .contains(wgpu::Features::STORAGE_RESOURCE_BINDING_ARRAY),
             supports_timestamps: features.contains(wgpu::Features::TIMESTAMP_QUERY),
@@ -240,7 +252,7 @@ impl GpuBackend {
     /// Validate that GPU meets minimum requirements
     fn validate_capabilities(
         capabilities: &GpuCapabilities,
-        config: &GpuConfig,
+        _config: &GpuConfig,
     ) -> Result<(), PlottingError> {
         // Check minimum texture size (need at least 4K for reasonable plots)
         if capabilities.max_texture_size < 4096 {
@@ -248,15 +260,6 @@ impl GpuBackend {
                 "Maximum texture size {} is too small (minimum 4096)",
                 capabilities.max_texture_size
             )));
-        }
-
-        // Check compute shader support if required
-        if !capabilities.supports_compute
-            && config.required_features.contains(wgpu::Features::empty())
-        {
-            return Err(PlottingError::UnsupportedGpuFeature(
-                "Compute shaders required but not supported".to_string(),
-            ));
         }
 
         // Check minimum buffer size (need at least 256MB for large datasets)

--- a/src/render/gpu/renderer.rs
+++ b/src/render/gpu/renderer.rs
@@ -109,6 +109,7 @@ impl GpuRenderer {
 
     /// Create GPU renderer with custom configuration
     pub async fn with_config(config: super::GpuConfig) -> Result<Self> {
+        let memory_limit_fraction = config.memory_limit_fraction;
         // Initialize GPU backend
         let gpu_backend = Arc::new(GpuBackend::with_config(config).await.map_err(|e| {
             PlottingError::GpuInitError {
@@ -130,10 +131,11 @@ impl GpuRenderer {
                 })?;
 
         // Initialize GPU memory pool
-        let gpu_memory_pool = GpuMemoryPool::new(
+        let gpu_memory_pool = GpuMemoryPool::with_memory_limit_fraction(
             gpu_backend.device().device().clone(),
             gpu_backend.device().queue().clone(),
             gpu_backend.capabilities(),
+            memory_limit_fraction,
         )?;
 
         // Set intelligent threshold based on GPU capabilities

--- a/tests/gpu_backend_test.rs
+++ b/tests/gpu_backend_test.rs
@@ -4,6 +4,23 @@
 mod gpu_tests {
     use ruviz::render::gpu::*;
 
+    fn gpu_is_required() -> bool {
+        std::env::var_os("RUVIZ_REQUIRE_GPU_TESTS").is_some()
+    }
+
+    async fn backend_or_skip() -> Option<GpuBackend> {
+        match GpuBackend::new().await {
+            Ok(backend) => Some(backend),
+            Err(error) if gpu_is_required() => {
+                panic!("RUVIZ_REQUIRE_GPU_TESTS requires a working adapter: {error}")
+            }
+            Err(error) => {
+                println!("⚠️  GPU not available (expected outside required-adapter CI): {error}");
+                None
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_gpu_backend_initialization() {
         // Test GPU backend can be created
@@ -115,6 +132,91 @@ mod gpu_tests {
                 println!("⚠️  GPU backend not available: {}", e);
             }
         }
+    }
+
+    #[tokio::test]
+    async fn required_adapter_exercises_buffer_readback_and_pool_accounting() {
+        let Some(backend) = backend_or_skip().await else {
+            return;
+        };
+        let manager = backend.buffer_manager();
+        let payload = [3_u8, 1, 4, 1, 5, 9, 2, 6];
+
+        let (handle, mut buffer) = {
+            let mut manager = manager.lock().unwrap();
+            manager
+                .create_with_data(
+                    backend.device(),
+                    &payload,
+                    BufferUsage::Download,
+                    "required-adapter readback",
+                )
+                .expect("download buffer should be created")
+        };
+        assert_eq!(buffer.map_read().await.unwrap(), payload);
+        assert!(!buffer.is_mapped());
+
+        {
+            let mut manager = manager.lock().unwrap();
+            assert_eq!(manager.get_memory_usage(), payload.len() as u64);
+            manager.deallocate(handle).unwrap();
+            assert_eq!(
+                manager.get_memory_usage(),
+                payload.len() as u64,
+                "cached buffers remain physically allocated"
+            );
+
+            let reused = manager
+                .allocate(
+                    backend.device(),
+                    payload.len() as u64,
+                    BufferUsage::Download,
+                    "required-adapter reuse",
+                )
+                .unwrap();
+            assert_eq!(manager.get_memory_usage(), payload.len() as u64);
+            assert_eq!(manager.get_stats().reused_buffers, 1);
+            manager.deallocate(reused).unwrap();
+        }
+
+        let typed_pool = GpuMemoryPool::new(
+            backend.device().device().clone(),
+            backend.device().queue().clone(),
+            backend.capabilities(),
+        )
+        .unwrap();
+        let typed_buffer = typed_pool
+            .create_buffer(
+                &payload,
+                wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            )
+            .unwrap();
+        let tracked_bytes = typed_pool.get_stats().total_allocated;
+        assert!(tracked_bytes >= payload.len() as u64);
+        drop(typed_buffer);
+        assert_eq!(typed_pool.get_stats().total_allocated, 0);
+
+        let cached_buffer = typed_pool
+            .create_buffer(
+                &payload,
+                wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            )
+            .unwrap();
+        typed_pool.return_buffer(cached_buffer);
+        assert_eq!(typed_pool.get_stats().total_allocated, tracked_bytes);
+        typed_pool.clear_cache();
+        assert_eq!(typed_pool.get_stats().total_allocated, 0);
+    }
+
+    #[tokio::test]
+    async fn required_adapter_rejects_impossible_feature_sets() {
+        if !gpu_is_required() {
+            return;
+        }
+        let instance =
+            wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle_from_env());
+        let selector = DeviceSelector::new().require_features(wgpu::Features::all());
+        assert!(selector.select_adapter(&instance).await.is_err());
     }
 }
 


### PR DESCRIPTION
## Summary

- validate animation codecs, extensions, dimensions, timing, and frame buffers; fix RGBA-to-RGB recording and preserve-figure dimension parity
- implement GPU buffer readback, adapter capability filtering, device-loss tracking, configured memory limits, cache reuse, and physical allocation accounting
- require the generic GPU suite in software-adapter CI, move large rendering validations to the scheduled lane, and remove unused runtime dependencies

## Behavior and API notes

- `animation-video` remains as a compatibility alias, but AV1 now returns an explicit unsupported-operation error instead of advertising an unimplemented encoder
- `FrameCapture::new`, `FrameCapture::resize`, and `GifEncoder::with_framerate` now return `Result`
- GPU `map_read` now succeeds and returns an owned `Vec<u8>`

## Validation

- `cargo test -p ruviz --lib`: 1,813 passed; 4 scheduled heavy tests ignored
- `cargo test -p ruviz --lib animation --all-features`: 118 passed
- `RUVIZ_REQUIRE_GPU_TESTS=1 cargo test -p ruviz --test gpu_backend_test --features gpu -- --nocapture`: 7 passed
- `cargo test -p ruviz --doc --features animation-video,gpu`: 174 passed; 144 ignored
- feature-hygiene tests passed
- `cargo clippy -p ruviz --all-targets --all-features -- -D warnings`
- repository pre-commit hook passed rustfmt, Clippy, and documentation example validation

## Visual verification

Generated and inspected the 800x600 sine-wave GIF and 640x480 3D surface orbit. Both animated cleanly with stable dimensions, intact axes and titles, correct colors, and no black or malformed frames.