### PR TITLE
Document and enforce repository structure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1346,10 +1346,8 @@ jobs:
       - name: Check published docs do not reference generated preview assets
         run: uv run python scripts/check_no_generated_asset_refs.py
 
-      - name: Check repository output boundaries
-        run: |
-          uv run python -m unittest scripts/test_check_repository_outputs.py
-          uv run python scripts/check_repository_outputs.py
+      - name: Check repository structure and output boundaries
+        run: make check-repository
 
       - name: Build documentation
         run: cargo doc --all-features --no-deps

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 RELEASE_DOCS_BRANCH := docs/release-0.4.0-refresh
 PYTHON_SITE_DIR := ../../generated/python/site
 
-.PHONY: help setup-hooks assert-release-branch clean-generated release-docs release-docs-rust release-docs-python release-docs-web rust-gallery check-rust-gallery build-generated-preview build-generated-preview-rust build-generated-preview-python build-generated-preview-web generated-manifest check-doc-asset-refs check-docs check-ci-test-coverage fmt clippy clippy-gpui check-web check bench-plotting bench-plotting-smoke bench-rust-features bench-rust-features-smoke
+.PHONY: help setup-hooks assert-release-branch clean-generated release-docs release-docs-rust release-docs-python release-docs-web rust-gallery check-rust-gallery build-generated-preview build-generated-preview-rust build-generated-preview-python build-generated-preview-web generated-manifest check-doc-asset-refs check-docs check-repository check-ci-test-coverage fmt clippy clippy-gpui check-web check bench-plotting bench-plotting-smoke bench-rust-features bench-rust-features-smoke
 
 help:
 	@echo "ruviz release documentation workflow"
@@ -30,8 +30,9 @@ help:
 	@echo "  make clippy              cargo clippy --all-targets --all-features -- -D warnings"
 	@echo "  make clippy-gpui         Lint the separate adapters/gpui workspace (pulls the zed GPUI checkout)"
 	@echo "  make check-web           bun run check:web"
+	@echo "  make check-repository    Validate tracked directory and generated-output boundaries"
 	@echo "  make check-ci-test-coverage Fail if CI compiles a test target it never runs"
-	@echo "  make check               Run fmt, clippy, check-web, check-docs, and CI test coverage"
+	@echo "  make check               Run formatting, lint, web, docs, repository, and CI policy checks"
 	@echo ""
 	@echo "Benchmark targets:"
 	@echo "  make bench-plotting"
@@ -119,6 +120,11 @@ check-doc-asset-refs:
 check-docs:
 	uv run python scripts/check_docs.py
 
+check-repository:
+	uv run python -m unittest scripts/test_check_repository_structure.py scripts/test_check_repository_outputs.py
+	uv run python scripts/check_repository_structure.py
+	uv run python scripts/check_repository_outputs.py
+
 # tests/integration/ci_test_coverage.rs fails when .github/workflows/ci.yml
 # compiles a tests/*.rs target that no pull-request job names in a `--test`
 # flag, and when a job pins a toolchain without asserting the rustc it actually
@@ -154,7 +160,7 @@ check-web:
 # `clippy-gpui` is deliberately not here: it is the one command that resolves
 # the zed GPUI checkout, and making the default local check pay for it would
 # undo the workspace split. CI runs it in its own job.
-check: fmt clippy check-web check-docs check-ci-test-coverage
+check: fmt clippy check-web check-docs check-repository check-ci-test-coverage
 
 bench-plotting:
 	bun install --frozen-lockfile --ignore-scripts

