### PR TITLE
Update installation snippets to 0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-ruviz = "0.6.0"
+ruviz = "0.7.0"
 ```
 
 Create and save a PNG:
@@ -232,7 +232,7 @@ Enable Typst-backed text rendering with:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["typst-math"] }
+ruviz = { version = "0.7.0", features = ["typst-math"] }
 ```
 
 Then call `.typst(true)`. The configured family is passed to plain raster,
@@ -267,7 +267,7 @@ compiled. If Typst is optional in your crate, forward and guard your own feature
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", default-features = false }
+ruviz = { version = "0.7.0", default-features = false }
 
 [features]
 default = []

--- a/adapters/gpui/README.md
+++ b/adapters/gpui/README.md
@@ -10,8 +10,8 @@ own the window, layout tree, and surrounding application shell.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["3d"] }
-ruviz-gpui = { version = "0.6.0", features = ["3d"] }
+ruviz = { version = "0.7.0", features = ["3d"] }
+ruviz-gpui = { version = "0.7.0", features = ["3d"] }
 ```
 
 ## What This Crate Provides

--- a/adapters/gpui/src/lib.rs
+++ b/adapters/gpui/src/lib.rs
@@ -49,8 +49,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ruviz = "0.6.0"
-//! ruviz-gpui = "0.6.0"
+//! ruviz = "0.7.0"
+//! ruviz-gpui = "0.7.0"
 //! ```
 //!
 //! Then build a normal `ruviz::Plot` or `PreparedPlot` and hand it to the GPUI

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,17 +2,20 @@
 
 Get started with ruviz in less than 5 minutes!
 
-## What's New in v0.6.0
+## What's New in v0.7.0
 
-- First-class 3D plotting now spans Rust, Python, WebAssembly, GPUI, egui, Iced, and Slint.
-- Native adapters support static and interactive 2D/3D plots with responsive HiDPI rendering and nonblocking reactive updates.
-- CPU and GPU 3D paths share corrected lighting, alpha, clipping, camera, legend, and picking behavior.
-- Legend layout and styling are unified across 2D and 3D raster and SVG output.
+- The Python binding grew per-series styling, axis control, full typing, and a
+  faster NumPy path with GIL-released rendering; notebook widgets render the
+  styled snapshots.
+- Stricter, earlier validation across the Python surface, with atomic
+  observable updates.
+- Wheels now cover Linux aarch64, and notebook widget dependencies moved to
+  the optional `ruviz[widget]` extra.
 
 See full details:
 
-- [Release notes for v0.6.0](releases/v0.6.0.md)
 - [Project changelog](../CHANGELOG.md)
+- [Release notes for v0.6.0](releases/v0.6.0.md) (historical)
 
 ## Installation
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -25,7 +25,7 @@ cd my_plot
 2. **Add ruviz to your `Cargo.toml`**:
 ```toml
 [dependencies]
-ruviz = "0.6.0"
+ruviz = "0.7.0"
 ```
 
 3. **Write your first plot** in `src/main.rs`:
@@ -64,8 +64,8 @@ an embedded interactive plot view:
 
 ```toml
 [dependencies]
-ruviz = "0.6.0"
-ruviz-gpui = "0.6.0"
+ruviz = "0.7.0"
+ruviz-gpui = "0.7.0"
 ```
 
 `ruviz-gpui` is supported on Linux, macOS, and Windows. On Windows, prefer the
@@ -93,7 +93,7 @@ If you want publication-style math in labels and titles, enable Typst text rende
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["typst-math"] }
+ruviz = { version = "0.7.0", features = ["typst-math"] }
 ```
 
 `.typst(true)` is only available when `typst-math` is enabled. The configured
@@ -112,7 +112,7 @@ If you want Typst to stay optional in your own crate, forward a local feature fi
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", default-features = false }
+ruviz = { version = "0.7.0", default-features = false }
 
 [features]
 default = []
@@ -364,7 +364,7 @@ Plot::new()
 ### With polars (requires `polars_support` feature)
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["polars_support"] }
+ruviz = { version = "0.7.0", features = ["polars_support"] }
 polars = "0.50"
 ```
 
@@ -392,7 +392,7 @@ Plot::new()
 only when you have benchmarked a path that benefits from the extra SIMD support:
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["performance"] }
+ruviz = { version = "0.7.0", features = ["performance"] }
 ```
 
 ### Large Dataset Export

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -282,7 +282,7 @@ rustup update
 
 ### Feature Conflicts
 
-**Problem**: `error: package ruviz v0.6.0 cannot be built because it requires rustc 1.92 or newer`
+**Problem**: `error: package ruviz v0.7.0 cannot be built because it requires rustc 1.92 or newer`
 
 **Solution**: Update Rust:
 ```bash

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -62,14 +62,14 @@ Add ruviz to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruviz = "0.6.0"
+ruviz = "0.7.0"
 ```
 
 Or with specific features:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.7.0", features = ["ndarray_support", "parallel"] }
 ```
 
 ## Feature Flags
@@ -79,7 +79,7 @@ ruviz uses feature flags to enable optional functionality. Choose based on your 
 ### Default Features
 
 ```toml
-ruviz = "0.6.0"  # Includes: ndarray_support, parallel
+ruviz = "0.7.0"  # Includes: ndarray_support, parallel
 ```
 
 **Enabled by default**:
