### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.8.0] - 2026-08-15
 
 ### Added
 
+- A grouped `figure()` presentation call in the Python and web bindings
+  (`Plot.figure(...)` / `PlotBuilder.figure({...})`, with matching setters on
+  the raw wasm handle): figure size in inches, dpi, font and title size, font
+  family, typography scale, line width, margin, tight-layout padding,
+  scientific notation and a maximum resolution, chosen as one set the way a
+  journal specifies them. The call is atomic — every argument is validated
+  before any is applied — and the settings are recorded under snapshot schema
+  version 2, so copies, notebook widgets and worker replay reproduce them.
+  Validation rejects the values the core would silently clamp: sizes below
+  1.0 inch, dpi below 72, font sizes below 4pt and line widths below 0.1pt.
 - `Theme` gains four knobs that let a theme express a panel-based look:
   `panel_background: Option<Color>` fills the plot area before the grid,
   `frame: bool` removes every spine, `tick_marks: bool` removes the tick marks
@@ -28,6 +38,20 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- The default data line width is now the documented matplotlib 1.5pt. The
+  renderer used to hard-code 2.0pt for a line series with no explicit width,
+  ignoring both `line_width_pt()` and the width the active theme asked for
+  (publication's 0.75pt included); the fallback now reads the configured
+  width, so those finally apply.
+- `max_resolution()` is a true cap when `dpi()` was set explicitly: a DPI
+  whose output already fits the bounds is kept, an overflowing one is reduced
+  to fit. Without an explicit DPI it scales to fit the bounds as before.
+  Bounds small enough to imply a DPI below the render minimum are honoured
+  like an exact pixel size instead of failing every subsequent render.
+- `scientific_notation(bool)` now forces tick-label notation on both axes —
+  `true` always scientific, `false` always plain decimals — where unset keeps
+  the automatic per-axis choice. A symlog axis keeps its linear region's
+  labels plain either way.
 - `Theme::seaborn()` is now a faithful port of `seaborn.set_theme()` rather than
   a loose approximation: an `#EAEAF2` data panel on a white figure, white grid
   lines drawn on that panel, no spines and no tick marks, soft near-black text
@@ -83,6 +107,23 @@ All notable changes to this project will be documented in this file.
   corner-most tick labels used to come to rest a few pixels apart and read as
   one number ("2 2"). The y label is now stepped clear of the x label, and
   dropped if it cannot be.
+
+### Fixed
+
+- `margin()` and `scientific_notation()` were recorded but never read by any
+  render path; both now reach the layout and the tick formatter. `margin()`
+  writes the proportional margins the layout actually consumes, on all four
+  sides.
+- A font family with surrounding whitespace (`"Arial "`) now matches the
+  registered family instead of silently falling back to the default face, and
+  the wasm binding rejects empty family names like the other bindings.
+- A web build without the `embedded-font` feature could never follow its own
+  error message: module initialization demanded a registered font before
+  `registerFont()` could supply one. Initialization now succeeds font-free
+  and the render entry points keep reporting the actionable error.
+- Snapshot replay tolerates malformed foreign metadata — a null, sparse or
+  out-of-range `maxResolution` is skipped instead of aborting the plot
+  rebuild.
 
 ## [0.7.0] - 2026-08-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -5417,7 +5417,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-py"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "image",
  "numpy",
@@ -5428,7 +5428,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-web"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [package]
 name = "ruviz"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Ruviz Contributors"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bindings. Every figure in it is real ruviz output.
 
 ```toml
 [dependencies]
-ruviz = "0.7.0"
+ruviz = "0.8.0"
 ```
 
 ## Hello, plot

--- a/adapters/gpui/Cargo.lock
+++ b/adapters/gpui/Cargo.lock
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bytemuck",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-gpui"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arboard",
  "core-foundation 0.10.0",

--- a/adapters/gpui/Cargo.toml
+++ b/adapters/gpui/Cargo.toml
@@ -24,7 +24,7 @@ gpui = { git = "https://github.com/zed-industries/zed", rev = "3060e4170ea5ef0e6
 
 [package]
 name = "ruviz-gpui"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -45,7 +45,7 @@ gpu = ["ruviz/gpu"]
 "3d-gpu" = ["3d", "gpu"]
 
 [dependencies]
-ruviz = { version = "0.7.0", path = "../.." }
+ruviz = { version = "0.8.0", path = "../.." }
 image = "0.25"
 smallvec = "1.15"
 futures = "0.3"

--- a/adapters/gpui/README.md
+++ b/adapters/gpui/README.md
@@ -10,8 +10,8 @@ own the window, layout tree, and surrounding application shell.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["3d"] }
-ruviz-gpui = { version = "0.7.0", features = ["3d"] }
+ruviz = { version = "0.8.0", features = ["3d"] }
+ruviz-gpui = { version = "0.8.0", features = ["3d"] }
 ```
 
 ## What This Crate Provides

--- a/adapters/gpui/src/lib.rs
+++ b/adapters/gpui/src/lib.rs
@@ -49,8 +49,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ruviz = "0.7.0"
-//! ruviz-gpui = "0.7.0"
+//! ruviz = "0.8.0"
+//! ruviz-gpui = "0.8.0"
 //! ```
 //!
 //! Then build a normal `ruviz::Plot` or `PreparedPlot` and hand it to the GPUI

--- a/adapters/gui/Cargo.lock
+++ b/adapters/gui/Cargo.lock
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "bytemuck",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-egui"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "eframe",
  "egui",
@@ -5240,7 +5240,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-iced"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arboard",
  "async-channel",
@@ -5254,7 +5254,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-slint"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arboard",
  "i-slint-backend-testing",

--- a/adapters/gui/Cargo.toml
+++ b/adapters/gui/Cargo.toml
@@ -5,7 +5,7 @@ members = ["ruviz-egui", "ruviz-iced", "ruviz-slint"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"

--- a/adapters/gui/ruviz-egui/Cargo.toml
+++ b/adapters/gui/ruviz-egui/Cargo.toml
@@ -22,7 +22,7 @@ gpu = ["ruviz/gpu"]
 egui = { version = "0.35", default-features = false, features = ["default_fonts"] }
 pollster = "0.4"
 rfd = "0.15"
-ruviz = { version = "=0.7.0", path = "../../.." }
+ruviz = { version = "=0.8.0", path = "../../.." }
 
 [dev-dependencies]
 eframe = { version = "0.35", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }

--- a/adapters/gui/ruviz-iced/Cargo.toml
+++ b/adapters/gui/ruviz-iced/Cargo.toml
@@ -33,7 +33,7 @@ async-channel = "2"
 bytes = "1.9"
 arboard = "3.6.1"
 rfd = "0.15"
-ruviz = { version = "=0.7.0", path = "../../.." }
+ruviz = { version = "=0.8.0", path = "../../.." }
 
 [dev-dependencies]
 # `default-features = false` drops iced's default renderer set, so `wgpu` and

--- a/adapters/gui/ruviz-iced/README.md
+++ b/adapters/gui/ruviz-iced/README.md
@@ -98,7 +98,7 @@ to enable it:
 ```toml
 [dependencies]
 iced = { version = "0.14", features = ["wgpu", "crisp"] }
-ruviz-iced = "0.7.0"
+ruviz-iced = "0.8.0"
 ```
 
 - `wgpu` — GPU presentation. Without it Iced falls back to the `tiny-skia` CPU

--- a/adapters/gui/ruviz-slint/Cargo.toml
+++ b/adapters/gui/ruviz-slint/Cargo.toml
@@ -29,7 +29,7 @@ gpu = ["ruviz/gpu"]
 "3d-gpu" = ["3d", "gpu"]
 
 [dependencies]
-ruviz = { version = "=0.7.0", path = "../../.." }
+ruviz = { version = "=0.8.0", path = "../../.." }
 slint = { version = "~1.17", default-features = false, features = ["std", "compat-1-2"] }
 arboard = "3.6.1"
 rfd = "0.15"

--- a/adapters/gui/ruviz-slint/README.md
+++ b/adapters/gui/ruviz-slint/README.md
@@ -41,7 +41,7 @@ module support:
 
 ```toml
 [dependencies]
-ruviz-slint = "0.7.0"
+ruviz-slint = "0.8.0"
 slint = { version = "~1.17", default-features = false, features = [
     "std", "compat-1-2", "backend-winit", "renderer-femtovg"
 ] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-py"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Python bindings and notebook widget support for ruviz"
@@ -20,7 +20,7 @@ crate-type = ["cdylib"]
 numpy = "0.24"
 pollster = "0.4"
 pyo3 = { version = "0.24", features = ["abi3-py310"] }
-ruviz = { path = "../..", version = "0.7.0", default-features = false, features = ["3d", "pdf", "svg"] }
+ruviz = { path = "../..", version = "0.8.0", default-features = false, features = ["3d", "pdf", "svg"] }
 
 [dev-dependencies]
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruviz"
-version = "0.7.0"
+version = "0.8.0"
 description = "Python bindings and notebook widget support for ruviz"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "ruviz"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-web"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ default = ["embedded-font"]
 "3d-gpu" = ["3d", "ruviz/gpu", "dep:wgpu", "dep:wasm-bindgen-futures"]
 
 [dependencies]
-ruviz = { version = "0.7.0", path = "../..", default-features = false }
+ruviz = { version = "0.8.0", path = "../..", default-features = false }
 js-sys = "0.3.92"
 wasm-bindgen = "0.2.105"
 console_error_panic_hook = "0.1.7"

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -21,7 +21,7 @@ Add the bridge crate to your Cargo manifest:
 
 ```toml
 [dependencies]
-ruviz-web = "0.7.0"
+ruviz-web = "0.8.0"
 ```
 
 Build for `wasm32-unknown-unknown` and generate bindings with your preferred

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,15 +2,18 @@
 
 Get started with ruviz in less than 5 minutes!
 
-## What's New in v0.7.0
+## What's New in v0.8.0
 
-- The Python binding grew per-series styling, axis control, full typing, and a
-  faster NumPy path with GIL-released rendering; notebook widgets render the
-  styled snapshots.
-- Stricter, earlier validation across the Python surface, with atomic
-  observable updates.
-- Wheels now cover Linux aarch64, and notebook widget dependencies moved to
-  the optional `ruviz[widget]` extra.
+- A grouped `figure()` presentation call in the Python and web bindings: size
+  in inches, dpi, typography, margins, tick notation and a resolution cap in
+  one atomic, validated call, recorded under snapshot schema version 2.
+- `margin()`, `scientific_notation()` and `line_width_pt()` now actually reach
+  the render; default data lines are matplotlib's 1.5pt, so theme line widths
+  finally apply.
+- `max_resolution()` caps an explicit DPI instead of replacing it, and small
+  pixel budgets render instead of failing. Named themes gained panel-based
+  styling knobs, and `Theme::seaborn()` is a faithful `seaborn.set_theme()`
+  port.
 
 See full details:
 
@@ -28,7 +31,7 @@ cd my_plot
 2. **Add ruviz to your `Cargo.toml`**:
 ```toml
 [dependencies]
-ruviz = "0.7.0"
+ruviz = "0.8.0"
 ```
 
 3. **Write your first plot** in `src/main.rs`:
@@ -67,8 +70,8 @@ an embedded interactive plot view:
 
 ```toml
 [dependencies]
-ruviz = "0.7.0"
-ruviz-gpui = "0.7.0"
+ruviz = "0.8.0"
+ruviz-gpui = "0.8.0"
 ```
 
 `ruviz-gpui` is supported on Linux, macOS, and Windows. On Windows, prefer the
@@ -96,7 +99,7 @@ If you want publication-style math in labels and titles, enable Typst text rende
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["typst-math"] }
+ruviz = { version = "0.8.0", features = ["typst-math"] }
 ```
 
 `.typst(true)` is only available when `typst-math` is enabled. The configured
@@ -115,7 +118,7 @@ If you want Typst to stay optional in your own crate, forward a local feature fi
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", default-features = false }
+ruviz = { version = "0.8.0", default-features = false }
 
 [features]
 default = []
@@ -367,7 +370,7 @@ Plot::new()
 ### With polars (requires `polars_support` feature)
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["polars_support"] }
+ruviz = { version = "0.8.0", features = ["polars_support"] }
 polars = "0.50"
 ```
 
@@ -395,7 +398,7 @@ Plot::new()
 only when you have benchmarked a path that benefits from the extra SIMD support:
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["performance"] }
+ruviz = { version = "0.8.0", features = ["performance"] }
 ```
 
 ### Large Dataset Export

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -62,14 +62,14 @@ Add ruviz to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruviz = "0.7.0"
+ruviz = "0.8.0"
 ```
 
 Or with specific features:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.8.0", features = ["ndarray_support", "parallel"] }
 ```
 
 ## Feature Flags
@@ -79,7 +79,7 @@ ruviz uses feature flags to enable optional functionality. Choose based on your 
 ### Default Features
 
 ```toml
-ruviz = "0.7.0"  # Includes: ndarray_support, parallel
+ruviz = "0.8.0"  # Includes: ndarray_support, parallel
 ```
 
 **Enabled by default**:
@@ -110,40 +110,40 @@ SVG export is available without an extra feature flag. The legacy `svg` feature 
 
 ```toml
 # High performance (parallel + SIMD)
-ruviz = { version = "0.7.0", features = ["performance"] }
+ruviz = { version = "0.8.0", features = ["performance"] }
 
 # Maximum capability (all features)
-ruviz = { version = "0.7.0", features = ["full"] }
+ruviz = { version = "0.8.0", features = ["full"] }
 
 # Minimal (no default features)
-ruviz = { version = "0.7.0", default-features = false }
+ruviz = { version = "0.8.0", default-features = false }
 ```
 
 ### Feature Combinations
 
 **Scientific Computing**:
 ```toml
-ruviz = { version = "0.7.0", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.8.0", features = ["ndarray_support", "parallel"] }
 ```
 
 **Data Analysis**:
 ```toml
-ruviz = { version = "0.7.0", features = ["polars_support", "performance"] }
+ruviz = { version = "0.8.0", features = ["polars_support", "performance"] }
 ```
 
 **Publication Quality**:
 ```toml
-ruviz = { version = "0.7.0", features = ["serde", "pdf"] }
+ruviz = { version = "0.8.0", features = ["serde", "pdf"] }
 ```
 
 **Real-time Visualization**:
 ```toml
-ruviz = { version = "0.7.0", features = ["interactive-gpu"] }
+ruviz = { version = "0.8.0", features = ["interactive-gpu"] }
 ```
 
 **Large Datasets**:
 ```toml
-ruviz = { version = "0.7.0", features = ["parallel", "simd", "gpu"] }
+ruviz = { version = "0.8.0", features = ["parallel", "simd", "gpu"] }
 ```
 
 ## Verification
@@ -189,7 +189,7 @@ Test specific features:
 **ndarray**:
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["ndarray_support"] }
+ruviz = { version = "0.8.0", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -282,7 +282,7 @@ rustup update
 
 ### Feature Conflicts
 
-**Problem**: `error: package ruviz v0.7.0 cannot be built because it requires rustc 1.92 or newer`
+**Problem**: `error: package ruviz v0.8.0 cannot be built because it requires rustc 1.92 or newer`
 
 **Solution**: Update Rust:
 ```bash
@@ -306,7 +306,7 @@ vulkaninfo
 
 Or disable GPU features:
 ```toml
-ruviz = { version = "0.7.0", default-features = false, features = ["parallel"] }
+ruviz = { version = "0.8.0", default-features = false, features = ["parallel"] }
 ```
 
 ### Memory Issues (Large Datasets)

--- a/docs/guide/03_first_plot.md
+++ b/docs/guide/03_first_plot.md
@@ -166,7 +166,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = "0.7.0"
+ruviz = "0.8.0"
 ```
 
 ## Customization Basics
@@ -304,7 +304,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["ndarray_support"] }
+ruviz = { version = "0.8.0", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 

--- a/docs/guide/04_plot_types.md
+++ b/docs/guide/04_plot_types.md
@@ -721,7 +721,7 @@ Use `performance` only after benchmarking a path that benefits from SIMD support
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["simd"] }
+ruviz = { version = "0.8.0", features = ["simd"] }
 ```
 
 ### Very Large Datasets (> 100K points)

--- a/docs/guide/07_backends.md
+++ b/docs/guide/07_backends.md
@@ -132,7 +132,7 @@ not a guarantee that a public `render()` call will take a SIMD path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["simd"] }
+ruviz = { version = "0.8.0", features = ["simd"] }
 ```
 
 ## What `save()` actually does
