### PR TITLE
Give the GUI render-worker wait 60s of runner headroom

### DIFF
--- a/adapters/gui/ruviz-slint/src/lib.rs
+++ b/adapters/gui/ruviz-slint/src/lib.rs
@@ -2857,13 +2857,20 @@ mod tests {
     /// Do not change the waiting primitive to "fix" the flake without a
     /// reproduction and a control run: swapping `yield_now` for a 1ms sleep
     /// was tried and made these tests fail 11 runs out of 12 under load.
+    ///
+    /// The deadline is 60s because 10s was measured too tight for shared CI
+    /// runners: with the suites already serialized, a 4-core Linux runner
+    /// still timed out at 9.2M polls — the waiter had CPU the whole time and
+    /// the render work was genuinely in flight, just slow next to noisy
+    /// neighbors. A passing wait exits the moment the condition holds, so
+    /// headroom costs nothing except on a real hang, which still fails.
     fn wait_for(condition: impl Fn() -> bool) {
         let start = Instant::now();
         let mut polls: u64 = 0;
         while !condition() {
             let elapsed = start.elapsed();
             assert!(
-                elapsed < Duration::from_secs(10),
+                elapsed < Duration::from_secs(60),
                 "timed out waiting for render worker after {polls} polls in {elapsed:?} \
                  (available_parallelism: {:?})",
                 std::thread::available_parallelism(),


### PR DESCRIPTION
Issue #152 recurred on the 0.11.0 release CI run (run 31941997363) with `--test-threads=1` already in place: `timed out waiting for render worker after 9192664 polls in 10s (available_parallelism: Ok(4))` on Linux.

The poll counter — added exactly for this decision — reads "millions": the waiter was never starved, the render work was in flight and simply slow on a shared 4-core runner. Serialization (#160) removed the self-inflicted oversubscription; what remains is runner speed we don't control. Per the issue's own decision tree, this is the case where raising the deadline is the honest fix: a passing wait exits immediately, so headroom is free except on a real hang, which still fails at 60s with the same diagnostic.

Deliberately *not* done, to avoid masking real regressions: no step-level retries, no change to the `yield_now` waiting primitive (the 1ms-sleep experiment on the issue measured 11/12 failures). The remaining known CI flakes already have targeted fixes: the 3D clip proptest tolerance landed in #163, and the e2e boot retry is in `tests/navigate.js`.

Reopens the #152 discussion with the new occurrence.