### PR TITLE
Release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,75 @@ All notable changes to this project will be documented in this file.
 
 _None yet._
 
+## [0.7.0] - 2026-08-05
+
+### Breaking
+
+- The Python binding rejects input it previously mis-handled silently:
+  non-1D arrays into 1D series (including `contour` with a 2D `z`), unknown
+  or missing `save()` extensions (previously wrote PNG bytes to any path),
+  non-positive or fractional `size_px`/`dpi`/`bins`/`levels`, DataFrames
+  passed as vectors, `data=` with a Series, bare string columns without
+  `data=`, and observables passed to plot kinds that cannot track them.
+- `anywidget`/`traitlets` moved to the optional `ruviz[widget]` extra;
+  `import ruviz` no longer requires them and widget entry points raise an
+  `ImportError` naming the extra. New `ruviz[all]` extra.
+- The private `ruviz._native` module no longer exports the legacy JSON
+  snapshot functions (`render_png_bytes`, `render_svg`, `save`,
+  `show_native`); rendering goes exclusively through the native handles.
+- `ObservableSeries.replace()` validates resizes across the whole derivation
+  graph before mutating and raises `ValueError` on any bound-series
+  violation; previously invalid resizes partially committed.
+
+### Added
+
+- Per-series styling in the Python binding wherever the renderer honors it:
+  `label`, `color` (hex and named, with did-you-mean suggestions), `alpha`,
+  `width`, `linestyle`, `marker`, `marker_size`, plus `histogram(bins=)`,
+  `kde(bandwidth=)`, and `contour(levels=)`; matplotlib shorthand aliases
+  (`"o"`, `"--"`, ...) are accepted and normalized.
+- Plot-level `legend(position)`, `grid()`, `dpi()`, `xlim`/`ylim`
+  (descending bounds render an inverted axis), and `xscale`/`yscale` with
+  linear, log, and symlog scales.
+- Full typing support: `py.typed`, `_native.pyi` stubs, runtime-valid
+  public aliases and snapshot TypedDicts, `ruviz.__version__`, and a
+  pyright-checked consumer contract in CI.
+- The notebook widget and web runtime render the styled snapshot schema
+  (`schemaVersion: 1`): series styles, `dpi`, legend, grid, limits, and
+  scales, with unknown fields tolerated and preserved for forward
+  compatibility. The TS `PlotBuilder` gains the matching styling and axis
+  methods with eager validation.
+- `data=` accepts any `Mapping` or object indexable by column name;
+  `ObservableSeries` supports `len()`, indexing, and the NumPy 2
+  `__array__` copy contract.
+- Linux aarch64 wheels (manylinux 2_28); wheels for every platform are
+  smoke tested before upload; CI tests Python 3.10 and 3.13.
+
+### Changed
+
+- NumPy arrays cross the Python boundary with a single `memcpy` instead of
+  a Python-list round trip (1M-point series add: 141 ms to 0.9 ms), plot
+  building and rendering release the GIL, snapshots materialize lazily
+  (cached `to_snapshot()` at 1M points: 477 ms to 4 ms), first-plot latency
+  drops from ~185 ms to ~0.2 ms, and widget refreshes coalesce under a
+  running event loop.
+- Native handles are `Send`: plots and observables built on one thread can
+  be used from another (GIL-serialized) instead of aborting with a panic.
+- The Python `numpy` floor relaxed to `>=1.26`.
+- Python examples, docs, and the PyPI README were rewritten around the new
+  API, with regenerated gallery assets.
+
+### Fixed
+
+- Vetoed observable resizes are atomic across derivation graphs (diamond
+  and unequal-depth paths included) and their error messages are
+  deterministic; derived updates propagate in dependency order.
+- `Plot3D.size_px`/`dpi` no longer accept sub-1 floats that truncated to
+  zero and failed at render; 3D methods reject observables instead of
+  silently freezing them.
+- `typing.get_type_hints` works on the whole public surface.
+- The web runtime's snapshot clones no longer drop or alias unknown fields.
+
 ## [0.6.0] - 2026-07-28
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-py"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "image",
  "numpy",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-web"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [package]
 name = "ruviz"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Ruviz Contributors"]

--- a/adapters/gpui/Cargo.lock
+++ b/adapters/gpui/Cargo.lock
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "bytemuck",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-gpui"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arboard",
  "core-foundation 0.10.0",