--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ cargo run --features animation --example animation_wave
 - [API Documentation](https://docs.rs/ruviz)
 - [Gallery](docs/gallery/README.md)
 - [Native GUI Adapters](adapters/gui/README.md)
+- [Repository Structure](docs/REPOSITORY_STRUCTURE.md)
 
 ## Development
 

--- a/docs/REPOSITORY_STRUCTURE.md
+++ b/docs/REPOSITORY_STRUCTURE.md
@@ -1,0 +1,62 @@
+# Repository Structure
+
+Ruviz groups tracked files by responsibility. New top-level directories should
+be rare: add one only when none of the existing ownership boundaries fit, and
+update the structure checker in the same change.
+
+| Path | Responsibility |
+| --- | --- |
+| `.github/` | GitHub Actions, issue templates, and repository automation |
+| `adapters/` | Native framework integrations that wrap the core crate |
+| `apps/` | Runnable applications and deployable demos |
+| `benches/` | Cargo benchmark targets for the root Rust crate |
+| `bindings/` | Language and target bindings, currently Python and wasm |
+| `docs/` | Maintained documentation and committed documentation assets |
+| `examples/` | Runnable examples for the root Rust crate |
+| `generated/` | Ignored build/output staging; only control files are tracked |
+| `packages/` | Packages published through non-Cargo package managers |
+| `proptest-regressions/` | Reproducible property-test regression cases |
+| `scripts/` | Repository automation and policy checks |
+| `src/` | Source for the root `ruviz` crate |
+| `tests/` | Root-crate integration, contract, and visual tests |
+| `tools/` | Developer tools, including the gallery and benchmark suites |
+
+Root-level project files such as `Cargo.toml`, `package.json`, `README.md`, and
+license files remain at the root.
+
+## Placement Rules
+
+- Put host-framework wrappers under `adapters/`; put language or compilation-
+  target APIs under `bindings/`.
+- Put an application under `apps/`, a published package under `packages/`, and
+  developer-only programs or workflows under `tools/`.
+- Keep Cargo's conventional root-crate targets in `benches/`, `examples/`,
+  `src/`, and `tests/`.
+- Treat `generated/` as disposable local output. See [Build Outputs](BUILD_OUTPUTS.md)
+  for the tracked-file and cleanup policy.
+- Do not introduce a generic `crates/` bucket. Choose the directory that
+  describes why the crate exists.
+
+The root Cargo workspace includes `bindings/wasm` and `bindings/python`.
+`adapters/gpui` and `adapters/gui` are separate Cargo workspaces; see
+[Architecture](ARCHITECTURE.md#repository-layout) for the reason.
+
+## Retired Paths
+
+These former locations must not be restored:
+
+| Retired path | Canonical path |
+| --- | --- |
+| `benchmarks/` | `tools/benchmarks/` |
+| `crates/gui-adapters/` | `adapters/gui/` |
+| `crates/ruviz-gpui/` | `adapters/gpui/` |
+| `crates/ruviz-web/` | `bindings/wasm/` |
+| `demo/` | `apps/web-demo/` |
+| `gallery/` | `tools/gallery/` |
+| `packages/ruviz-web/` | `packages/ruviz/` |
+| `python/` | `bindings/python/` |
+
+`scripts/check_repository_structure.py` enforces this layout against
+`git ls-files`. It intentionally ignores untracked and gitignored local
+directories, so old local build artifacts do not affect the check; only files
+proposed for tracking are in scope.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,9 @@ pre-commit:
     - name: docs-examples
       files: git diff --cached --name-only --diff-filter=ACMR | grep -E '(^|/)[^/]+\.md$|^scripts/check_docs\.py$|^lefthook\.yml$' || true
       run: uv run python scripts/check_docs.py
+    - name: repository-structure
+      files: git diff --cached --name-only --diff-filter=ACMR
+      run: uv run python scripts/check_repository_structure.py
     - name: oxfmt
       files: git diff --cached --name-only --diff-filter=ACMR | grep -E '^(packages/ruviz/src/.*\.(js|ts)|apps/web-demo/src/.*\.(js|ts)|apps/web-demo/tests/.*\.(js|ts)|apps/web-demo/playwright\.config\.js)$' || true
       run: bunx oxfmt --check {files}

--- a/scripts/check_repository_structure.py
+++ b/scripts/check_repository_structure.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Keep tracked files within the repository's documented directory layout."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+
+CANONICAL_TOP_LEVEL_DIRECTORIES = frozenset(
+    {
+        ".github",
+        "adapters",
+        "apps",
+        "benches",
+        "bindings",
+        "docs",
+        "examples",
+        "generated",
+        "packages",
+        "proptest-regressions",
+        "scripts",
+        "src",
+        "tests",
+        "tools",
+    }
+)
+RETIRED_PATH_PREFIXES = (
+    PurePosixPath("packages/ruviz-web"),
+)
+
+
+def is_within(path: PurePosixPath, parent: PurePosixPath) -> bool:
+    """Return whether a repository-relative path is inside a parent path."""
+
+    return path == parent or parent in path.parents
+
+
+def tracked_structure_violations(paths: Iterable[str]) -> list[str]:
+    """Describe tracked paths that do not follow the canonical layout."""
+
+    violations: list[str] = []
+    for raw_path in paths:
+        path = PurePosixPath(raw_path)
+        if len(path.parts) < 2:
+            # Root-level project files such as Cargo.toml and README.md are valid.
+            continue
+
+        root = path.parts[0]
+        if root not in CANONICAL_TOP_LEVEL_DIRECTORIES:
+            violations.append(
+                f"{raw_path}: non-canonical top-level directory {root}/"
+            )
+            continue
+
+        retired_prefix = next(
+            (prefix for prefix in RETIRED_PATH_PREFIXES if is_within(path, prefix)),
+            None,
+        )
+        if retired_prefix is not None:
+            violations.append(
+                f"{raw_path}: retired directory {retired_prefix.as_posix()}/"
+            )
+
+    return sorted(violations)
+
+
+def tracked_files(repository: Path) -> list[str]:
+    """Read tracked paths only, leaving ignored local directories out of scope."""
+
+    result = subprocess.run(
+        ["git", "-C", str(repository), "ls-files", "-z"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [path for path in result.stdout.split("\0") if path]
+
+
+def main() -> int:
+    repository = Path(__file__).resolve().parent.parent
+    violations = tracked_structure_violations(tracked_files(repository))
+    if violations:
+        print("Tracked files must follow docs/REPOSITORY_STRUCTURE.md:")
+        for violation in violations:
+            print(f"  {violation}")
+        return 1
+
+    print("Tracked repository structure is canonical.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_check_repository_structure.py
+++ b/scripts/test_check_repository_structure.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import unittest
+
+from scripts.check_repository_structure import tracked_structure_violations
+
+
+class TrackedStructureTests(unittest.TestCase):
+    def test_allows_root_files_and_canonical_directories(self) -> None:
+        paths = [
+            "Cargo.toml",
+            "README.md",
+            ".github/workflows/ci.yml",
+            "adapters/gpui/src/lib.rs",
+            "apps/web-demo/package.json",
+            "benches/rendering.rs",
+            "bindings/python/pyproject.toml",
+            "bindings/wasm/Cargo.toml",
+            "docs/REPOSITORY_STRUCTURE.md",
+            "examples/basic.rs",
+            "generated/README.md",
+            "packages/ruviz/package.json",
+            "proptest-regressions/render.txt",
+            "scripts/check_docs.py",
+            "src/lib.rs",
+            "tests/integration.rs",
+            "tools/gallery/basic/line.rs",
+        ]
+
+        self.assertEqual(tracked_structure_violations(paths), [])
+
+    def test_rejects_retired_and_unclassified_top_level_directories(self) -> None:
+        paths = [
+            "benchmarks/results.csv",
+            "crates/ruviz-web/Cargo.toml",
+            "demo/index.html",
+            "gallery/basic/line.rs",
+            "python/pyproject.toml",
+        ]
+
+        self.assertEqual(
+            tracked_structure_violations(paths),
+            [
+                "benchmarks/results.csv: non-canonical top-level directory benchmarks/",
+                "crates/ruviz-web/Cargo.toml: non-canonical top-level directory crates/",
+                "demo/index.html: non-canonical top-level directory demo/",
+                "gallery/basic/line.rs: non-canonical top-level directory gallery/",
+                "python/pyproject.toml: non-canonical top-level directory python/",
+            ],
+        )
+
+    def test_rejects_retired_nested_package_path(self) -> None:
+        self.assertEqual(
+            tracked_structure_violations(["packages/ruviz-web/package.json"]),
+            [
+                "packages/ruviz-web/package.json: retired directory packages/ruviz-web/"
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document the canonical top-level repository layout and retired paths
- enforce the structure against tracked files only, leaving ignored local directories out of scope
- run the structure and output-boundary policies through Make, CI, and the pre-commit hook

## Validation
- `make check-repository`
- `uv run python scripts/check_docs.py`
- `cd bindings/python && uv run ruff check ../../scripts/check_repository_structure.py ../../scripts/test_check_repository_structure.py`
- `cd bindings/python && uv run ruff format --check ../../scripts/check_repository_structure.py ../../scripts/test_check_repository_structure.py`
- pre-commit hooks (rustfmt, clippy, documentation, repository structure)