@@ -201,7 +201,7 @@ path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["gpu"] }
+ruviz = { version = "0.8.0", features = ["gpu"] }
 ```
 
 ```rust
@@ -237,7 +237,7 @@ dependency for you.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["interactive"] }
+ruviz = { version = "0.8.0", features = ["interactive"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 ```
 

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -48,7 +48,7 @@ at `t`.
 
 ```toml
 [dependencies]
-ruviz = "0.7.0"
+ruviz = "0.8.0"
 ```
 
 Useful opt-in features:

--- a/docs/guide/09_data_integration.md
+++ b/docs/guide/09_data_integration.md
@@ -64,7 +64,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["ndarray_support"] }
+ruviz = { version = "0.8.0", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -183,7 +183,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["nalgebra_support"] }
+ruviz = { version = "0.8.0", features = ["nalgebra_support"] }
 nalgebra = "0.32"
 ```
 
@@ -231,7 +231,7 @@ synthetic absorbed-energy style example.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["polars_support"] }
+ruviz = { version = "0.8.0", features = ["polars_support"] }
 polars = { version = "0.50", features = ["lazy", "rolling_window"] }
 ```
 
@@ -491,7 +491,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 ```toml
 [dependencies]
-ruviz = "0.7.0"
+ruviz = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ```

--- a/docs/guide/10_export.md
+++ b/docs/guide/10_export.md
@@ -534,7 +534,7 @@ Plot::new()
 ### PDF Export
 
 ```rust
-// Requires: ruviz = { version = "0.7.0", features = ["pdf"] }
+// Requires: ruviz = { version = "0.8.0", features = ["pdf"] }
 use ruviz::prelude::*;
 
 Plot::new()

--- a/docs/guide/12_3d.md
+++ b/docs/guide/12_3d.md
@@ -5,7 +5,7 @@ feature name `3d`:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.7.0", features = ["3d"] }
+ruviz = { version = "0.8.0", features = ["3d"] }
 ```
 
 The canonical entry points are deliberately small:

--- a/docs/migration/makie-3d.md
+++ b/docs/migration/makie-3d.md
@@ -3,7 +3,7 @@
 Enable Ruviz's exact `3d` feature:
 
 ```toml
-ruviz = { version = "0.7.0", features = ["3d"] }
+ruviz = { version = "0.8.0", features = ["3d"] }
 ```
 
 The closest API mappings are:

--- a/docs/migration/matplotlib-3d.md
+++ b/docs/migration/matplotlib-3d.md
@@ -3,7 +3,7 @@
 Enable Ruviz's exact `3d` feature:
 
 ```toml
-ruviz = { version = "0.7.0", features = ["3d"] }
+ruviz = { version = "0.8.0", features = ["3d"] }
 ```
 
 The closest API mappings are:

--- a/docs/migration/matplotlib.md
+++ b/docs/migration/matplotlib.md
@@ -416,7 +416,7 @@ let viridis_like = Theme::builder()
 ## Migration Checklist
 
 - [ ] Install Rust and cargo
-- [ ] Add `ruviz = "0.7.0"` to `Cargo.toml`
+- [ ] Add `ruviz = "0.8.0"` to `Cargo.toml`
 - [ ] Convert numpy arrays to `Vec<f64>` or `ndarray`
 - [ ] Replace `plt.plot()` with `Plot::new().line()`
 - [ ] Change `plt.savefig()` to `.save()?`

--- a/packages/ruviz/package.json
+++ b/packages/ruviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruviz",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Browser-first JS/TS SDK for ruviz WebAssembly rendering",
   "type": "module",
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
Version bump to 0.8.0 across the workspace, bindings, adapters, docs pins and lockfiles, following the same file set as the 0.7.0 release.

The CHANGELOG folds the unreleased theme work together with the figure() presentation API (#153): the grouped atomic figure() call in the Python and web bindings under snapshot schema v2, the margin/scientific-notation/line-width controls now wired through to rendering, the 1.5pt matplotlib default line width, cap semantics for max_resolution with an explicit dpi, and the fontless-wasm registerFont fix.

After merge: tag v0.8.0 on the merge commit to trigger the release workflow.