### PR TITLE
Fix sheared interactive overlays (dynamic annotations, hover markers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Interactive session overlays — dynamic `add_annotation` / `update_annotation`
+  annotations, hover and selection markers, brush rectangles and tooltips — no
+  longer shear diagonally at frame sizes where the fitted base canvas came out
+  one pixel wider than the requested frame (for example a default-size figure
+  fitted into a 734×513 pt card on a 2× display). The exact-DPI search now
+  uses the same snapping arithmetic as `FigureConfig::canvas_size`, the
+  overlay raster is allocated at the base layer's actual size before the two
+  are composed, and `ruviz-gpui` refuses to blend a cached overlay of a
+  different size into a captured image.
 - Long 2D plot titles now wrap at Unicode line-break opportunities and shrink
   only when two automatic lines do not fit. Authored newlines remain hard
   breaks, the configured title size remains the preferred maximum, and PNG

--- a/adapters/gpui/src/platform_impl/presentation.rs
+++ b/adapters/gpui/src/platform_impl/presentation.rs
@@ -461,6 +461,11 @@ impl RuvizPlot {
 
         if let Some(overlay) = frame.overlay_image.as_ref() {
             let overlay = render_image_to_ruviz(overlay)?;
+            if (overlay.width, overlay.height) != (image.width, image.height) {
+                // Blending row-major buffers of different widths shears the
+                // overlay; fall back to a fresh session render instead.
+                return None;
+            }
             blend_rgba_into_rgba(&overlay.pixels, &mut image.pixels);
         }
 

--- a/src/core/plot/construction.rs
+++ b/src/core/plot/construction.rs
@@ -1178,8 +1178,22 @@ impl Plot {
             && figure.height > 0.0
     }
 
+    /// The canvas the renderer will actually allocate for `figure` at `dpi`.
+    ///
+    /// This must be the same arithmetic as [`FigureConfig::canvas_size`],
+    /// which snaps products within representation noise of an integer
+    /// instead of truncating. A plain `(width * dpi) as u32` here disagreed
+    /// with it by one pixel for many fitted frame sizes, so the base layer
+    /// came out one column wider than the overlay raster that shares its
+    /// frame size and the composed overlay sheared diagonally.
+    ///
+    /// [`FigureConfig::canvas_size`]: crate::core::FigureConfig::canvas_size
     fn canvas_size_for_figure_dpi(figure: &crate::core::FigureConfig, dpi: f32) -> (u32, u32) {
-        ((figure.width * dpi) as u32, (figure.height * dpi) as u32)
+        crate::core::FigureConfig {
+            dpi,
+            ..figure.clone()
+        }
+        .canvas_size()
     }
 
     fn next_positive_f32(value: f32) -> f32 {

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -2954,13 +2954,6 @@ impl InteractivePlotSession {
             };
 
             let geometry = self.ensure_geometry(&base_key, resolved_frame.as_ref())?;
-            let frame_size_px = {
-                self.inner
-                    .state
-                    .lock()
-                    .expect("InteractivePlotSession state lock poisoned")
-                    .size_px
-            };
             let base_result = self.ensure_base_image(
                 &base_key,
                 &geometry,
@@ -2968,6 +2961,14 @@ impl InteractivePlotSession {
                 epoch_before_render,
                 resolved_frame.as_ref(),
             )?;
+            // The overlay raster is allocated at the base layer's actual pixel
+            // size rather than the requested `state.size_px`. The two agree
+            // whenever the base render honours its frame size, and when they
+            // do not, sizing the overlay from the request would hand
+            // `compose_images` (and every straight-alpha compositor
+            // downstream) two buffers with different row strides, which
+            // shears the whole overlay diagonally.
+            let frame_size_px = (base_result.layer.width(), base_result.layer.height());
             self.run_render_test_hook(RenderTestPoint::AfterBasePublication);
             self.refresh_overlay_state(dirty_before_render, epoch_before_render)?;
             let overlay_result = self.ensure_overlay_image(frame_size_px, dirty_before_render)?;

--- a/src/core/plot/interactive_session/helpers.rs
+++ b/src/core/plot/interactive_session/helpers.rs
@@ -1,6 +1,11 @@
 use super::*;
 
 pub(super) fn compose_images(base: &Image, overlay: &Image) -> Image {
+    debug_assert_eq!(
+        (base.width, base.height),
+        (overlay.width, overlay.height),
+        "overlay raster must match the base layer size or the composite shears"
+    );
     let mut pixels = base
         .pixels_in_alpha_mode(crate::core::plot::AlphaMode::Straight)
         .into_owned();

--- a/src/core/plot/interactive_session/tests.rs
+++ b/src/core/plot/interactive_session/tests.rs
@@ -5512,3 +5512,132 @@ fn test_heatmap_cell_tooltip_carries_the_series_label() {
     let tooltip = tooltip_from_hit(&plot, &hit);
     assert_eq!(tooltip.content, "field: row=2, col=3, value=4.200e-5");
 }
+
+/// A frame size at which the exact-DPI search used to pick a DPI whose
+/// `(figure.width * dpi) as u32` truncated to 1367 while
+/// `FigureConfig::canvas_size` snapped the same product to 1368, so the base
+/// layer rendered one column wider than the overlay raster.
+fn shear_prone_image_target() -> ImageTarget {
+    ImageTarget {
+        size_px: (1367, 1026),
+        scale_factor: 2.0,
+        time_seconds: 0.0,
+    }
+}
+
+fn sine_plot(size_px: Option<(u32, u32)>) -> Plot {
+    let x: Vec<f64> = (0..400).map(|i| i as f64 * 0.025).collect();
+    let y: Vec<f64> = x.iter().map(|v| v.sin()).collect();
+    let mut builder = Plot::new().line(&x, &y).title("shear").grid(false);
+    if let Some((width, height)) = size_px {
+        builder = builder.size_px(width, height);
+    }
+    builder.into()
+}
+
+#[test]
+fn test_prepared_frame_canvas_matches_requested_size() {
+    let figures = [sine_plot(None), sine_plot(Some((900, 420)))];
+    let mut mismatches = Vec::new();
+    for plot in &figures {
+        let frame = plot.resolve_frame(0.0).unwrap();
+        for scale in [1.0f32, 2.0] {
+            for max_width in 1..=2600u32 {
+                let width_limited = (max_width, 4000);
+                let height_limited = (max_width, ((max_width as f32 * 0.7) as u32).max(1));
+                for max_size in [width_limited, height_limited] {
+                    let fitted = plot.fitted_output_size_for_max_pixels(max_size);
+                    let canvas = plot
+                        .prepared_frame_shell_with_style(fitted, scale, &frame.style)
+                        .config_canvas_size();
+                    if canvas != fitted {
+                        mismatches.push((scale, max_size, fitted, canvas));
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "{} fitted frames render at a different canvas size, e.g. {:?}",
+        mismatches.len(),
+        &mismatches[..mismatches.len().min(8)]
+    );
+}
+
+fn filled_column_range(image: &Image, row: u32) -> Option<(u32, u32)> {
+    let start = (row * image.width) as usize * 4;
+    let columns = image.pixels[start..start + image.width as usize * 4]
+        .chunks_exact(4)
+        .enumerate()
+        .filter(|(_, pixel)| pixel[3] > 0)
+        .map(|(column, _)| column as u32);
+    let mut range: Option<(u32, u32)> = None;
+    for column in columns {
+        range = Some(match range {
+            None => (column, column),
+            Some((min, max)) => (min.min(column), max.max(column)),
+        });
+    }
+    range
+}
+
+fn differing_column_range(base: &Image, composed: &Image, row: u32) -> Option<(u32, u32)> {
+    let start = (row * base.width) as usize * 4;
+    let end = start + base.width as usize * 4;
+    let mut range: Option<(u32, u32)> = None;
+    for (column, (before, after)) in base.pixels[start..end]
+        .chunks_exact(4)
+        .zip(composed.pixels[start..end].chunks_exact(4))
+        .enumerate()
+    {
+        if before != after {
+            let column = column as u32;
+            range = Some(match range {
+                None => (column, column),
+                Some((min, max)) => (min.min(column), max.max(column)),
+            });
+        }
+    }
+    range
+}
+
+#[test]
+fn test_dynamic_annotation_overlay_matches_base_size_and_stays_axis_aligned() {
+    let session = sine_plot(None).prepare_interactive();
+    session.add_annotation(Annotation::hspan(2.0, 3.0)).unwrap();
+    let target = shear_prone_image_target();
+    let frame = session.render_to_image(target).unwrap();
+
+    let base = &frame.layers.base;
+    let overlay = frame
+        .layers
+        .overlay
+        .as_ref()
+        .expect("a dynamic annotation renders an overlay layer");
+    assert_eq!((base.width, base.height), target.size_px);
+    assert_eq!((overlay.width, overlay.height), target.size_px);
+    assert_eq!((frame.image.width, frame.image.height), target.size_px);
+
+    let plot_area = session.geometry_snapshot().unwrap().plot_area;
+    let rows = (plot_area.top() as u32 + 2)..(plot_area.bottom() as u32 - 2);
+    let expected = filled_column_range(overlay, rows.start).expect("span fills the first row");
+    assert!(
+        expected.1 > expected.0 + 8,
+        "span is wider than a line: {expected:?}"
+    );
+    let expected_composed =
+        differing_column_range(base, &frame.image, rows.start).expect("span shows in composite");
+    for row in rows {
+        assert_eq!(
+            filled_column_range(overlay, row),
+            Some(expected),
+            "overlay span drifted on row {row}"
+        );
+        assert_eq!(
+            differing_column_range(base, &frame.image, row),
+            Some(expected_composed),
+            "composed span drifted on row {row}"
+        );
+    }
+}


### PR DESCRIPTION
Root cause and fix are described in the commit message. Regression tests sweep the fitted frame sizes and check an HSpan stays axis-aligned at 1367×1026 @2×. CHANGELOG entry under Unreleased.
