### PR TITLE
Release 0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.12.1] - 2026-09-02
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-py"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "image",
  "numpy",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-web"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [package]
 name = "ruviz"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Ruviz Contributors"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bindings. Every figure in it is real ruviz output.
 
 ```toml
 [dependencies]
-ruviz = "0.12.0"
+ruviz = "0.12.1"
 ```
 
 ## Hello, plot

--- a/adapters/gpui/Cargo.lock
+++ b/adapters/gpui/Cargo.lock
@@ -5120,7 +5120,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "bytemuck",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-gpui"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arboard",
  "core-foundation 0.10.0",

--- a/adapters/gpui/Cargo.toml
+++ b/adapters/gpui/Cargo.toml
@@ -24,7 +24,7 @@ gpui = { git = "https://github.com/zed-industries/zed", rev = "3060e4170ea5ef0e6
 
 [package]
 name = "ruviz-gpui"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -45,7 +45,7 @@ gpu = ["ruviz/gpu"]
 "3d-gpu" = ["3d", "gpu"]
 
 [dependencies]
-ruviz = { version = "0.12.0", path = "../.." }
+ruviz = { version = "0.12.1", path = "../.." }
 image = "0.25"
 smallvec = "1.15"
 futures = "0.3"

--- a/adapters/gpui/README.md
+++ b/adapters/gpui/README.md
@@ -10,8 +10,8 @@ own the window, layout tree, and surrounding application shell.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["3d"] }
-ruviz-gpui = { version = "0.12.0", features = ["3d"] }
+ruviz = { version = "0.12.1", features = ["3d"] }
+ruviz-gpui = { version = "0.12.1", features = ["3d"] }
 ```
 
 ## What This Crate Provides

--- a/adapters/gpui/src/lib.rs
+++ b/adapters/gpui/src/lib.rs
@@ -49,8 +49,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ruviz = "0.12.0"
-//! ruviz-gpui = "0.12.0"
+//! ruviz = "0.12.1"
+//! ruviz-gpui = "0.12.1"
 //! ```
 //!
 //! Then build a normal `ruviz::Plot` or `PreparedPlot` and hand it to the GPUI

--- a/adapters/gui/Cargo.lock
+++ b/adapters/gui/Cargo.lock
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "base64",
  "bytemuck",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-egui"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "eframe",
  "egui",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-iced"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arboard",
  "async-channel",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-slint"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arboard",
  "i-slint-backend-testing",

--- a/adapters/gui/Cargo.toml
+++ b/adapters/gui/Cargo.toml
@@ -5,7 +5,7 @@ members = ["ruviz-egui", "ruviz-iced", "ruviz-slint"]
 resolver = "2"
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"

--- a/adapters/gui/ruviz-egui/Cargo.toml
+++ b/adapters/gui/ruviz-egui/Cargo.toml
@@ -22,7 +22,7 @@ gpu = ["ruviz/gpu"]
 egui = { version = "0.35", default-features = false, features = ["default_fonts"] }
 pollster = "0.4"
 rfd = "0.15"
-ruviz = { version = "=0.12.0", path = "../../.." }
+ruviz = { version = "=0.12.1", path = "../../.." }
 
 [dev-dependencies]
 eframe = { version = "0.35", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }

--- a/adapters/gui/ruviz-iced/Cargo.toml
+++ b/adapters/gui/ruviz-iced/Cargo.toml
@@ -33,7 +33,7 @@ async-channel = "2"
 bytes = "1.9"
 arboard = "3.6.1"
 rfd = "0.15"
-ruviz = { version = "=0.12.0", path = "../../.." }
+ruviz = { version = "=0.12.1", path = "../../.." }
 
 [dev-dependencies]
 # `default-features = false` drops iced's default renderer set, so `wgpu` and

--- a/adapters/gui/ruviz-iced/README.md
+++ b/adapters/gui/ruviz-iced/README.md
@@ -98,7 +98,7 @@ to enable it:
 ```toml
 [dependencies]
 iced = { version = "0.14", features = ["wgpu", "crisp"] }
-ruviz-iced = "0.12.0"
+ruviz-iced = "0.12.1"
 ```
 
 - `wgpu` — GPU presentation. Without it Iced falls back to the `tiny-skia` CPU

--- a/adapters/gui/ruviz-slint/Cargo.toml
+++ b/adapters/gui/ruviz-slint/Cargo.toml
@@ -29,7 +29,7 @@ gpu = ["ruviz/gpu"]
 "3d-gpu" = ["3d", "gpu"]
 
 [dependencies]