@@ -110,40 +110,40 @@ SVG export is available without an extra feature flag. The legacy `svg` feature 
 
 ```toml
 # High performance (parallel + SIMD)
-ruviz = { version = "0.6.0", features = ["performance"] }
+ruviz = { version = "0.7.0", features = ["performance"] }
 
 # Maximum capability (all features)
-ruviz = { version = "0.6.0", features = ["full"] }
+ruviz = { version = "0.7.0", features = ["full"] }
 
 # Minimal (no default features)
-ruviz = { version = "0.6.0", default-features = false }
+ruviz = { version = "0.7.0", default-features = false }
 ```
 
 ### Feature Combinations
 
 **Scientific Computing**:
 ```toml
-ruviz = { version = "0.6.0", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.7.0", features = ["ndarray_support", "parallel"] }
 ```
 
 **Data Analysis**:
 ```toml
-ruviz = { version = "0.6.0", features = ["polars_support", "performance"] }
+ruviz = { version = "0.7.0", features = ["polars_support", "performance"] }
 ```
 
 **Publication Quality**:
 ```toml
-ruviz = { version = "0.6.0", features = ["serde", "pdf"] }
+ruviz = { version = "0.7.0", features = ["serde", "pdf"] }
 ```
 
 **Real-time Visualization**:
 ```toml
-ruviz = { version = "0.6.0", features = ["interactive-gpu"] }
+ruviz = { version = "0.7.0", features = ["interactive-gpu"] }
 ```
 
 **Large Datasets**:
 ```toml
-ruviz = { version = "0.6.0", features = ["parallel", "simd", "gpu"] }
+ruviz = { version = "0.7.0", features = ["parallel", "simd", "gpu"] }
 ```
 
 ## Verification
@@ -189,7 +189,7 @@ Test specific features:
 **ndarray**:
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["ndarray_support"] }
+ruviz = { version = "0.7.0", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -306,7 +306,7 @@ vulkaninfo
 
 Or disable GPU features:
 ```toml
-ruviz = { version = "0.6.0", default-features = false, features = ["parallel"] }
+ruviz = { version = "0.7.0", default-features = false, features = ["parallel"] }
 ```
 
 ### Memory Issues (Large Datasets)

--- a/docs/guide/03_first_plot.md
+++ b/docs/guide/03_first_plot.md
@@ -166,7 +166,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = "0.6.0"
+ruviz = "0.7.0"
 ```
 
 ## Customization Basics
@@ -304,7 +304,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["ndarray_support"] }
+ruviz = { version = "0.7.0", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 

--- a/docs/guide/04_plot_types.md
+++ b/docs/guide/04_plot_types.md
@@ -721,7 +721,7 @@ Use `performance` only after benchmarking a path that benefits from SIMD support
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["simd"] }
+ruviz = { version = "0.7.0", features = ["simd"] }
 ```
 
 ### Very Large Datasets (> 100K points)

--- a/docs/guide/07_backends.md
+++ b/docs/guide/07_backends.md
@@ -132,7 +132,7 @@ not a guarantee that a public `render()` call will take a SIMD path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["simd"] }
+ruviz = { version = "0.7.0", features = ["simd"] }
 ```
 
 ## What `save()` actually does
@@ -201,7 +201,7 @@ path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["gpu"] }
+ruviz = { version = "0.7.0", features = ["gpu"] }
 ```
 
 ```rust
@@ -237,7 +237,7 @@ dependency for you.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["interactive"] }
+ruviz = { version = "0.7.0", features = ["interactive"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 ```
 

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -48,7 +48,7 @@ at `t`.
 
 ```toml
 [dependencies]
-ruviz = "0.6.0"
+ruviz = "0.7.0"
 ```
 
 Useful opt-in features:

--- a/docs/guide/09_data_integration.md
+++ b/docs/guide/09_data_integration.md
@@ -64,7 +64,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["ndarray_support"] }
+ruviz = { version = "0.7.0", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -183,7 +183,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["nalgebra_support"] }
+ruviz = { version = "0.7.0", features = ["nalgebra_support"] }
 nalgebra = "0.32"
 ```
 
@@ -231,7 +231,7 @@ synthetic absorbed-energy style example.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.6.0", features = ["polars_support"] }
+ruviz = { version = "0.7.0", features = ["polars_support"] }
 polars = { version = "0.50", features = ["lazy", "rolling_window"] }
 ```
 

--- a/docs/guide/10_export.md
+++ b/docs/guide/10_export.md
@@ -534,7 +534,7 @@ Plot::new()
 ### PDF Export
 
 ```rust
-// Requires: ruviz = { version = "0.6.0", features = ["pdf"] }
+// Requires: ruviz = { version = "0.7.0", features = ["pdf"] }
 use ruviz::prelude::*;
 
 Plot::new()

--- a/docs/migration/matplotlib.md
+++ b/docs/migration/matplotlib.md
@@ -416,7 +416,7 @@ let viridis_like = Theme::builder()
 ## Migration Checklist
 
 - [ ] Install Rust and cargo
-- [ ] Add `ruviz = "0.6.0"` to `Cargo.toml`
+- [ ] Add `ruviz = "0.7.0"` to `Cargo.toml`
 - [ ] Convert numpy arrays to `Vec<f64>` or `ndarray`
 - [ ] Replace `plt.plot()` with `Plot::new().line()`
 - [ ] Change `plt.savefig()` to `.save()?`


### PR DESCRIPTION
Dependency pins across README.md, docs/QUICKSTART.md, docs/guide/, docs/migration/matplotlib.md, and the GUI adapter docs still said `0.6.0` after the 0.7.0 release — the release process bumps manifests but not prose. Historical release notes are left as-is. Follow-up worth considering: a release-workflow check that greps docs for the old version.