### PR TITLE
Serialize the GUI behavioral test suites in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,13 +227,13 @@ jobs:
           restore-keys: ${{ matrix.platform.cache_key }}-cargo-native-gui-tests-
 
       - name: Test adapter default behavior
-        run: cargo test --manifest-path adapters/gui/Cargo.toml --workspace --lib --locked
+        run: cargo test --manifest-path adapters/gui/Cargo.toml --workspace --lib --locked -- --test-threads=1
 
       - name: Test adapter 3D behavior
-        run: cargo test --manifest-path adapters/gui/Cargo.toml --workspace --lib --features 3d --locked
+        run: cargo test --manifest-path adapters/gui/Cargo.toml --workspace --lib --features 3d --locked -- --test-threads=1
 
       - name: Test all adapter feature behavior
-        run: cargo test --manifest-path adapters/gui/Cargo.toml --workspace --lib --all-features --locked
+        run: cargo test --manifest-path adapters/gui/Cargo.toml --workspace --lib --all-features --locked -- --test-threads=1
 
       - name: Test adapter documentation
         run: |

--- a/adapters/gui/ruviz-slint/src/lib.rs
+++ b/adapters/gui/ruviz-slint/src/lib.rs
@@ -2838,12 +2838,15 @@ mod tests {
 
     /// Block until `condition` holds, or fail with enough detail to diagnose why.
     ///
-    /// This times out intermittently on Linux CI and has not been reproduced
-    /// anywhere else — not on macOS or Windows CI, not locally, and not under
-    /// a Linux container capped at 2 or 4 CPUs (issue #152). The bare message
-    /// it used to fail with could not distinguish a worker that never ran from
-    /// one that ran and never finished, so every theory about it stayed a
-    /// theory.
+    /// This times out intermittently on CI (issue #152) — first on Linux and,
+    /// as of 2026-08, on a 4-core Windows runner, where four 3D tests failed
+    /// together at ~18M polls each: the waiters had CPU, the render workers
+    /// did not. Four concurrent 3D renders (each with a rayon tile pool) plus
+    /// four yield-spinning waiters oversubscribe a 4-core runner heavily,
+    /// which is why CI now runs these suites with --test-threads=1. The bare
+    /// message it used to fail with could not distinguish a worker that never
+    /// ran from one that ran and never finished, so every theory about it
+    /// stayed a theory.
     ///
     /// The poll count is the discriminator. A waiter that spun millions of
     /// times was not itself starved of CPU, which is the reading the spin


### PR DESCRIPTION
Issue #152's render-worker timeout finally reproduced with its instrumentation doing its job: on a 4-core Windows runner, four 3D tests failed together at ~18M polls each — the waiters had CPU; the render workers didn't. Four concurrent 3D renders (each with a rayon tile pool) plus four yield-spinning waiters oversubscribe a 4-core runner several times over.

Fix: run the adapter lib suites with `--test-threads=1` in the behavioral CI job, so each render worker gets the machine. The waiting primitive is untouched — its doc comment (which explicitly warns against "fixing" this with a sleep, tried and worse) now records the Windows reproduction and the mitigation.

Cost: the test-execution portion of the job serializes; the job is build-dominated, so the wall-clock impact is small against the retry cost of the flake (three reruns across two PRs this week).