-ruviz = { version = "=0.12.0", path = "../../.." }
+ruviz = { version = "=0.12.1", path = "../../.." }
 slint = { version = "~1.17", default-features = false, features = ["std", "compat-1-2"] }
 arboard = "3.6.1"
 rfd = "0.15"

--- a/adapters/gui/ruviz-slint/README.md
+++ b/adapters/gui/ruviz-slint/README.md
@@ -41,7 +41,7 @@ module support:
 
 ```toml
 [dependencies]
-ruviz-slint = "0.12.0"
+ruviz-slint = "0.12.1"
 slint = { version = "~1.17", default-features = false, features = [
     "std", "compat-1-2", "backend-winit", "renderer-femtovg"
 ] }

--- a/adapters/gui/ruviz-slint/tests/package-consumer/Cargo.lock
+++ b/adapters/gui/ruviz-slint/tests/package-consumer/Cargo.lock
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "cosmic-text",
  "ctor",
@@ -2978,13 +2978,15 @@ dependencies = [
  "tiny-skia",
  "tiny-skia-path",
  "ttf-parser",
+ "unicode-linebreak",
+ "unicode-segmentation",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ruviz-slint"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "arboard",
  "rfd",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-py"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Python bindings and notebook widget support for ruviz"
@@ -20,7 +20,7 @@ crate-type = ["cdylib"]
 numpy = "0.24"
 pollster = "0.4"
 pyo3 = { version = "0.24", features = ["abi3-py310"] }
-ruviz = { path = "../..", version = "0.12.0", default-features = false, features = ["3d", "parallel", "pdf", "svg"] }
+ruviz = { path = "../..", version = "0.12.1", default-features = false, features = ["3d", "parallel", "pdf", "svg"] }
 
 [dev-dependencies]
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruviz"
-version = "0.12.0"
+version = "0.12.1"
 description = "Python bindings and notebook widget support for ruviz"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "ruviz"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-web"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ default = ["embedded-font"]
 "3d-gpu" = ["3d", "ruviz/gpu", "dep:wgpu", "dep:wasm-bindgen-futures"]
 
 [dependencies]
-ruviz = { version = "0.12.0", path = "../..", default-features = false }
+ruviz = { version = "0.12.1", path = "../..", default-features = false }
 js-sys = "0.3.92"
 wasm-bindgen = "0.2.105"
 console_error_panic_hook = "0.1.7"

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -21,7 +21,7 @@ Add the bridge crate to your Cargo manifest:
 
 ```toml
 [dependencies]
-ruviz-web = "0.12.0"
+ruviz-web = "0.12.1"
 ```
 
 Build for `wasm32-unknown-unknown` and generate bindings with your preferred

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,21 +2,16 @@
 
 Get started with ruviz in less than 5 minutes!
 
-## What's New in v0.12.0
+## What's New in v0.12.1
 
-- Horizontal everything: bars, grouped and stacked bars, and box plots all
-  turn with `.horizontal()` — categories move to the y axis with real
-  labels, the value axis keeps its scale, and Python
-  (`orientation="horizontal"`), Wasm and the TypeScript SDK spell the same
-  knob. Ranked charts read top-down with the new `.invert_y()`
-  (`.invert_x()` is its twin), which composes with auto-scaled bounds.
-- Box plots draw the mean `.show_mean(true)` always promised, grouped and
-  stacked bars carry the same derived edge a plain bar has (with legend
-  swatches to match), and horizontal groups read top-to-bottom in legend
-  order.
-- PNG output stamps the configured DPI in a standard `pHYs` chunk — direct
-  and interactive-session exports byte-identically — so print software
-  recovers the intended physical figure size.
+- Interactive overlays render straight again: dynamic annotations, hover and
+  selection markers, brushes and tooltips could shear diagonally when the
+  fitted canvas came out one pixel narrower than the rendered base layer.
+  Canvas sizing now shares the renderer's arithmetic and the overlay takes
+  its size from the base layer it is composited onto.
+- Long 2D titles wrap at Unicode line-break opportunities before shrinking,
+  and `LegendPosition::Best` scores the visible geometry with a bounded
+  screen-space mask so dense sampling no longer moves the legend.
 
 See full details:
 
@@ -34,7 +29,7 @@ cd my_plot
 2. **Add ruviz to your `Cargo.toml`**:
 ```toml
 [dependencies]
-ruviz = "0.12.0"
+ruviz = "0.12.1"
 ```
 
 3. **Write your first plot** in `src/main.rs`:
@@ -73,8 +68,8 @@ an embedded interactive plot view:
 
 ```toml
 [dependencies]