--- a/adapters/gpui/Cargo.toml
+++ b/adapters/gpui/Cargo.toml
@@ -24,7 +24,7 @@ gpui = { git = "https://github.com/zed-industries/zed", rev = "3060e4170ea5ef0e6
 
 [package]
 name = "ruviz-gpui"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -45,7 +45,7 @@ gpu = ["ruviz/gpu"]
 "3d-gpu" = ["3d", "gpu"]
 
 [dependencies]
-ruviz = { version = "0.6.0", path = "../.." }
+ruviz = { version = "0.7.0", path = "../.." }
 image = "0.25"
 smallvec = "1.15"
 futures = "0.3"

--- a/adapters/gui/Cargo.lock
+++ b/adapters/gui/Cargo.lock
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "bytemuck",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-egui"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "eframe",
  "egui",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-iced"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arboard",
  "async-channel",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-slint"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arboard",
  "i-slint-backend-testing",

--- a/adapters/gui/Cargo.toml
+++ b/adapters/gui/Cargo.toml
@@ -5,7 +5,7 @@ members = ["ruviz-egui", "ruviz-iced", "ruviz-slint"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"

--- a/adapters/gui/ruviz-egui/Cargo.toml
+++ b/adapters/gui/ruviz-egui/Cargo.toml
@@ -22,7 +22,7 @@ gpu = ["ruviz/gpu"]
 egui = { version = "0.35", default-features = false, features = ["default_fonts"] }
 pollster = "0.4"
 rfd = "0.15"
-ruviz = { version = "=0.6.0", path = "../../.." }
+ruviz = { version = "=0.7.0", path = "../../.." }
 
 [dev-dependencies]
 eframe = { version = "0.35", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }

--- a/adapters/gui/ruviz-iced/Cargo.toml
+++ b/adapters/gui/ruviz-iced/Cargo.toml
@@ -33,7 +33,7 @@ async-channel = "2"
 bytes = "1.9"
 arboard = "3.6.1"
 rfd = "0.15"
-ruviz = { version = "=0.6.0", path = "../../.." }
+ruviz = { version = "=0.7.0", path = "../../.." }
 
 [dev-dependencies]
 # `default-features = false` drops iced's default renderer set, so `wgpu` and

--- a/adapters/gui/ruviz-slint/Cargo.toml
+++ b/adapters/gui/ruviz-slint/Cargo.toml
@@ -29,7 +29,7 @@ gpu = ["ruviz/gpu"]
 "3d-gpu" = ["3d", "gpu"]
 
 [dependencies]
-ruviz = { version = "=0.6.0", path = "../../.." }
+ruviz = { version = "=0.7.0", path = "../../.." }
 slint = { version = "~1.17", default-features = false, features = ["std", "compat-1-2"] }
 arboard = "3.6.1"
 rfd = "0.15"

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-py"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Python bindings and notebook widget support for ruviz"
@@ -20,7 +20,7 @@ crate-type = ["cdylib"]
 numpy = "0.24"
 pollster = "0.4"
 pyo3 = { version = "0.24", features = ["abi3-py310"] }
-ruviz = { path = "../..", version = "0.6.0", default-features = false, features = ["3d", "pdf", "svg"] }
+ruviz = { path = "../..", version = "0.7.0", default-features = false, features = ["3d", "pdf", "svg"] }
 
 [dev-dependencies]
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruviz"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python bindings and notebook widget support for ruviz"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "ruviz"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-web"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -25,7 +25,7 @@ default = []
 "3d-gpu" = ["3d", "ruviz/gpu", "dep:wgpu", "dep:wasm-bindgen-futures"]
 
 [dependencies]
-ruviz = { version = "0.6.0", path = "../..", default-features = false }
+ruviz = { version = "0.7.0", path = "../..", default-features = false }
 js-sys = "0.3.92"
 wasm-bindgen = "0.2.105"
 console_error_panic_hook = "0.1.7"

--- a/packages/ruviz/package.json
+++ b/packages/ruviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruviz",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Browser-first JS/TS SDK for ruviz WebAssembly rendering",
   "type": "module",
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
Bumps every publishable unit to 0.7.0 — core crate, wasm crate, gpui/gui adapters, npm package, and the Python package + crate — with regenerated lockfiles, and adds the 0.7.0 changelog entry.

Headline changes shipping in this release (all merged via #137):
- Python binding overhaul: strict validation, per-series styling and axis control, full typing (`py.typed` + stubs), `ruviz[widget]` extra, `ruviz.__version__`
- Performance: single-memcpy NumPy ingestion, GIL-released rendering, lazy snapshots, sendable handles
- Atomic observable derivation graphs with topological resize planning
- The notebook widget and web runtime render the versioned styled snapshot schema
- Linux aarch64 wheels, pre-upload wheel smoke tests, Python 3.10/3.13 CI matrix

The release version gate was replicated locally against tag v0.7.0: all versions match.