-ruviz = "0.12.0"
-ruviz-gpui = "0.12.0"
+ruviz = "0.12.1"
+ruviz-gpui = "0.12.1"
 ```
 
 `ruviz-gpui` is supported on Linux, macOS, and Windows. On Windows, prefer the
@@ -102,7 +97,7 @@ If you want publication-style math in labels and titles, enable Typst text rende
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["typst-math"] }
+ruviz = { version = "0.12.1", features = ["typst-math"] }
 ```
 
 `.typst(true)` is only available when `typst-math` is enabled. The configured
@@ -121,7 +116,7 @@ If you want Typst to stay optional in your own crate, forward a local feature fi
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", default-features = false }
+ruviz = { version = "0.12.1", default-features = false }
 
 [features]
 default = []
@@ -373,7 +368,7 @@ Plot::new()
 ### With polars (requires `polars_support` feature)
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["polars_support"] }
+ruviz = { version = "0.12.1", features = ["polars_support"] }
 polars = "0.50"
 ```
 
@@ -401,7 +396,7 @@ Plot::new()
 only when you have benchmarked a path that benefits from the extra SIMD support:
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["performance"] }
+ruviz = { version = "0.12.1", features = ["performance"] }
 ```
 
 ### Large Dataset Export

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -62,14 +62,14 @@ Add ruviz to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruviz = "0.12.0"
+ruviz = "0.12.1"
 ```
 
 Or with specific features:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.12.1", features = ["ndarray_support", "parallel"] }
 ```
 
 ## Feature Flags
@@ -79,7 +79,7 @@ ruviz uses feature flags to enable optional functionality. Choose based on your 
 ### Default Features
 
 ```toml
-ruviz = "0.12.0"  # Includes: ndarray_support, parallel
+ruviz = "0.12.1"  # Includes: ndarray_support, parallel
 ```
 
 **Enabled by default**:
@@ -110,40 +110,40 @@ SVG export is available without an extra feature flag. The legacy `svg` feature 
 
 ```toml
 # High performance (parallel + SIMD)
-ruviz = { version = "0.12.0", features = ["performance"] }
+ruviz = { version = "0.12.1", features = ["performance"] }
 
 # Maximum capability (all features)
-ruviz = { version = "0.12.0", features = ["full"] }
+ruviz = { version = "0.12.1", features = ["full"] }
 
 # Minimal (no default features)
-ruviz = { version = "0.12.0", default-features = false }
+ruviz = { version = "0.12.1", default-features = false }
 ```
 
 ### Feature Combinations
 
 **Scientific Computing**:
 ```toml
-ruviz = { version = "0.12.0", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.12.1", features = ["ndarray_support", "parallel"] }
 ```
 
 **Data Analysis**:
 ```toml
-ruviz = { version = "0.12.0", features = ["polars_support", "performance"] }
+ruviz = { version = "0.12.1", features = ["polars_support", "performance"] }
 ```
 
 **Publication Quality**:
 ```toml
-ruviz = { version = "0.12.0", features = ["serde", "pdf"] }
+ruviz = { version = "0.12.1", features = ["serde", "pdf"] }
 ```
 
 **Real-time Visualization**:
 ```toml
-ruviz = { version = "0.12.0", features = ["interactive-gpu"] }
+ruviz = { version = "0.12.1", features = ["interactive-gpu"] }
 ```
 
 **Large Datasets**:
 ```toml
-ruviz = { version = "0.12.0", features = ["parallel", "simd", "gpu"] }
+ruviz = { version = "0.12.1", features = ["parallel", "simd", "gpu"] }
 ```
 
 ## Verification
@@ -189,7 +189,7 @@ Test specific features:
 **ndarray**:
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["ndarray_support"] }
+ruviz = { version = "0.12.1", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -282,7 +282,7 @@ rustup update
 
 ### Feature Conflicts
 
-**Problem**: `error: package ruviz v0.12.0 cannot be built because it requires rustc 1.92 or newer`
+**Problem**: `error: package ruviz v0.12.1 cannot be built because it requires rustc 1.92 or newer`
 
 **Solution**: Update Rust:
 ```bash
@@ -306,7 +306,7 @@ vulkaninfo
 
 Or disable GPU features:
 ```toml
-ruviz = { version = "0.12.0", default-features = false, features = ["parallel"] }
+ruviz = { version = "0.12.1", default-features = false, features = ["parallel"] }
 ```
 
 ### Memory Issues (Large Datasets)

--- a/docs/guide/03_first_plot.md
+++ b/docs/guide/03_first_plot.md
@@ -166,7 +166,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = "0.12.0"
+ruviz = "0.12.1"
 ```
 
 ## Customization Basics
@@ -304,7 +304,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["ndarray_support"] }
+ruviz = { version = "0.12.1", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 

--- a/docs/guide/04_plot_types.md
+++ b/docs/guide/04_plot_types.md
@@ -776,7 +776,7 @@ Use `performance` only after benchmarking a path that benefits from SIMD support
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["simd"] }
+ruviz = { version = "0.12.1", features = ["simd"] }
 ```
 
 ### Very Large Datasets (> 100K points)

--- a/docs/guide/07_backends.md
+++ b/docs/guide/07_backends.md
@@ -132,7 +132,7 @@ not a guarantee that a public `render()` call will take a SIMD path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["simd"] }
+ruviz = { version = "0.12.1", features = ["simd"] }
 ```
 
 ## What `save()` actually does
@@ -201,7 +201,7 @@ path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["gpu"] }
+ruviz = { version = "0.12.1", features = ["gpu"] }
 ```
 
 ```rust
@@ -237,7 +237,7 @@ dependency for you.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["interactive"] }
+ruviz = { version = "0.12.1", features = ["interactive"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 ```
 

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -48,7 +48,7 @@ at `t`.
 
 ```toml
 [dependencies]
-ruviz = "0.12.0"
+ruviz = "0.12.1"
 ```
 
 Useful opt-in features:

--- a/docs/guide/09_data_integration.md
+++ b/docs/guide/09_data_integration.md
@@ -64,7 +64,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["ndarray_support"] }
+ruviz = { version = "0.12.1", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -183,7 +183,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["nalgebra_support"] }
+ruviz = { version = "0.12.1", features = ["nalgebra_support"] }
 nalgebra = "0.32"
 ```
 
@@ -231,7 +231,7 @@ synthetic absorbed-energy style example.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["polars_support"] }
+ruviz = { version = "0.12.1", features = ["polars_support"] }
 polars = { version = "0.50", features = ["lazy", "rolling_window"] }
 ```
 
@@ -491,7 +491,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 ```toml
 [dependencies]
-ruviz = "0.12.0"
+ruviz = "0.12.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ```

--- a/docs/guide/10_export.md
+++ b/docs/guide/10_export.md
@@ -539,7 +539,7 @@ Plot::new()
 ### PDF Export
 
 ```rust
-// Requires: ruviz = { version = "0.12.0", features = ["pdf"] }
+// Requires: ruviz = { version = "0.12.1", features = ["pdf"] }
 use ruviz::prelude::*;
 
 Plot::new()

--- a/docs/guide/12_3d.md
+++ b/docs/guide/12_3d.md
@@ -5,7 +5,7 @@ feature name `3d`:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.12.0", features = ["3d"] }
+ruviz = { version = "0.12.1", features = ["3d"] }
 ```
 
 The canonical entry points are deliberately small:

--- a/docs/migration/makie-3d.md
+++ b/docs/migration/makie-3d.md
@@ -3,7 +3,7 @@
 Enable Ruviz's exact `3d` feature:
 
 ```toml
-ruviz = { version = "0.12.0", features = ["3d"] }
+ruviz = { version = "0.12.1", features = ["3d"] }
 ```
 
 The closest API mappings are:

--- a/docs/migration/matplotlib-3d.md
+++ b/docs/migration/matplotlib-3d.md
@@ -3,7 +3,7 @@
 Enable Ruviz's exact `3d` feature:
 
 ```toml
-ruviz = { version = "0.12.0", features = ["3d"] }
+ruviz = { version = "0.12.1", features = ["3d"] }
 ```
 
 The closest API mappings are:

--- a/docs/migration/matplotlib.md
+++ b/docs/migration/matplotlib.md
@@ -416,7 +416,7 @@ let viridis_like = Theme::builder()
 ## Migration Checklist
 
 - [ ] Install Rust and cargo
-- [ ] Add `ruviz = "0.12.0"` to `Cargo.toml`
+- [ ] Add `ruviz = "0.12.1"` to `Cargo.toml`
 - [ ] Convert numpy arrays to `Vec<f64>` or `ndarray`
 - [ ] Replace `plt.plot()` with `Plot::new().line()`
 - [ ] Change `plt.savefig()` to `.save()?`

--- a/packages/ruviz/package.json
+++ b/packages/ruviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruviz",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Browser-first JS/TS SDK for ruviz WebAssembly rendering",
   "type": "module",
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
Patch release: interactive overlay shear fix (#178) plus the title-wrap and LegendPosition::Best fixes. Version bumps across workspace, adapters, bindings, lockfiles and docs; QUICKSTART What's New updated. Merge after #178.
