### PR TITLE
ruviz-gpui: keep pans alive while their own render is in flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `InteractivePlotSession::axis_inset_px` reports the band inside the plot-area edge that the axes own (spine and inward tick marks), for embedders that slide a cached frame's plot area.
+
 - `ruviz-gpui`: a pan drag no longer waits for a raster. While the pointer
   moves, the cached base frame's plot area is repainted on the GPU at the
   offset the pending view implies (margins and axes keep their place until
@@ -25,6 +27,11 @@ All notable changes to this project will be documented in this file.
   presentation path.
 
 ### Fixed
+
+- A pan drag keeps the frame it started on as its anchor: margins, axis spines, tick marks and tick labels stay exactly where they were for the whole drag while throttled rasters feed only the plot-area content, so a fast drag no longer makes the axes flicker. The preview mask is clipped to where the shifted frame's plot area lands, so its margins never show through, and the axis band is left to the anchor. Only the final raster after release redraws the axes.
+- An in-flight frame is installed under a queued request only when it was rendered for the same instant (`time_bits`), not just the same geometry, so an animation step or `set_time` never shows an older frame first.
+- A generation rollover clears the scheduler's install floor, which otherwise rejected every post-rollover frame.
+- A pan survives its own pending render only while that render keeps the cached frame's geometry (size, scale, presentation); a pending resize resets the pointer state as before.
 
 - `ruviz-gpui`: a pan or brush drag no longer dies after its first move. The
   pointer gate reset the drag whenever the session's displayed base

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `ruviz-gpui`: a pan or brush drag no longer dies after its first move. The
+  pointer gate reset the drag whenever the session's displayed base
+  generation ran ahead of the cached frame — which is exactly what happens
+  while the view's own render of that pan is in flight — so continuous input
+  froze the view after one frame. A pending render of our own now keeps the
+  pointer state; only an externally moved session resets it. The render
+  scheduler also installs an in-flight frame that finishes while a newer
+  request of the same size, scale and presentation is queued, so continuous
+  input paints every rendered frame instead of only the last one (a
+  superseded or resized frame is still discarded).
+
 ## [0.12.1] - 2026-09-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- `ruviz-gpui`: a pan drag no longer waits for a raster. While the pointer
+  moves, the cached base frame's plot area is repainted on the GPU at the
+  offset the pending view implies (margins and axes keep their place until
+  the next raster), rasters are spaced at least 32 ms apart, and the frame
+  that lands replaces the translated preview without a jump. Input now stays
+  at display rate on large Retina plots where a raster costs 8–10 ms.
+- `InteractivePlotSession::render_surface_layers_stamped` hands a surface
+  presenter the native (premultiplied) base layer; `StampedInteractiveLayers`
+  gains `target` and `surface_capability`.
+
+### Changed
+
+- `ruviz-gpui`'s surface upload reads the base layer's native premultiplied
+  bytes and un-premultiplies per pixel only where alpha asks, instead of
+  materializing a straight-alpha copy of the whole frame first; the YCbCr
+  conversion runs row-wise. Roughly halves the per-frame cost on the gpu
+  presentation path.
+
 ### Fixed
 
 - `ruviz-gpui`: a pan or brush drag no longer dies after its first move. The

--- a/adapters/gpui/src/lib.rs
+++ b/adapters/gpui/src/lib.rs
@@ -526,6 +526,15 @@ mod platform_impl {
             f64::from_bits(self.time_bits)
         }
 
+        /// Whether two requests describe the same frame geometry: size,
+        /// backing scale and presentation. Frames that agree here map pointer
+        /// positions identically and can stand in for each other on screen.
+        fn same_frame_contract(&self, other: &Self) -> bool {
+            self.size_px == other.size_px
+                && self.scale_bits == other.scale_bits
+                && self.presentation_mode == other.presentation_mode
+        }
+
         fn is_dirty(&self, session: &InteractivePlotSession) -> bool {
             let dirty = session.dirty_domains();
             dirty.layout || dirty.data || dirty.overlay || dirty.temporal || dirty.interaction
@@ -564,6 +573,9 @@ mod platform_impl {
     struct FrameView {
         visible: ViewportRect,
         plot_area: ViewportRect,
+        /// Frame pixels inside the plot-area edge owned by the axes (spine
+        /// and inward ticks); a translated preview leaves them untouched.
+        axis_inset_px: f64,
         x_scale: AxisScale,
         y_scale: AxisScale,
     }
@@ -575,6 +587,17 @@ mod platform_impl {
     struct PanPreview {
         offset: Point<Pixels>,
         mask: Bounds<Pixels>,
+    }
+
+    /// The frame on screen when a pan drag started. Its margins and axes are
+    /// painted unchanged for the whole drag while newer rasters supply the
+    /// plot-area content, so nothing outside the plot area moves until the
+    /// final raster after release replaces it.
+    #[derive(Clone)]
+    struct PanAnchor {
+        request: RenderRequest,
+        primary: PrimaryFrame,
+        view: FrameView,
     }
 
     #[derive(Clone)]
@@ -631,8 +654,8 @@ mod platform_impl {
         install_floor: u64,
         /// The most recently scheduled request; an older in-flight frame is
         /// still installed when it matches this request's frame contract
-        /// (size, scale, presentation), so a drag shows every rendered frame
-        /// instead of only the last one.
+        /// (size, scale, presentation) and time, so a drag shows every
+        /// rendered frame instead of only the last one.
         latest_request: Option<RenderRequest>,
         in_flight: Option<ScheduledRender>,
         queued: Option<ScheduledRender>,
@@ -658,6 +681,10 @@ mod platform_impl {
             if self.latest_requested_generation == u64::MAX {
                 self.scheduler_incarnation = Arc::new(RenderSchedulerIncarnation);
                 self.latest_requested_generation = 1;
+                // The floor names a generation of the old incarnation; every
+                // frame of that incarnation is already rejected by the
+                // incarnation check, so the new one starts unfloored.
+                self.install_floor = 0;
             } else {
                 self.latest_requested_generation += 1;
             }
@@ -701,11 +728,13 @@ mod platform_impl {
             // newer than what is on screen: install it when its frame contract
             // matches the latest request (only the session state differs), so
             // continuous input paints every rendered frame.
+            // The frame must also be for the same time: an animation step or a
+            // `set_time` that queued behind it would otherwise show the older
+            // instant first, and keep showing it if its own render failed.
             let installable = scheduled.generation == self.latest_requested_generation
                 || self.latest_request.as_ref().is_some_and(|latest| {
-                    latest.size_px == scheduled.request.size_px
-                        && latest.scale_bits == scheduled.request.scale_bits
-                        && latest.presentation_mode == scheduled.request.presentation_mode
+                    latest.same_frame_contract(&scheduled.request)
+                        && latest.time_bits == scheduled.request.time_bits
                 });
             Some(same_incarnation && not_superseded && installable)
         }
@@ -923,6 +952,9 @@ mod platform_impl {
         primary: PrimaryFrame,
         overlay_image: Option<Arc<RenderImage>>,
         preview: Option<PanPreview>,
+        /// Painted whole underneath the previewed plot area: the drag anchor's
+        /// frame, whose margins and axes stay put for the whole drag.
+        axes: Option<PrimaryFrame>,
     }
 
     #[cfg(all(feature = "gpu", target_os = "macos"))]
@@ -955,6 +987,7 @@ mod platform_impl {
         scheduler: RenderScheduler,
         in_flight_render: Option<Task<()>>,
         last_render_started: Option<Instant>,
+        pan_anchor: Option<PanAnchor>,
         raster_wakeup: Option<Task<()>>,
         failed_request: Option<RenderRequest>,
         last_error: Option<PlottingError>,
@@ -1017,6 +1050,7 @@ mod platform_impl {
                 scheduler: RenderScheduler::default(),
                 in_flight_render: None,
                 last_render_started: None,
+                pan_anchor: None,
                 raster_wakeup: None,
                 failed_request: None,
                 last_error: None,
@@ -1461,12 +1495,18 @@ mod platform_impl {
                         let fitted_bounds = image_fit
                             .into_gpui()
                             .get_bounds(bounds, primary_size(&image.primary));
-                        paint_primary(window, fitted_bounds, &image.primary);
+                        // During a pan drag the anchor frame supplies the margins
+                        // and axes; otherwise the frame paints itself whole.
+                        paint_primary(
+                            window,
+                            fitted_bounds,
+                            image.axes.as_ref().unwrap_or(&image.primary),
+                        );
                         if let Some(preview) = image.preview {
                             // A pan is pending a raster: repaint the plot area of
-                            // the stale frame shifted to where the pending view
-                            // puts it. Margins and axes keep the frame's own
-                            // placement until the raster lands.
+                            // the content frame shifted to where the pending view
+                            // puts it, clipped to the plot area of the frame
+                            // whose axes are showing.
                             let shifted = Bounds::new(
                                 fitted_bounds.origin + preview.offset,
                                 fitted_bounds.size,
@@ -1664,6 +1704,31 @@ mod platform_impl {
         content_bounds: Bounds<Pixels>,
         frame_size_px: (u32, u32),
     ) -> Option<PanPreview> {
+        preview_translation_onto(
+            view,
+            pending,
+            view.plot_area,
+            view.axis_inset_px,
+            content_bounds,
+            frame_size_px,
+            false,
+        )
+    }
+
+    /// Like [`preview_translation`], but the content is clipped to
+    /// `anchor_plot_area` (the plot area of the frame whose axes are showing)
+    /// and shifted so the frame's own plot area lands on it. With
+    /// `allow_identity` a preview is produced even when nothing moves, so a
+    /// drag anchor keeps painting its axes over a fresh raster.
+    fn preview_translation_onto(
+        view: &FrameView,
+        pending: ViewportRect,
+        anchor_plot_area: ViewportRect,
+        axis_inset_px: f64,
+        content_bounds: Bounds<Pixels>,
+        frame_size_px: (u32, u32),
+        allow_identity: bool,
+    ) -> Option<PanPreview> {
         let shown = view.visible;
         let nx0 = view
             .x_scale
@@ -1692,9 +1757,10 @@ mod platform_impl {
         // A view whose left edge sits `nx0` of the way across the frame is
         // shown by sliding the frame left by that much; the y axis grows
         // upward in data and downward in pixels, so its sign flips.
-        let shift_x = -nx0 * plot_w;
-        let shift_y = ny0 * plot_h;
-        if shift_x.abs() < 0.01 && shift_y.abs() < 0.01 {
+        // Land this frame's plot area on the anchor's before applying the pan.
+        let shift_x = -nx0 * plot_w + (anchor_plot_area.min.x - view.plot_area.min.x);
+        let shift_y = ny0 * plot_h + (anchor_plot_area.min.y - view.plot_area.min.y);
+        if !allow_identity && shift_x.abs() < 0.01 && shift_y.abs() < 0.01 {
             return None;
         }
         let scale_x = f64::from(content_bounds.size.width) / f64::from(frame_size_px.0.max(1));
@@ -1703,12 +1769,29 @@ mod platform_impl {
             px((shift_x * scale_x) as f32),
             px((shift_y * scale_y) as f32),
         );
+        // The spine and inward ticks along the plot-area edge belong to the
+        // axes: keep them out of the mask so they never slide with the data.
+        // The mask is also clipped to where the shifted frame's own plot area
+        // lands, so its margins (labels, spine) never show through.
+        let inset = axis_inset_px.max(0.0);
+        let dest_min_x = anchor_plot_area.min.x + inset;
+        let dest_min_y = anchor_plot_area.min.y + inset;
+        let dest_max_x = anchor_plot_area.max.x - inset;
+        let dest_max_y = anchor_plot_area.max.y - inset;
+        let src_min_x = view.plot_area.min.x + inset + shift_x;
+        let src_min_y = view.plot_area.min.y + inset + shift_y;
+        let src_max_x = view.plot_area.max.x - inset + shift_x;
+        let src_max_y = view.plot_area.max.y - inset + shift_y;
+        let min_x = dest_min_x.max(src_min_x);
+        let min_y = dest_min_y.max(src_min_y);
+        let mask_w = (dest_max_x.min(src_max_x) - min_x).max(0.0);
+        let mask_h = (dest_max_y.min(src_max_y) - min_y).max(0.0);
         let mask = Bounds::new(
             point(
-                content_bounds.origin.x + px((view.plot_area.min.x * scale_x) as f32),
-                content_bounds.origin.y + px((view.plot_area.min.y * scale_y) as f32),
+                content_bounds.origin.x + px((min_x * scale_x) as f32),
+                content_bounds.origin.y + px((min_y * scale_y) as f32),
             ),
-            size(px((plot_w * scale_x) as f32), px((plot_h * scale_y) as f32)),
+            size(px((mask_w * scale_x) as f32), px((mask_h * scale_y) as f32)),
         );
         Some(PanPreview { offset, mask })
     }
@@ -1720,6 +1803,7 @@ mod platform_impl {
         Some(FrameView {
             visible: snapshot.visible_bounds,
             plot_area: snapshot.plot_area,
+            axis_inset_px: f64::from(session.axis_inset_px().unwrap_or(0.0)),
             x_scale: scales.x_scale,
             y_scale: scales.y_scale,
         })
@@ -2012,6 +2096,7 @@ mod platform_impl {
                 scheduler: RenderScheduler::default(),
                 in_flight_render: None,
                 last_render_started: None,
+                pan_anchor: None,
                 raster_wakeup: None,
                 failed_request: None,
                 last_error: None,
@@ -3757,6 +3842,7 @@ mod platform_impl {
                 scheduler: RenderScheduler::default(),
                 in_flight_render: None,
                 last_render_started: None,
+                pan_anchor: None,
                 raster_wakeup: None,
                 failed_request: None,
                 last_error: None,
@@ -4043,6 +4129,7 @@ mod platform_impl {
                 scheduler: RenderScheduler::default(),
                 in_flight_render: None,
                 last_render_started: None,
+                pan_anchor: None,
                 raster_wakeup: None,
                 failed_request: None,
                 last_error: None,
@@ -4495,6 +4582,7 @@ mod platform_impl {
 
         fn unit_frame_view() -> FrameView {
             FrameView {
+                axis_inset_px: 0.0,
                 visible: ViewportRect::from_points(
                     ViewportPoint::new(0.0, 0.0),
                     ViewportPoint::new(1.0, 1.0),
@@ -4523,16 +4611,19 @@ mod platform_impl {
                 .expect("a pure pan previews");
             assert!((f64::from(preview.offset.x) - 10.0).abs() < 1e-4);
             assert!((f64::from(preview.offset.y) - 20.0).abs() < 1e-4);
-            assert_window_points_close(preview.mask.origin, point(px(30.0), px(40.0)));
-            assert!((f64::from(preview.mask.size.width) - 100.0).abs() < 1e-4);
-            assert!((f64::from(preview.mask.size.height) - 100.0).abs() < 1e-4);
+            // The mask is the plot area intersected with where the shifted
+            // frame's plot area lands: the strip the pan uncovers is left to
+            // the frame underneath instead of showing the shifted margins.
+            assert_window_points_close(preview.mask.origin, point(px(40.0), px(60.0)));
+            assert!((f64::from(preview.mask.size.width) - 90.0).abs() < 1e-4);
+            assert!((f64::from(preview.mask.size.height) - 80.0).abs() < 1e-4);
 
             // Logical pixels scale with the fitted content bounds.
             let half = Bounds::new(point(px(0.0), px(0.0)), size(px(150.0), px(150.0)));
             let preview = preview_translation(&view, pending, half, (300, 300))
                 .expect("a pure pan previews at any fit");
             assert!((f64::from(preview.offset.x) - 5.0).abs() < 1e-4);
-            assert!((f64::from(preview.mask.size.width) - 50.0).abs() < 1e-4);
+            assert!((f64::from(preview.mask.size.width) - 45.0).abs() < 1e-4);
         }
 
         #[test]
@@ -4581,8 +4672,13 @@ mod platform_impl {
                         .expect("a pending pan previews on the cached frame");
                     assert!((f64::from(preview.offset.x) - 12.0).abs() < 1e-3);
                     assert!((f64::from(preview.offset.y) + 7.0).abs() < 1e-3);
+                    // The mask covers the plot area minus the axis band on each
+                    // side and minus the strip the pan uncovered.
                     let plot_w = frame_view.plot_area.max.x - frame_view.plot_area.min.x;
-                    assert!((f64::from(preview.mask.size.width) - plot_w).abs() < 1e-3);
+                    let inset = 2.0 * frame_view.axis_inset_px;
+                    assert!(
+                        (f64::from(preview.mask.size.width) - (plot_w - inset - 12.0)).abs() < 1e-3
+                    );
 
                     // The raster of the pending view replaces the preview exactly.
                     let request = view.cached_frame.as_ref().expect("cached").request.clone();
@@ -4600,8 +4696,8 @@ mod platform_impl {
         fn test_render_scheduler_installs_in_flight_frame_when_newer_request_is_queued() {
             let mut scheduler = RenderScheduler::default();
             let first = RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid);
-            let same_contract = RenderRequest::new((320, 240), 1.0, 1.0, PresentationMode::Hybrid);
-            let resized = RenderRequest::new((640, 480), 1.0, 2.0, PresentationMode::Hybrid);
+            let same_contract = RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid);
+            let resized = RenderRequest::new((640, 480), 1.0, 0.0, PresentationMode::Hybrid);
 
             let scheduled = scheduler.schedule(first).expect("starts");
             scheduler.start(scheduled.clone());
@@ -4614,6 +4710,217 @@ mod platform_impl {
             assert!(scheduler.schedule(resized).is_none());
             // A resize queued behind it: the stale-size frame is not installed.
             assert_eq!(scheduler.finish(&queued), Some(false));
+        }
+
+        /// Whether two primaries are the same GPU resource.
+        fn same_primary(a: &PrimaryFrame, b: &PrimaryFrame) -> bool {
+            match (a, b) {
+                (PrimaryFrame::Image(a), PrimaryFrame::Image(b)) => Arc::ptr_eq(a, b),
+                #[cfg(all(feature = "gpu", target_os = "macos"))]
+                (PrimaryFrame::Surface(a), PrimaryFrame::Surface(b)) => {
+                    a.as_CFTypeRef() == b.as_CFTypeRef()
+                }
+                #[cfg(all(feature = "gpu", target_os = "macos"))]
+                _ => false,
+            }
+        }
+
+        #[test]
+        fn test_render_scheduler_declines_in_flight_frame_from_an_older_time() {
+            let mut scheduler = RenderScheduler::default();
+            let at_zero = RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid);
+            let at_one = RenderRequest::new((320, 240), 1.0, 1.0, PresentationMode::Hybrid);
+
+            let scheduled = scheduler.schedule(at_zero).expect("starts");
+            scheduler.start(scheduled.clone());
+            assert!(scheduler.schedule(at_one).is_none());
+            // Same geometry but an older instant: showing it would step the
+            // animation backwards, and keep it there if the newer render failed.
+            assert_eq!(scheduler.finish(&scheduled), Some(false));
+        }
+
+        #[test]
+        fn test_render_scheduler_rollover_clears_install_floor() {
+            let mut scheduler = RenderScheduler {
+                latest_requested_generation: u64::MAX - 1,
+                ..RenderScheduler::default()
+            };
+            // Superseding at the top of the range raises the floor to u64::MAX.
+            scheduler.supersede_in_flight();
+            assert_eq!(scheduler.install_floor, u64::MAX);
+
+            // The next request rolls the generation over; without clearing the
+            // floor every post-rollover frame would compare as superseded.
+            let request = RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid);
+            let scheduled = scheduler.schedule(request).expect("starts");
+            assert_eq!(scheduled.generation, 1);
+            assert_eq!(scheduler.install_floor, 0);
+            scheduler.start(scheduled.clone());
+            assert_eq!(scheduler.finish(&scheduled), Some(true));
+        }
+
+        #[test]
+        fn test_pending_render_keeps_pointer_state_only_for_the_same_frame_contract() {
+            let component_bounds =
+                Bounds::new(point(px(20.0), px(30.0)), size(px(300.0), px(300.0)));
+            let plot: Plot = Plot::new()
+                .line(&[0.0, 1.0], &[0.0, 1.0])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let (cx, view) = mapped_test_view(
+                plot,
+                RuvizPlotOptions::default(),
+                (300, 300),
+                1.0,
+                component_bounds,
+            );
+            cx.update(|app| {
+                view.update(app, |view, cx| {
+                    let drag = ActiveDrag::LeftPan {
+                        anchor_px: ViewportPoint::new(10.0, 10.0),
+                        anchor_window: point(px(30.0), px(40.0)),
+                        last_px: ViewportPoint::new(10.0, 10.0),
+                        crossed_threshold: true,
+                        click_eligible: false,
+                    };
+                    let cached_request =
+                        view.cached_frame.as_ref().expect("cached").request.clone();
+                    // The session moved past the cached frame (a render of ours
+                    // is pending) — the pointer state survives when the pending
+                    // frame keeps the geometry...
+                    view.cached_frame.as_mut().expect("cached").base_generation = u64::MAX;
+                    view.interaction_state.active_drag = drag;
+                    view.scheduler.in_flight = Some(ScheduledRender {
+                        scheduler_incarnation: Arc::clone(&view.scheduler.scheduler_incarnation),
+                        generation: 1,
+                        request: cached_request.clone(),
+                    });
+                    assert!(view.pointer_base_generation_is_current(cx));
+                    assert_eq!(view.interaction_state.active_drag, drag);
+
+                    // ...and is reset when a resize is what is pending.
+                    view.scheduler.in_flight = Some(ScheduledRender {
+                        scheduler_incarnation: Arc::clone(&view.scheduler.scheduler_incarnation),
+                        generation: 2,
+                        request: RenderRequest::new((600, 600), 1.0, 0.0, PresentationMode::Hybrid),
+                    });
+                    assert!(!view.pointer_base_generation_is_current(cx));
+                    assert_eq!(view.interaction_state.active_drag, ActiveDrag::None);
+                });
+            });
+        }
+
+        #[test]
+        fn test_pan_anchor_keeps_axes_until_the_final_raster_shows_the_view() {
+            let component_bounds =
+                Bounds::new(point(px(20.0), px(30.0)), size(px(300.0), px(300.0)));
+            let plot: Plot = Plot::new()
+                .line(&[0.0, 1.0], &[0.0, 1.0])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let (cx, view) = mapped_test_view(
+                plot,
+                RuvizPlotOptions::default(),
+                (300, 300),
+                1.0,
+                component_bounds,
+            );
+            cx.update(|app| {
+                view.update(app, |view, cx| {
+                    let frame_view = frame_view_from_session(&view.session)
+                        .expect("a rendered session has a view");
+                    view.cached_frame
+                        .as_mut()
+                        .expect("mapped view has a cached frame")
+                        .view = Some(frame_view.clone());
+                    let anchor_primary_is = |view: &RuvizPlot, primary: &PrimaryFrame| {
+                        view.pan_anchor
+                            .as_ref()
+                            .is_some_and(|anchor| same_primary(&anchor.primary, primary))
+                    };
+
+                    // No drag: no anchor, the frame paints itself.
+                    view.update_pan_anchor(cx);
+                    assert!(view.pan_anchor.is_none());
+                    assert!(view.pan_paint().expect("frame").axes.is_none());
+
+                    // The pan crosses its threshold: the frame on screen becomes
+                    // the anchor and supplies the axes.
+                    view.interaction_state.active_drag = ActiveDrag::LeftPan {
+                        anchor_px: ViewportPoint::new(10.0, 10.0),
+                        anchor_window: point(px(30.0), px(40.0)),
+                        last_px: ViewportPoint::new(10.0, 10.0),
+                        crossed_threshold: true,
+                        click_eligible: false,
+                    };
+                    view.update_pan_anchor(cx);
+                    let anchor_primary =
+                        view.cached_frame.as_ref().expect("cached").primary.clone();
+                    assert!(anchor_primary_is(view, &anchor_primary));
+
+                    view.session.apply_input(PlotInputEvent::Pan {
+                        delta_px: ViewportPoint::new(12.0, -7.0),
+                    });
+                    let paint = view.pan_paint().expect("frame");
+                    assert!(
+                        paint.axes.is_some(),
+                        "the anchor's axes show during the drag"
+                    );
+                    let preview = paint.preview.expect("the pan previews");
+                    assert!((f64::from(preview.offset.x) - 12.0).abs() < 1e-3);
+                    assert!((f64::from(preview.offset.y) + 7.0).abs() < 1e-3);
+
+                    // A throttled raster of the pending view lands mid-drag: it
+                    // supplies the content, the anchor still supplies the axes,
+                    // and the content does not move.
+                    let request = view.cached_frame.as_ref().expect("cached").request.clone();
+                    let frame = render_frame_from_session(view.session.clone(), request.clone())
+                        .expect("render succeeds");
+                    view.replace_cached_frame(request, frame);
+                    view.update_layout(component_bounds, (300, 300));
+                    view.update_pan_anchor(cx);
+                    assert!(
+                        anchor_primary_is(view, &anchor_primary),
+                        "the anchor is kept"
+                    );
+                    let paint = view.pan_paint().expect("frame");
+                    assert!(paint.axes.is_some());
+                    let preview = paint.preview.expect("identity preview under the anchor");
+                    assert!(f64::from(preview.offset.x).abs() < 1e-3);
+                    assert!(f64::from(preview.offset.y).abs() < 1e-3);
+                    // The fresh raster supplies the content when its plot area
+                    // has the anchor's size; if the pan changed the tick label
+                    // widths the anchor's own content stays instead.
+                    let fresh_view = view
+                        .cached_frame
+                        .as_ref()
+                        .and_then(|frame| frame.view.clone())
+                        .expect("frames carry their view");
+                    let anchor_view = view.pan_anchor.as_ref().expect("anchor").view.clone();
+                    let expected: PrimaryFrame = if same_plot_area_size(&fresh_view, &anchor_view) {
+                        view.cached_frame.as_ref().expect("cached").primary.clone()
+                    } else {
+                        anchor_primary.clone()
+                    };
+                    assert!(
+                        same_primary(&paint.primary, &expected),
+                        "content comes from the fresh raster when it fits the anchor's plot area"
+                    );
+                    assert!(
+                        view.retired_images.is_empty(),
+                        "the anchor's image is not retired while it paints"
+                    );
+
+                    // Release: the frame on screen shows the pending view, so
+                    // the anchor is dropped and its image retired.
+                    view.reset_pointer_state();
+                    view.update_pan_anchor(cx);
+                    assert!(view.pan_anchor.is_none());
+                    assert!(view.pan_paint().expect("frame").axes.is_none());
+                });
+            });
         }
 
         #[test]

--- a/adapters/gpui/src/lib.rs
+++ b/adapters/gpui/src/lib.rs
@@ -99,12 +99,14 @@ mod platform_impl {
         executor::block_on,
     };
     use gpui::{
-        AnyElement, App, Bounds, Context, Corners, Entity, FocusHandle, Focusable,
+        AnyElement, App, Bounds, ContentMask, Context, Corners, Entity, FocusHandle, Focusable,
         InteractiveElement, IntoElement, KeyDownEvent, MouseButton, MouseDownEvent, MouseMoveEvent,
         MouseUpEvent, ObjectFit, Pixels, Point, Render, RenderImage, ScrollDelta, ScrollWheelEvent,
         Task, Window, canvas, div, point, prelude::*, px, rgb, rgba, size,
     };
     use image::{Frame, ImageBuffer, Rgba};
+    #[cfg(all(feature = "gpu", target_os = "macos"))]
+    use ruviz::core::RenderedLayer;
     use ruviz::{
         axes::AxisScale,
         core::plot::Image as RuvizImage,
@@ -136,6 +138,10 @@ mod platform_impl {
     pub use ruviz;
 
     const DRAG_THRESHOLD_PX: f64 = 3.0;
+    /// Minimum spacing between base rasters while a pan drag is active. The
+    /// cached frame is translated on the GPU between rasters, so input stays
+    /// at display rate no matter how long a raster takes.
+    const PAN_RASTER_INTERVAL: Duration = Duration::from_millis(32);
     const LINE_SCROLL_DELTA_PX: f32 = 50.0;
     const MENU_MIN_WIDTH_PX: f32 = 220.0;
     const MENU_ITEM_HEIGHT_PX: f32 = 30.0;
@@ -547,7 +553,28 @@ mod platform_impl {
     enum RenderedPrimary {
         Image(Arc<RenderImage>),
         #[cfg(all(feature = "gpu", target_os = "macos"))]
-        Surface(Arc<RuvizImage>),
+        Surface(RenderedLayer),
+    }
+
+    /// The view a rendered frame shows: its visible data bounds, the plot
+    /// area inside the frame (frame pixels), and the axis scales that map
+    /// between the two. Lets the adapter place a stale frame under a newer
+    /// pending view without waiting for a raster.
+    #[derive(Clone, Debug, PartialEq)]
+    struct FrameView {
+        visible: ViewportRect,
+        plot_area: ViewportRect,
+        x_scale: AxisScale,
+        y_scale: AxisScale,
+    }
+
+    /// GPU-side placement of the cached frame under a pending pan: the plot
+    /// area is repainted at `offset`, clipped to `mask` (window coordinates),
+    /// while the margins and axes stay where the frame drew them.
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    struct PanPreview {
+        offset: Point<Pixels>,
+        mask: Bounds<Pixels>,
     }
 
     #[derive(Clone)]
@@ -558,6 +585,7 @@ mod platform_impl {
         overlay_image: Option<Arc<RenderImage>>,
         stats: FrameStats,
         target: RenderTargetKind,
+        view: Option<FrameView>,
     }
 
     struct RenderedFrame {
@@ -566,6 +594,7 @@ mod platform_impl {
         overlay: RenderedOverlay,
         stats: FrameStats,
         target: RenderTargetKind,
+        view: Option<FrameView>,
     }
 
     enum RenderedOverlay {
@@ -893,6 +922,7 @@ mod platform_impl {
     struct PaintFrame {
         primary: PrimaryFrame,
         overlay_image: Option<Arc<RenderImage>>,
+        preview: Option<PanPreview>,
     }
 
     #[cfg(all(feature = "gpu", target_os = "macos"))]
@@ -924,6 +954,8 @@ mod platform_impl {
         surface_upload: SurfaceUploadState,
         scheduler: RenderScheduler,
         in_flight_render: Option<Task<()>>,
+        last_render_started: Option<Instant>,
+        raster_wakeup: Option<Task<()>>,
         failed_request: Option<RenderRequest>,
         last_error: Option<PlottingError>,
         last_layout: Option<InteractionLayout>,
@@ -984,6 +1016,8 @@ mod platform_impl {
                 surface_upload: SurfaceUploadState::default(),
                 scheduler: RenderScheduler::default(),
                 in_flight_render: None,
+                last_render_started: None,
+                raster_wakeup: None,
                 failed_request: None,
                 last_error: None,
                 last_layout: None,
@@ -1421,56 +1455,38 @@ mod platform_impl {
                             .lock()
                             .expect("RuvizPlot presentation clock lock poisoned")
                             .record_now();
-                        if let Some(image) = image {
-                            let fitted_bounds = match image.primary {
-                                PrimaryFrame::Image(primary_image) => {
-                                    let image_size = primary_image.size(0);
-                                    let fitted_bounds =
-                                        image_fit.into_gpui().get_bounds(bounds, image_size);
-                                    let _ = window.paint_image(
-                                        fitted_bounds,
-                                        Corners::default(),
-                                        primary_image,
-                                        0,
-                                        false,
-                                    );
-                                    fitted_bounds
-                                }
-                                #[cfg(all(feature = "gpu", target_os = "macos"))]
-                                PrimaryFrame::Surface(surface) => {
-                                    let image_size = size(
-                                        surface.get_width().into(),
-                                        surface.get_height().into(),
-                                    );
-                                    let fitted_bounds =
-                                        image_fit.into_gpui().get_bounds(bounds, image_size);
-                                    // `gpui` 0.2.2 from crates.io uses core-video
-                                    // 0.4, while the workspace GPUI patch uses
-                                    // core-video 0.5 like this crate. Both wrappers
-                                    // own the same Core Foundation object, but their
-                                    // Rust types are intentionally distinct. Borrow
-                                    // the raw CF object under the get rule so GPUI's
-                                    // inferred wrapper receives its own retain; the
-                                    // ruviz wrapper can then drop independently.
-                                    // SAFETY: both wrapper versions use the same
-                                    // non-null CVPixelBufferRef ABI, and the get rule
-                                    // balances the target wrapper's eventual release.
-                                    let gpui_surface = unsafe {
-                                        TCFType::wrap_under_get_rule(surface.as_CFTypeRef() as _)
-                                    };
-                                    window.paint_surface(fitted_bounds, gpui_surface);
-                                    fitted_bounds
-                                }
-                            };
-                            if let Some(overlay_image) = image.overlay_image {
-                                let _ = window.paint_image(
-                                    fitted_bounds,
-                                    Corners::default(),
-                                    overlay_image,
-                                    0,
-                                    false,
-                                );
-                            }
+                        let Some(image) = image else {
+                            return;
+                        };
+                        let fitted_bounds = image_fit
+                            .into_gpui()
+                            .get_bounds(bounds, primary_size(&image.primary));
+                        paint_primary(window, fitted_bounds, &image.primary);
+                        if let Some(preview) = image.preview {
+                            // A pan is pending a raster: repaint the plot area of
+                            // the stale frame shifted to where the pending view
+                            // puts it. Margins and axes keep the frame's own
+                            // placement until the raster lands.
+                            let shifted = Bounds::new(
+                                fitted_bounds.origin + preview.offset,
+                                fitted_bounds.size,
+                            );
+                            window.with_content_mask(
+                                Some(ContentMask {
+                                    bounds: preview.mask,
+                                }),
+                                |window| paint_primary(window, shifted, &image.primary),
+                            );
+                            return;
+                        }
+                        if let Some(overlay_image) = image.overlay_image {
+                            let _ = window.paint_image(
+                                fitted_bounds,
+                                Corners::default(),
+                                overlay_image,
+                                0,
+                                false,
+                            );
                         }
                     }
                 },
@@ -1602,6 +1618,113 @@ mod platform_impl {
         }
     }
 
+    fn primary_size(primary: &PrimaryFrame) -> gpui::Size<gpui::DevicePixels> {
+        match primary {
+            PrimaryFrame::Image(image) => image.size(0),
+            #[cfg(all(feature = "gpu", target_os = "macos"))]
+            PrimaryFrame::Surface(surface) => {
+                size(surface.get_width().into(), surface.get_height().into())
+            }
+        }
+    }
+
+    fn paint_primary(window: &mut Window, bounds: Bounds<Pixels>, primary: &PrimaryFrame) {
+        match primary {
+            PrimaryFrame::Image(image) => {
+                let _ = window.paint_image(bounds, Corners::default(), Arc::clone(image), 0, false);
+            }
+            #[cfg(all(feature = "gpu", target_os = "macos"))]
+            PrimaryFrame::Surface(surface) => {
+                // `gpui` 0.2.2 from crates.io uses core-video 0.4, while the
+                // workspace GPUI patch uses core-video 0.5 like this crate.
+                // Both wrappers own the same Core Foundation object, but their
+                // Rust types are intentionally distinct. Borrow the raw CF
+                // object under the get rule so GPUI's inferred wrapper receives
+                // its own retain; the ruviz wrapper can then drop independently.
+                // SAFETY: both wrapper versions use the same non-null
+                // CVPixelBufferRef ABI, and the get rule balances the target
+                // wrapper's eventual release.
+                let gpui_surface =
+                    unsafe { TCFType::wrap_under_get_rule(surface.as_CFTypeRef() as _) };
+                window.paint_surface(bounds, gpui_surface);
+            }
+        }
+    }
+
+    /// Where the cached frame's plot area must be drawn so that it shows
+    /// `pending` — the session's current view — using nothing but a translation.
+    ///
+    /// Returns `None` when the two views differ by more than a pan (a zoom
+    /// changes the span, and a translated raster would lie about the axes),
+    /// when the shift is under a hundredth of a frame pixel, or when either
+    /// bound is outside the frame's axis scale.
+    fn preview_translation(
+        view: &FrameView,
+        pending: ViewportRect,
+        content_bounds: Bounds<Pixels>,
+        frame_size_px: (u32, u32),
+    ) -> Option<PanPreview> {
+        let shown = view.visible;
+        let nx0 = view
+            .x_scale
+            .normalized_position(pending.min.x, shown.min.x, shown.max.x);
+        let nx1 = view
+            .x_scale
+            .normalized_position(pending.max.x, shown.min.x, shown.max.x);
+        let ny0 = view
+            .y_scale
+            .normalized_position(pending.min.y, shown.min.y, shown.max.y);
+        let ny1 = view
+            .y_scale
+            .normalized_position(pending.max.y, shown.min.y, shown.max.y);
+        if ![nx0, nx1, ny0, ny1].iter().all(|v| v.is_finite()) {
+            return None;
+        }
+        const SPAN_TOLERANCE: f64 = 1e-6;
+        if (nx1 - nx0 - 1.0).abs() > SPAN_TOLERANCE || (ny1 - ny0 - 1.0).abs() > SPAN_TOLERANCE {
+            return None;
+        }
+        let plot_w = view.plot_area.max.x - view.plot_area.min.x;
+        let plot_h = view.plot_area.max.y - view.plot_area.min.y;
+        if plot_w <= 0.0 || plot_h <= 0.0 {
+            return None;
+        }
+        // A view whose left edge sits `nx0` of the way across the frame is
+        // shown by sliding the frame left by that much; the y axis grows
+        // upward in data and downward in pixels, so its sign flips.
+        let shift_x = -nx0 * plot_w;
+        let shift_y = ny0 * plot_h;
+        if shift_x.abs() < 0.01 && shift_y.abs() < 0.01 {
+            return None;
+        }
+        let scale_x = f64::from(content_bounds.size.width) / f64::from(frame_size_px.0.max(1));
+        let scale_y = f64::from(content_bounds.size.height) / f64::from(frame_size_px.1.max(1));
+        let offset = point(
+            px((shift_x * scale_x) as f32),
+            px((shift_y * scale_y) as f32),
+        );
+        let mask = Bounds::new(
+            point(
+                content_bounds.origin.x + px((view.plot_area.min.x * scale_x) as f32),
+                content_bounds.origin.y + px((view.plot_area.min.y * scale_y) as f32),
+            ),
+            size(px((plot_w * scale_x) as f32), px((plot_h * scale_y) as f32)),
+        );
+        Some(PanPreview { offset, mask })
+    }
+
+    /// The view of the frame the session just rendered.
+    fn frame_view_from_session(session: &InteractivePlotSession) -> Option<FrameView> {
+        let snapshot = session.viewport_snapshot().ok()?;
+        let scales = session.view_bounds_snapshot();
+        Some(FrameView {
+            visible: snapshot.visible_bounds,
+            plot_area: snapshot.plot_area,
+            x_scale: scales.x_scale,
+            y_scale: scales.y_scale,
+        })
+    }
+
     impl Focusable for RuvizPlot {
         fn focus_handle(&self, _: &App) -> FocusHandle {
             self.focus_handle.clone()
@@ -1698,6 +1821,7 @@ mod platform_impl {
                         overlay_image: None,
                         stats: frame.stats,
                         target: frame.target,
+                        view: None,
                     });
                     view.update_layout(component_bounds, frame_size_px);
                     view
@@ -1880,12 +2004,15 @@ mod platform_impl {
                     overlay_image: Some(render_image_from_ruviz(overlay)),
                     stats: FrameStats::default(),
                     target: RenderTargetKind::Surface,
+                    view: None,
                 }),
                 retired_images: Vec::new(),
                 #[cfg(all(feature = "gpu", target_os = "macos"))]
                 surface_upload: SurfaceUploadState::default(),
                 scheduler: RenderScheduler::default(),
                 in_flight_render: None,
+                last_render_started: None,
+                raster_wakeup: None,
                 failed_request: None,
                 last_error: None,
                 last_layout: None,
@@ -2920,6 +3047,7 @@ mod platform_impl {
                         overlay_image: None,
                         stats: FrameStats::default(),
                         target: RenderTargetKind::Surface,
+                        view: None,
                     });
                     view.scheduler.latest_requested_generation = 7;
                     view.scheduler.in_flight = Some(ScheduledRender {
@@ -3612,6 +3740,7 @@ mod platform_impl {
                 overlay_image: None,
                 stats: FrameStats::default(),
                 target: RenderTargetKind::Surface,
+                view: None,
             };
             let mut view = RuvizPlot {
                 session: initial_session,
@@ -3627,6 +3756,8 @@ mod platform_impl {
                 surface_upload: SurfaceUploadState::default(),
                 scheduler: RenderScheduler::default(),
                 in_flight_render: None,
+                last_render_started: None,
+                raster_wakeup: None,
                 failed_request: None,
                 last_error: None,
                 last_layout: Some(InteractionLayout {
@@ -3911,6 +4042,8 @@ mod platform_impl {
                 surface_upload: SurfaceUploadState::default(),
                 scheduler: RenderScheduler::default(),
                 in_flight_render: None,
+                last_render_started: None,
+                raster_wakeup: None,
                 failed_request: None,
                 last_error: None,
                 last_layout: None,
@@ -4357,6 +4490,109 @@ mod platform_impl {
                         "an external base change with nothing pending resets the drag"
                     );
                 })
+            });
+        }
+
+        fn unit_frame_view() -> FrameView {
+            FrameView {
+                visible: ViewportRect::from_points(
+                    ViewportPoint::new(0.0, 0.0),
+                    ViewportPoint::new(1.0, 1.0),
+                ),
+                plot_area: ViewportRect::from_points(
+                    ViewportPoint::new(10.0, 10.0),
+                    ViewportPoint::new(110.0, 110.0),
+                ),
+                x_scale: AxisScale::Linear,
+                y_scale: AxisScale::Linear,
+            }
+        }
+
+        #[test]
+        fn test_preview_translation_slides_the_plot_area_by_the_pan() {
+            // A pan of (+10, +20) frame px moves the view to x -0.1..0.9 and
+            // y 0.2..1.2 on a 100 px plot area; the frame must slide by the
+            // same pixels, and the mask must cover the plot area only.
+            let view = unit_frame_view();
+            let content_bounds = Bounds::new(point(px(20.0), px(30.0)), size(px(300.0), px(300.0)));
+            let pending = ViewportRect::from_points(
+                ViewportPoint::new(-0.1, 0.2),
+                ViewportPoint::new(0.9, 1.2),
+            );
+            let preview = preview_translation(&view, pending, content_bounds, (300, 300))
+                .expect("a pure pan previews");
+            assert!((f64::from(preview.offset.x) - 10.0).abs() < 1e-4);
+            assert!((f64::from(preview.offset.y) - 20.0).abs() < 1e-4);
+            assert_window_points_close(preview.mask.origin, point(px(30.0), px(40.0)));
+            assert!((f64::from(preview.mask.size.width) - 100.0).abs() < 1e-4);
+            assert!((f64::from(preview.mask.size.height) - 100.0).abs() < 1e-4);
+
+            // Logical pixels scale with the fitted content bounds.
+            let half = Bounds::new(point(px(0.0), px(0.0)), size(px(150.0), px(150.0)));
+            let preview = preview_translation(&view, pending, half, (300, 300))
+                .expect("a pure pan previews at any fit");
+            assert!((f64::from(preview.offset.x) - 5.0).abs() < 1e-4);
+            assert!((f64::from(preview.mask.size.width) - 50.0).abs() < 1e-4);
+        }
+
+        #[test]
+        fn test_preview_translation_declines_zooms_and_identity() {
+            let view = unit_frame_view();
+            let content_bounds = Bounds::new(point(px(0.0), px(0.0)), size(px(300.0), px(300.0)));
+            let zoomed = ViewportRect::from_points(
+                ViewportPoint::new(0.0, 0.0),
+                ViewportPoint::new(0.5, 1.0),
+            );
+            assert!(preview_translation(&view, zoomed, content_bounds, (300, 300)).is_none());
+            assert!(preview_translation(&view, view.visible, content_bounds, (300, 300)).is_none());
+        }
+
+        #[test]
+        fn test_pan_preview_follows_pending_view_until_the_raster_lands() {
+            let component_bounds =
+                Bounds::new(point(px(20.0), px(30.0)), size(px(300.0), px(300.0)));
+            let plot: Plot = Plot::new()
+                .line(&[0.0, 1.0], &[0.0, 1.0])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let (cx, view) = mapped_test_view(
+                plot,
+                RuvizPlotOptions::default(),
+                (300, 300),
+                1.0,
+                component_bounds,
+            );
+            cx.update(|app| {
+                view.update(app, |view, _cx| {
+                    let frame_view = frame_view_from_session(&view.session)
+                        .expect("a rendered session has a view");
+                    view.cached_frame
+                        .as_mut()
+                        .expect("mapped view has a cached frame")
+                        .view = Some(frame_view.clone());
+                    assert!(view.pan_preview().is_none(), "the frame shows the view");
+
+                    view.session.apply_input(PlotInputEvent::Pan {
+                        delta_px: ViewportPoint::new(12.0, -7.0),
+                    });
+                    let preview = view
+                        .pan_preview()
+                        .expect("a pending pan previews on the cached frame");
+                    assert!((f64::from(preview.offset.x) - 12.0).abs() < 1e-3);
+                    assert!((f64::from(preview.offset.y) + 7.0).abs() < 1e-3);
+                    let plot_w = frame_view.plot_area.max.x - frame_view.plot_area.min.x;
+                    assert!((f64::from(preview.mask.size.width) - plot_w).abs() < 1e-3);
+
+                    // The raster of the pending view replaces the preview exactly.
+                    let request = view.cached_frame.as_ref().expect("cached").request.clone();
+                    let frame = render_frame_from_session(view.session.clone(), request.clone())
+                        .expect("render succeeds");
+                    assert!(frame.view.is_some(), "frames carry their view");
+                    view.replace_cached_frame(request, frame);
+                    view.update_layout(component_bounds, (300, 300));
+                    assert!(view.pan_preview().is_none(), "the new frame shows the view");
+                });
             });
         }
 
@@ -5033,6 +5269,7 @@ mod platform_impl {
                         overlay_image: None,
                         stats: FrameStats::default(),
                         target: RenderTargetKind::Surface,
+                        view: None,
                     });
 
                     let current = view
@@ -5194,6 +5431,7 @@ mod platform_impl {
                 overlay_image: None,
                 stats: FrameStats::default(),
                 target: RenderTargetKind::Surface,
+                view: None,
             };
 
             assert_eq!(
@@ -5203,19 +5441,24 @@ mod platform_impl {
         }
 
         #[cfg(all(feature = "gpu", target_os = "macos"))]
+        fn straight_layer(image: ruviz::core::plot::Image) -> RenderedLayer {
+            RenderedLayer::from_straight_image(Arc::new(image))
+        }
+
+        #[cfg(all(feature = "gpu", target_os = "macos"))]
         #[test]
         fn test_active_backend_reports_fast_path_for_surface_backed_frames() {
             let mut upload = SurfaceUploadState::default();
             let surface = upload
                 .update(
                     None,
-                    &ruviz::core::plot::Image::new(
+                    &straight_layer(ruviz::core::plot::Image::new(
                         2,
                         2,
                         vec![
                             255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255,
                         ],
-                    ),
+                    )),
                 )
                 .expect("surface upload should succeed");
             let frame = CachedFrame {
@@ -5225,6 +5468,7 @@ mod platform_impl {
                 overlay_image: None,
                 stats: FrameStats::default(),
                 target: RenderTargetKind::Surface,
+                view: None,
             };
 
             assert_eq!(
@@ -5240,13 +5484,21 @@ mod platform_impl {
             let first = upload
                 .update(
                     None,
-                    &ruviz::core::plot::Image::new(2, 1, vec![1, 2, 3, 255, 4, 5, 6, 255]),
+                    &straight_layer(ruviz::core::plot::Image::new(
+                        2,
+                        1,
+                        vec![1, 2, 3, 255, 4, 5, 6, 255],
+                    )),
                 )
                 .expect("first surface upload should succeed");
             let reused = upload
                 .update(
                     Some(&first),
-                    &ruviz::core::plot::Image::new(2, 1, vec![10, 20, 30, 255, 40, 50, 60, 255]),
+                    &straight_layer(ruviz::core::plot::Image::new(
+                        2,
+                        1,
+                        vec![10, 20, 30, 255, 40, 50, 60, 255],
+                    )),
                 )
                 .expect("second surface upload should succeed");
 
@@ -5269,13 +5521,13 @@ mod platform_impl {
                 let source = upload
                     .update(
                         None,
-                        &ruviz::core::plot::Image::new(
+                        &straight_layer(ruviz::core::plot::Image::new(
                             2,
                             2,
                             vec![
                                 255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255,
                             ],
-                        ),
+                        )),
                     )
                     .expect("surface upload should succeed");
 

--- a/adapters/gpui/src/lib.rs
+++ b/adapters/gpui/src/lib.rs
@@ -597,6 +597,14 @@ mod platform_impl {
     struct RenderScheduler {
         scheduler_incarnation: Arc<RenderSchedulerIncarnation>,
         latest_requested_generation: u64,
+        /// Generations below this were superseded (session invalidated or
+        /// replaced) and must never be installed, even if they finish.
+        install_floor: u64,
+        /// The most recently scheduled request; an older in-flight frame is
+        /// still installed when it matches this request's frame contract
+        /// (size, scale, presentation), so a drag shows every rendered frame
+        /// instead of only the last one.
+        latest_request: Option<RenderRequest>,
         in_flight: Option<ScheduledRender>,
         queued: Option<ScheduledRender>,
         dropped_frames: u64,
@@ -607,6 +615,8 @@ mod platform_impl {
             Self {
                 scheduler_incarnation: Arc::new(RenderSchedulerIncarnation),
                 latest_requested_generation: 0,
+                install_floor: 0,
+                latest_request: None,
                 in_flight: None,
                 queued: None,
                 dropped_frames: 0,
@@ -627,6 +637,7 @@ mod platform_impl {
 
         fn schedule(&mut self, request: RenderRequest) -> Option<ScheduledRender> {
             let generation = self.advance_generation();
+            self.latest_request = Some(request.clone());
             let scheduled = ScheduledRender {
                 scheduler_incarnation: Arc::clone(&self.scheduler_incarnation),
                 generation,
@@ -652,12 +663,22 @@ mod platform_impl {
                 return None;
             }
             self.in_flight = None;
-            Some(
-                Arc::ptr_eq(
-                    &scheduled.scheduler_incarnation,
-                    &self.scheduler_incarnation,
-                ) && scheduled.generation == self.latest_requested_generation,
-            )
+            let same_incarnation = Arc::ptr_eq(
+                &scheduled.scheduler_incarnation,
+                &self.scheduler_incarnation,
+            );
+            let not_superseded = scheduled.generation >= self.install_floor;
+            // A frame that finished while a newer request is queued is still
+            // newer than what is on screen: install it when its frame contract
+            // matches the latest request (only the session state differs), so
+            // continuous input paints every rendered frame.
+            let installable = scheduled.generation == self.latest_requested_generation
+                || self.latest_request.as_ref().is_some_and(|latest| {
+                    latest.size_px == scheduled.request.size_px
+                        && latest.scale_bits == scheduled.request.scale_bits
+                        && latest.presentation_mode == scheduled.request.presentation_mode
+                });
+            Some(same_incarnation && not_superseded && installable)
         }
 
         fn take_queued(&mut self) -> Option<ScheduledRender> {
@@ -665,7 +686,8 @@ mod platform_impl {
         }
 
         fn supersede_in_flight(&mut self) {
-            self.advance_generation();
+            let floor = self.advance_generation();
+            self.install_floor = floor;
         }
     }
 
@@ -4214,6 +4236,148 @@ mod platform_impl {
                     assert_eq!(events[0].kind, PlotPointerEventKind::Click);
                 })
             });
+        }
+
+        #[test]
+        fn test_pan_survives_own_render_in_flight_past_the_cached_generation() {
+            // A pan schedules a render; the worker publishes the next base
+            // generation before the frame is installed on the UI thread. Pointer
+            // moves in that window must keep panning instead of resetting the
+            // drag (which previously froze every pan after its first move).
+            let component_bounds =
+                Bounds::new(point(px(20.0), px(30.0)), size(px(300.0), px(300.0)));
+            let plot: Plot = Plot::new()
+                .line(&[0.0, 1.0], &[0.0, 1.0])
+                .xlim(0.0, 1.0)
+                .ylim(0.0, 1.0)
+                .into();
+            let (cx, view) = mapped_test_view(
+                plot,
+                RuvizPlotOptions::default(),
+                (300, 300),
+                1.0,
+                component_bounds,
+            );
+            let anchor_window = point(
+                component_bounds.origin.x + component_bounds.size.width * 0.5,
+                component_bounds.origin.y + component_bounds.size.height * 0.5,
+            );
+            cx.update(|app| {
+                view.update(app, |view, cx| {
+                    let anchor_px = view
+                        .local_viewport_point(anchor_window)
+                        .expect("anchor should map into the frame");
+                    view.interaction_state.active_drag = ActiveDrag::LeftPan {
+                        anchor_px,
+                        anchor_window,
+                        last_px: anchor_px,
+                        crossed_threshold: true,
+                        click_eligible: false,
+                    };
+                    let cached_generation = view
+                        .cached_frame
+                        .as_ref()
+                        .expect("mapped view has a cached frame")
+                        .base_generation;
+
+                    // Our own render is in flight and the session has already
+                    // published the next base generation.
+                    let request = view
+                        .cached_frame
+                        .as_ref()
+                        .expect("cached frame")
+                        .request
+                        .clone();
+                    let scheduled = view
+                        .scheduler
+                        .schedule(request.clone())
+                        .expect("nothing in flight yet");
+                    view.scheduler.start(scheduled.clone());
+                    view.session.apply_input(PlotInputEvent::Pan {
+                        delta_px: ViewportPoint::new(10.0, 0.0),
+                    });
+                    let frame = render_frame_from_session(view.session.clone(), request)
+                        .expect("render succeeds");
+                    assert_ne!(
+                        view.session.displayed_frame_generation(),
+                        Some(cached_generation),
+                        "the session must have moved past the cached frame"
+                    );
+                    assert!(
+                        !view.session.dirty_domains().data,
+                        "the render must have cleared the pan's data dirtiness"
+                    );
+
+                    view.handle_mouse_move(
+                        &MouseMoveEvent {
+                            position: point(anchor_window.x + px(40.0), anchor_window.y),
+                            pressed_button: Some(MouseButton::Left),
+                            modifiers: Modifiers::default(),
+                        },
+                        cx,
+                    )
+                    .expect("move succeeds");
+                    assert!(
+                        matches!(
+                            view.interaction_state.active_drag,
+                            ActiveDrag::LeftPan { .. }
+                        ),
+                        "the pan must survive an in-flight render of our own"
+                    );
+                    assert!(
+                        view.session.dirty_domains().data,
+                        "the move must keep panning"
+                    );
+
+                    // The finished frame installs even though it is not the
+                    // latest generation the scheduler handed out.
+                    view.scheduler.schedule(scheduled.request.clone());
+                    assert_eq!(view.scheduler.finish(&scheduled), Some(true));
+                    let _ = frame;
+
+                    // With nothing of ours pending, an externally moved session
+                    // still resets the pointer state.
+                    view.scheduler.take_queued();
+                    view.session.apply_input(PlotInputEvent::Pan {
+                        delta_px: ViewportPoint::new(10.0, 0.0),
+                    });
+                    let request = view.cached_frame.as_ref().expect("cached").request.clone();
+                    let _ = render_frame_from_session(view.session.clone(), request);
+                    view.handle_mouse_move(
+                        &MouseMoveEvent {
+                            position: point(anchor_window.x + px(60.0), anchor_window.y),
+                            pressed_button: Some(MouseButton::Left),
+                            modifiers: Modifiers::default(),
+                        },
+                        cx,
+                    )
+                    .expect("move succeeds");
+                    assert!(
+                        matches!(view.interaction_state.active_drag, ActiveDrag::None),
+                        "an external base change with nothing pending resets the drag"
+                    );
+                })
+            });
+        }
+
+        #[test]
+        fn test_render_scheduler_installs_in_flight_frame_when_newer_request_is_queued() {
+            let mut scheduler = RenderScheduler::default();
+            let first = RenderRequest::new((320, 240), 1.0, 0.0, PresentationMode::Hybrid);
+            let same_contract = RenderRequest::new((320, 240), 1.0, 1.0, PresentationMode::Hybrid);
+            let resized = RenderRequest::new((640, 480), 1.0, 2.0, PresentationMode::Hybrid);
+
+            let scheduled = scheduler.schedule(first).expect("starts");
+            scheduler.start(scheduled.clone());
+            assert!(scheduler.schedule(same_contract).is_none());
+            // Same size/scale/presentation queued: the in-flight frame is still
+            // newer than the screen and installs.
+            assert_eq!(scheduler.finish(&scheduled), Some(true));
+            let queued = scheduler.take_queued().expect("queued");
+            scheduler.start(queued.clone());
+            assert!(scheduler.schedule(resized).is_none());
+            // A resize queued behind it: the stale-size frame is not installed.
+            assert_eq!(scheduler.finish(&queued), Some(false));
         }
 
         #[test]

--- a/adapters/gpui/src/platform_impl/interaction.rs
+++ b/adapters/gpui/src/platform_impl/interaction.rs
@@ -114,7 +114,7 @@ impl RuvizPlot {
         true
     }
 
-    fn pointer_base_generation_is_current(&mut self, cx: &mut Context<Self>) -> bool {
+    pub(super) fn pointer_base_generation_is_current(&mut self, cx: &mut Context<Self>) -> bool {
         let cached_generation = self
             .cached_frame
             .as_ref()
@@ -131,16 +131,38 @@ impl RuvizPlot {
         // so the drag in progress stays valid; resetting it here would cancel
         // every pan after its first move. Only an externally moved session
         // (nothing of ours in flight or queued) invalidates the pointer state.
+        // That only holds while the pending frame keeps the cached frame's
+        // geometry: a resize, scale or presentation change in flight would
+        // make the delta math lie, so the drag is dropped like any other
+        // stale pointer state.
         let own_render_pending = cached_generation.is_some()
-            && (self.in_flight_render.is_some()
-                || self.scheduler.in_flight.is_some()
-                || self.scheduler.queued.is_some());
+            && self
+                .cached_frame
+                .as_ref()
+                .is_some_and(|frame| self.pending_renders_keep_frame_contract(&frame.request));
         if own_render_pending {
             return true;
         }
         self.reset_pointer_state();
         cx.notify();
         false
+    }
+
+    /// Whether every render in flight or queued was requested for the same
+    /// frame geometry as `request` (and at least one is pending).
+    fn pending_renders_keep_frame_contract(&self, request: &RenderRequest) -> bool {
+        let pending = [
+            self.scheduler.in_flight.as_ref(),
+            self.scheduler.queued.as_ref(),
+        ];
+        let mut any = false;
+        for scheduled in pending.into_iter().flatten() {
+            any = true;
+            if !scheduled.request.same_frame_contract(request) {
+                return false;
+            }
+        }
+        any
     }
 
     fn emit_plot_click(

--- a/adapters/gpui/src/platform_impl/interaction.rs
+++ b/adapters/gpui/src/platform_impl/interaction.rs
@@ -115,14 +115,32 @@ impl RuvizPlot {
     }
 
     fn pointer_base_generation_is_current(&mut self, cx: &mut Context<Self>) -> bool {
-        let is_current = self.cached_frame.as_ref().is_some_and(|frame| {
-            self.session.displayed_frame_generation() == Some(frame.base_generation)
-        });
-        if !is_current {
-            self.reset_pointer_state();
-            cx.notify();
+        let cached_generation = self
+            .cached_frame
+            .as_ref()
+            .map(|frame| frame.base_generation);
+        let is_current = cached_generation.is_some()
+            && self.session.displayed_frame_generation() == cached_generation;
+        if is_current {
+            return true;
         }
-        is_current
+        // The session moved past the cached frame because this view's own
+        // render pipeline is producing the next one (a pan, zoom, hover or
+        // reactive data change scheduled a render that has not been installed
+        // yet). Pointer math is delta based and the frame size is unchanged,
+        // so the drag in progress stays valid; resetting it here would cancel
+        // every pan after its first move. Only an externally moved session
+        // (nothing of ours in flight or queued) invalidates the pointer state.
+        let own_render_pending = cached_generation.is_some()
+            && (self.in_flight_render.is_some()
+                || self.scheduler.in_flight.is_some()
+                || self.scheduler.queued.is_some());
+        if own_render_pending {
+            return true;
+        }
+        self.reset_pointer_state();
+        cx.notify();
+        false
     }
 
     fn emit_plot_click(

--- a/adapters/gpui/src/platform_impl/interaction.rs
+++ b/adapters/gpui/src/platform_impl/interaction.rs
@@ -924,7 +924,13 @@ impl RuvizPlot {
             self.emit_plot_click(event.position, cx)?;
         }
 
+        let pan_ended = self.pan_drag_active();
         self.reset_pointer_state();
+        if pan_ended {
+            // The final raster after a throttled pan must not wait for the
+            // next pointer move.
+            cx.notify();
+        }
         Ok(())
     }
 

--- a/adapters/gpui/src/platform_impl/presentation.rs
+++ b/adapters/gpui/src/platform_impl/presentation.rs
@@ -118,6 +118,7 @@ impl RuvizPlot {
             overlay_image,
             stats: frame.stats,
             target: frame.target,
+            view: frame.view,
         });
     }
 
@@ -129,19 +130,16 @@ impl RuvizPlot {
         match frame.primary.take() {
             Some(RenderedPrimary::Image(image)) => Some(PrimaryFrame::Image(image)),
             #[cfg(all(feature = "gpu", target_os = "macos"))]
-            Some(RenderedPrimary::Surface(base_image)) => {
+            Some(RenderedPrimary::Surface(base_layer)) => {
                 let previous_surface = previous.and_then(|cached| match &cached.primary {
                     PrimaryFrame::Surface(surface) => Some(surface),
                     PrimaryFrame::Image(_) => None,
                 });
 
-                match self
-                    .surface_upload
-                    .update(previous_surface, base_image.as_ref())
-                {
+                match self.surface_upload.update(previous_surface, &base_layer) {
                     Ok(surface) => Some(PrimaryFrame::Surface(surface)),
                     Err(_) => Some(PrimaryFrame::Image(render_image_from_ruviz(
-                        base_image.as_ref().clone(),
+                        base_layer.image().as_ref().clone(),
                     ))),
                 }
             }
@@ -239,10 +237,59 @@ impl RuvizPlot {
             self.last_layout = None;
         }
 
+        let preview = self.pan_preview();
         self.cached_frame.as_ref().map(|frame| PaintFrame {
             primary: frame.primary.clone(),
             overlay_image: frame.overlay_image.as_ref().map(Arc::clone),
+            preview,
         })
+    }
+
+    /// The GPU translation that shows the session's pending view with the
+    /// cached frame, or `None` when the frame already shows it (or the
+    /// change is not a pure pan).
+    pub(super) fn pan_preview(&self) -> Option<PanPreview> {
+        let frame = self.cached_frame.as_ref()?;
+        let view = frame.view.as_ref()?;
+        let layout = self.last_layout.as_ref()?;
+        let pending = self.session.view_bounds_snapshot().visible_bounds;
+        preview_translation(view, pending, layout.content_bounds, layout.frame_size_px)
+    }
+
+    /// Whether a left-button pan drag has crossed its threshold.
+    pub(super) fn pan_drag_active(&self) -> bool {
+        matches!(
+            self.interaction_state.active_drag,
+            ActiveDrag::LeftPan {
+                crossed_threshold: true,
+                ..
+            }
+        )
+    }
+
+    /// Wake the view up once `delay` has passed so a throttled raster is
+    /// scheduled even if no further input arrives.
+    fn arm_raster_wakeup(
+        &mut self,
+        entity: Entity<Self>,
+        delay: Duration,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if self.raster_wakeup.is_some() {
+            return;
+        }
+        let timer = cx.background_executor().timer(delay);
+        let task = window.spawn(cx, async move |cx| {
+            timer.await;
+            cx.on_next_frame(move |_, cx| {
+                entity.update(cx, |view, cx| {
+                    view.raster_wakeup = None;
+                    cx.notify();
+                });
+            });
+        });
+        self.raster_wakeup = Some(task);
     }
 
     #[cfg(test)]
@@ -274,6 +321,18 @@ impl RuvizPlot {
         cx: &mut App,
     ) {
         if !self.should_start_render(&request) {
+            return;
+        }
+
+        // During a pan the cached frame is translated on the GPU, so rasters
+        // only need to keep the axes fresh: space them out instead of
+        // rendering after every pointer move.
+        if self.pan_drag_active()
+            && self.scheduler.in_flight.is_none()
+            && let Some(started) = self.last_render_started
+            && started.elapsed() < PAN_RASTER_INTERVAL
+        {
+            self.arm_raster_wakeup(entity, PAN_RASTER_INTERVAL - started.elapsed(), window, cx);
             return;
         }
 
@@ -323,6 +382,7 @@ impl RuvizPlot {
 
         self.scheduler.start(scheduled);
         self.in_flight_render = Some(task);
+        self.last_render_started = Some(Instant::now());
     }
 
     pub(super) fn finish_render(
@@ -718,10 +778,10 @@ impl SurfaceUploadState {
     pub(super) fn update(
         &mut self,
         previous: Option<&CVPixelBuffer>,
-        image: &RuvizImage,
+        layer: &RenderedLayer,
     ) -> std::result::Result<CVPixelBuffer, String> {
-        let width = image.width as usize;
-        let height = image.height as usize;
+        let width = layer.width() as usize;
+        let height = layer.height() as usize;
         let pixel_buffer = match previous {
             Some(previous) if previous.get_width() == width && previous.get_height() == height => {
                 previous.clone()
@@ -735,7 +795,13 @@ impl SurfaceUploadState {
             .map_err(|status| format!("Failed to create CVPixelBuffer: {status}"))?,
         };
 
-        write_surface_pixels(&pixel_buffer, width, height, &image.pixels)?;
+        write_surface_pixels(
+            &pixel_buffer,
+            width,
+            height,
+            layer.pixels(),
+            layer.alpha_mode(),
+        )?;
         Ok(pixel_buffer)
     }
 }
@@ -746,7 +812,16 @@ fn write_surface_pixels(
     width: usize,
     height: usize,
     rgba_pixels: &[u8],
+    alpha_mode: AlphaMode,
 ) -> std::result::Result<(), String> {
+    if rgba_pixels.len() < width * height * 4 {
+        return Err(format!(
+            "surface source has {} bytes, expected at least {} for {width}x{height}",
+            rgba_pixels.len(),
+            width * height * 4
+        ));
+    }
+
     let lock_status = pixel_buffer.lock_base_address(0);
     if lock_status != 0 {
         return Err(format!(
@@ -759,21 +834,25 @@ fn write_surface_pixels(
             return Err("Expected a bi-planar 420f CVPixelBuffer".to_string());
         }
 
-        let y_width = pixel_buffer.get_width_of_plane(0);
-        let y_height = pixel_buffer.get_height_of_plane(0);
+        let y_width = pixel_buffer.get_width_of_plane(0).min(width);
+        let y_height = pixel_buffer.get_height_of_plane(0).min(height);
         let y_stride = pixel_buffer.get_bytes_per_row_of_plane(0);
         let y_plane = unsafe { pixel_buffer.get_base_address_of_plane(0) } as *mut u8;
         if y_plane.is_null() {
             return Err("CVPixelBuffer luma plane base address was null".to_string());
         }
 
-        for row in 0..height.min(y_height) {
-            for col in 0..width.min(y_width) {
-                let pixel = rgba_at(rgba_pixels, width, row, col);
-                let y = rgb_to_ycbcr_full_range(pixel.0, pixel.1, pixel.2).0;
-                unsafe {
-                    *y_plane.add(row * y_stride + col) = y;
-                }
+        let row_bytes = width * 4;
+        for row in 0..y_height {
+            let src = &rgba_pixels[row * row_bytes..row * row_bytes + y_width * 4];
+            // SAFETY: the plane is locked for the duration of this closure and
+            // `y_width` is clamped to the plane width, so every write stays
+            // inside row `row` of the plane.
+            let dst =
+                unsafe { std::slice::from_raw_parts_mut(y_plane.add(row * y_stride), y_width) };
+            for (dst, px) in dst.iter_mut().zip(src.chunks_exact(4)) {
+                let (r, g, b) = straight_rgb(px, alpha_mode);
+                *dst = luma_full_range(r, g, b);
             }
         }
 
@@ -786,41 +865,41 @@ fn write_surface_pixels(
         }
 
         for uv_row in 0..uv_height {
-            for uv_col in 0..uv_width {
+            let y0 = uv_row * 2;
+            if y0 >= height {
+                break;
+            }
+            let rows = if y0 + 1 < height { 2 } else { 1 };
+            let row0 = &rgba_pixels[y0 * row_bytes..y0 * row_bytes + row_bytes];
+            let row1 =
+                &rgba_pixels[(y0 + rows - 1) * row_bytes..(y0 + rows - 1) * row_bytes + row_bytes];
+            let uv_cols = uv_width.min(width.div_ceil(2));
+            // SAFETY: as above, for row `uv_row` of the chroma plane; `uv_cols`
+            // is clamped to the plane width so `uv_cols * 2` bytes fit.
+            let dst = unsafe {
+                std::slice::from_raw_parts_mut(uv_plane.add(uv_row * uv_stride), uv_cols * 2)
+            };
+            for (uv_col, dst) in dst.chunks_exact_mut(2).enumerate() {
                 let x0 = uv_col * 2;
-                let y0 = uv_row * 2;
-                if x0 >= width || y0 >= height {
-                    continue;
-                }
-
+                let cols = if x0 + 1 < width { 2 } else { 1 };
                 let mut r_sum: u32 = 0;
                 let mut g_sum: u32 = 0;
                 let mut b_sum: u32 = 0;
-                let mut sample_count: u32 = 0;
-
-                for sample_y in y0..(y0 + 2).min(height) {
-                    for sample_x in x0..(x0 + 2).min(width) {
-                        let (r, g, b, _) = rgba_at(rgba_pixels, width, sample_y, sample_x);
-                        r_sum += r as u32;
-                        g_sum += g as u32;
-                        b_sum += b as u32;
-                        sample_count += 1;
+                for source_row in [row0, row1].iter().take(rows) {
+                    for x in x0..x0 + cols {
+                        let (r, g, b) = straight_rgb(&source_row[x * 4..x * 4 + 4], alpha_mode);
+                        r_sum += u32::from(r);
+                        g_sum += u32::from(g);
+                        b_sum += u32::from(b);
                     }
                 }
-
-                if sample_count == 0 {
-                    continue;
-                }
-
+                let sample_count = (rows * cols) as u32;
                 let r = (r_sum / sample_count) as u8;
                 let g = (g_sum / sample_count) as u8;
                 let b = (b_sum / sample_count) as u8;
                 let (_, cb, cr) = rgb_to_ycbcr_full_range(r, g, b);
-                let uv_offset = uv_row * uv_stride + uv_col * 2;
-                unsafe {
-                    *uv_plane.add(uv_offset) = cb;
-                    *uv_plane.add(uv_offset + 1) = cr;
-                }
+                dst[0] = cb;
+                dst[1] = cr;
             }
         }
 
@@ -842,21 +921,31 @@ fn write_surface_pixels(
     copy_result
 }
 
+/// Straight RGB of one pixel, undoing premultiplication only where the alpha
+/// says it changed something. A plot's base layer is opaque, so this is a
+/// branch per pixel rather than a full-frame divide.
 #[cfg(all(feature = "gpu", target_os = "macos"))]
-fn rgba_at(rgba_pixels: &[u8], width: usize, row: usize, col: usize) -> (u8, u8, u8, u8) {
-    let offset = (row * width + col) * 4;
-    let end = offset.saturating_add(4);
-    debug_assert!(
-        rgba_pixels.len() >= end,
-        "pixel buffer too small for ({row}, {col}) in {width}-wide image: len={} need>={end}",
-        rgba_pixels.len()
-    );
-    (
-        rgba_pixels[offset],
-        rgba_pixels[offset + 1],
-        rgba_pixels[offset + 2],
-        rgba_pixels[offset + 3],
-    )
+#[inline]
+fn straight_rgb(px: &[u8], alpha_mode: AlphaMode) -> (u8, u8, u8) {
+    let (r, g, b, a) = (px[0], px[1], px[2], px[3]);
+    match alpha_mode {
+        AlphaMode::Straight => (r, g, b),
+        AlphaMode::Premultiplied => match a {
+            255 => (r, g, b),
+            0 => (0, 0, 0),
+            a => {
+                let a = u32::from(a);
+                let un = |c: u8| ((u32::from(c) * 255 + a / 2) / a).min(255) as u8;
+                (un(r), un(g), un(b))
+            }
+        },
+    }
+}
+
+#[cfg(all(feature = "gpu", target_os = "macos"))]
+#[inline]
+fn luma_full_range(r: u8, g: u8, b: u8) -> u8 {
+    ((77 * i32::from(r) + 150 * i32::from(g) + 29 * i32::from(b) + 128) >> 8).clamp(0, 255) as u8
 }
 
 #[cfg(all(feature = "gpu", target_os = "macos"))]
@@ -876,82 +965,83 @@ pub(super) fn render_frame_from_session(
     session: InteractivePlotSession,
     request: RenderRequest,
 ) -> Result<RenderedFrame> {
-    let result = match request.presentation_mode {
-        PresentationMode::Image => session.render_to_image_with_generation(ImageTarget {
-            size_px: request.size_px,
-            scale_factor: request.scale_factor(),
-            time_seconds: request.time_seconds(),
-        })?,
-        PresentationMode::Hybrid => session.render_to_surface_with_generation(SurfaceTarget {
-            size_px: request.size_px,
-            scale_factor: request.scale_factor(),
-            time_seconds: request.time_seconds(),
-        })?,
-        #[allow(deprecated)]
-        PresentationMode::SurfaceExperimental => {
-            session.render_to_surface_with_generation(SurfaceTarget {
+    let frame = match request.presentation_mode {
+        PresentationMode::Image => {
+            let result = session.render_to_image_with_generation(ImageTarget {
                 size_px: request.size_px,
                 scale_factor: request.scale_factor(),
                 time_seconds: request.time_seconds(),
-            })?
+            })?;
+            RenderedFrame {
+                base_generation: result.base_generation,
+                primary: Some(RenderedPrimary::Image(render_image_from_ruviz(
+                    result.frame.image.as_ref().clone(),
+                ))),
+                overlay: RenderedOverlay::Replace(None),
+                stats: result.frame.stats,
+                target: result.frame.target,
+                view: None,
+            }
+        }
+        #[allow(deprecated)]
+        PresentationMode::Hybrid | PresentationMode::SurfaceExperimental => {
+            // Layers stay in the renderer's native alpha representation: the
+            // surface upload converts straight from them, so no frame pays
+            // the full-size premultiplied -> straight pass.
+            let layers = session.render_surface_layers_stamped(SurfaceTarget {
+                size_px: request.size_px,
+                scale_factor: request.scale_factor(),
+                time_seconds: request.time_seconds(),
+            })?;
+            let base_generation = layers.base_generation;
+            let layer_state = layers.layer_state;
+            let generation_changed = request.presented_base_generation != Some(base_generation);
+            let include_base = layer_state.base_dirty || generation_changed;
+            let use_surface_primary = should_use_surface_primary(
+                request.presentation_mode,
+                layers.target,
+                layers.surface_capability,
+            );
+            let primary = if use_surface_primary {
+                #[cfg(all(feature = "gpu", target_os = "macos"))]
+                {
+                    include_base.then(|| RenderedPrimary::Surface(layers.base.clone()))
+                }
+                #[cfg(not(all(feature = "gpu", target_os = "macos")))]
+                {
+                    unreachable!("surface primary is only enabled on macOS with the gpu feature")
+                }
+            } else {
+                include_base.then(|| {
+                    RenderedPrimary::Image(render_image_from_ruviz(
+                        layers.base.image().as_ref().clone(),
+                    ))
+                })
+            };
+            let overlay = if layer_state.overlay_dirty || generation_changed {
+                RenderedOverlay::Replace(
+                    layers
+                        .overlay
+                        .as_ref()
+                        .map(|overlay| render_image_from_ruviz(overlay.image().as_ref().clone())),
+                )
+            } else {
+                RenderedOverlay::Reuse
+            };
+            RenderedFrame {
+                base_generation,
+                primary,
+                overlay,
+                stats: layers.stats,
+                target: layers.target,
+                view: None,
+            }
         }
     };
-
-    let base_generation = result.base_generation;
-    let frame = result.frame;
-    let layer_state = frame.layer_state;
-    let generation_changed = request.presented_base_generation != Some(base_generation);
-    let include_base = layer_state.base_dirty || generation_changed;
-    let use_surface_primary = should_use_surface_primary(
-        request.presentation_mode,
-        frame.target,
-        frame.surface_capability,
-    );
-    Ok(RenderedFrame {
-        base_generation,
-        primary: if use_surface_primary {
-            #[cfg(all(feature = "gpu", target_os = "macos"))]
-            {
-                include_base.then(|| RenderedPrimary::Surface(Arc::clone(&frame.layers.base)))
-            }
-            #[cfg(not(all(feature = "gpu", target_os = "macos")))]
-            {
-                unreachable!("surface primary is only enabled on macOS with the gpu feature")
-            }
-        } else {
-            match request.presentation_mode {
-                PresentationMode::Image => Some(RenderedPrimary::Image(render_image_from_ruviz(
-                    frame.image.as_ref().clone(),
-                ))),
-                PresentationMode::Hybrid => include_base.then(|| {
-                    RenderedPrimary::Image(render_image_from_ruviz(
-                        frame.layers.base.as_ref().clone(),
-                    ))
-                }),
-                #[allow(deprecated)]
-                PresentationMode::SurfaceExperimental => include_base.then(|| {
-                    RenderedPrimary::Image(render_image_from_ruviz(
-                        frame.layers.base.as_ref().clone(),
-                    ))
-                }),
-            }
-        },
-        overlay: if matches!(request.presentation_mode, PresentationMode::Image) {
-            RenderedOverlay::Replace(None)
-        } else if layer_state.overlay_dirty || generation_changed {
-            RenderedOverlay::Replace(
-                frame
-                    .layers
-                    .overlay
-                    .as_ref()
-                    .map(|overlay| render_image_from_ruviz(overlay.as_ref().clone())),
-            )
-        } else {
-            RenderedOverlay::Reuse
-        },
-        stats: frame.stats,
-        target: frame.target,
-    })
+    // The session's displayed geometry is this frame's: one render is in
+    // flight per view, and the worker just committed it.
+    let view = frame_view_from_session(&session);
+    Ok(RenderedFrame { view, ..frame })
 }
 
 pub(super) fn render_image_from_ruviz(image: RuvizImage) -> Arc<RenderImage> {
@@ -994,5 +1084,79 @@ pub(super) fn blend_rgba_into_rgba(src_rgba: &[u8], dst_rgba: &mut [u8]) {
         let destination = [dst[0], dst[1], dst[2], dst[3]];
         let source = [src[0], src[1], src[2], src[3]];
         dst.copy_from_slice(&source_over_straight_rgba(destination, source));
+    }
+}
+
+#[cfg(all(test, feature = "gpu", target_os = "macos"))]
+mod surface_tests {
+    use super::*;
+
+    #[test]
+    fn straight_rgb_undoes_premultiplication_only_where_alpha_asks() {
+        assert_eq!(
+            straight_rgb(&[10, 20, 30, 255], AlphaMode::Premultiplied),
+            (10, 20, 30)
+        );
+        assert_eq!(
+            straight_rgb(&[10, 20, 30, 0], AlphaMode::Premultiplied),
+            (0, 0, 0)
+        );
+        assert_eq!(
+            straight_rgb(&[64, 32, 16, 128], AlphaMode::Premultiplied),
+            (128, 64, 32)
+        );
+        assert_eq!(
+            straight_rgb(&[64, 32, 16, 128], AlphaMode::Straight),
+            (64, 32, 16)
+        );
+    }
+
+    #[test]
+    fn surface_upload_from_premultiplied_layer_matches_straight_layer() {
+        // A half-transparent premultiplied pixel and its straight twin must
+        // land as the same luma/chroma: the upload un-premultiplies inline
+        // instead of asking the layer for a materialized straight view.
+        let straight = RenderedLayer::from_straight_image(Arc::new(RuvizImage::new(
+            2,
+            2,
+            vec![
+                200, 100, 50, 255, 128, 64, 32, 128, 0, 0, 255, 255, 255, 255, 255, 255,
+            ],
+        )));
+        let premultiplied = RenderedLayer::from_premultiplied_pixels(
+            2,
+            2,
+            vec![
+                200, 100, 50, 255, 64, 32, 16, 128, 0, 0, 255, 255, 255, 255, 255, 255,
+            ],
+        );
+        let mut upload = SurfaceUploadState::default();
+        let a = upload.update(None, &straight).expect("straight upload");
+        let mut upload = SurfaceUploadState::default();
+        let b = upload
+            .update(None, &premultiplied)
+            .expect("premultiplied upload");
+        let read = |buffer: &CVPixelBuffer| {
+            buffer.lock_base_address(1);
+            let mut bytes = Vec::new();
+            for plane in 0..2 {
+                let stride = buffer.get_bytes_per_row_of_plane(plane);
+                let rows = buffer.get_height_of_plane(plane);
+                let cols = buffer.get_width_of_plane(plane) * if plane == 1 { 2 } else { 1 };
+                let base = unsafe { buffer.get_base_address_of_plane(plane) } as *const u8;
+                for row in 0..rows {
+                    bytes.extend_from_slice(unsafe {
+                        std::slice::from_raw_parts(base.add(row * stride), cols)
+                    });
+                }
+            }
+            buffer.unlock_base_address(1);
+            bytes
+        };
+        assert_eq!(read(&a), read(&b));
+        assert!(
+            !premultiplied.has_straight_view(),
+            "no straight view was materialized"
+        );
     }
 }

--- a/adapters/gpui/src/platform_impl/presentation.rs
+++ b/adapters/gpui/src/platform_impl/presentation.rs
@@ -100,7 +100,19 @@ impl RuvizPlot {
         };
 
         if let Some(previous) = previous {
-            maybe_retire_replaced_primary(&mut self.retired_images, &previous.primary, &primary);
+            let anchored = match (&previous.primary, self.pan_anchor.as_ref()) {
+                (PrimaryFrame::Image(image), Some(anchor)) => {
+                    matches!(&anchor.primary, PrimaryFrame::Image(held) if Arc::ptr_eq(held, image))
+                }
+                _ => false,
+            };
+            if !anchored {
+                maybe_retire_replaced_primary(
+                    &mut self.retired_images,
+                    &previous.primary,
+                    &primary,
+                );
+            }
             if let Some(previous_overlay) = previous.overlay_image {
                 let overlay_reused = overlay_image
                     .as_ref()
@@ -131,10 +143,21 @@ impl RuvizPlot {
             Some(RenderedPrimary::Image(image)) => Some(PrimaryFrame::Image(image)),
             #[cfg(all(feature = "gpu", target_os = "macos"))]
             Some(RenderedPrimary::Surface(base_layer)) => {
-                let previous_surface = previous.and_then(|cached| match &cached.primary {
-                    PrimaryFrame::Surface(surface) => Some(surface),
-                    PrimaryFrame::Image(_) => None,
-                });
+                // The anchor keeps its pixels for the whole drag, so a frame
+                // it shares its surface with must render into a new one.
+                let anchor_surface =
+                    self.pan_anchor
+                        .as_ref()
+                        .and_then(|anchor| match &anchor.primary {
+                            PrimaryFrame::Surface(surface) => Some(surface.as_CFTypeRef()),
+                            PrimaryFrame::Image(_) => None,
+                        });
+                let previous_surface = previous
+                    .and_then(|cached| match &cached.primary {
+                        PrimaryFrame::Surface(surface) => Some(surface),
+                        PrimaryFrame::Image(_) => None,
+                    })
+                    .filter(|surface| anchor_surface != Some(surface.as_CFTypeRef()));
 
                 match self.surface_upload.update(previous_surface, &base_layer) {
                     Ok(surface) => Some(PrimaryFrame::Surface(surface)),
@@ -237,12 +260,104 @@ impl RuvizPlot {
             self.last_layout = None;
         }
 
-        let preview = self.pan_preview();
-        self.cached_frame.as_ref().map(|frame| PaintFrame {
-            primary: frame.primary.clone(),
-            overlay_image: frame.overlay_image.as_ref().map(Arc::clone),
-            preview,
-        })
+        self.update_pan_anchor(cx);
+        self.pan_paint()
+    }
+
+    /// Keep the drag anchor in step with the drag: capture the frame on
+    /// screen when a pan crosses its threshold, drop it once the drag has
+    /// ended and the final raster shows the pending view, and drop it early
+    /// when the frame geometry changes (resize, scale, presentation).
+    pub(super) fn update_pan_anchor(&mut self, cx: &mut App) {
+        let contract_changed = match (self.pan_anchor.as_ref(), self.cached_frame.as_ref()) {
+            (Some(anchor), Some(frame)) => !anchor.request.same_frame_contract(&frame.request),
+            _ => false,
+        };
+        if contract_changed {
+            self.clear_pan_anchor(cx);
+        }
+        if self.pan_drag_active() {
+            if self.pan_anchor.is_none()
+                && let Some(frame) = self.cached_frame.as_ref()
+                && let Some(view) = frame.view.as_ref()
+            {
+                self.pan_anchor = Some(PanAnchor {
+                    request: frame.request.clone(),
+                    primary: frame.primary.clone(),
+                    view: view.clone(),
+                });
+            }
+            return;
+        }
+        if self.pan_anchor.is_some() && self.pan_preview().is_none() {
+            // The drag is over and the frame on screen shows the pending view:
+            // its own axes are correct again.
+            self.clear_pan_anchor(cx);
+        }
+    }
+
+    fn clear_pan_anchor(&mut self, cx: &mut App) {
+        let Some(anchor) = self.pan_anchor.take() else {
+            return;
+        };
+        if let PrimaryFrame::Image(image) = anchor.primary {
+            let still_shown = self.cached_frame.as_ref().is_some_and(|frame| {
+                matches!(&frame.primary, PrimaryFrame::Image(current) if Arc::ptr_eq(current, &image))
+            });
+            if !still_shown {
+                cx.drop_image(image, None);
+            }
+        }
+    }
+
+    /// What to paint: the plot-area content (the newest frame whose plot
+    /// area matches the anchor's, else the anchor itself) shifted under the
+    /// anchor's axes while a pan drag is in progress, or the cached frame
+    /// with a plain pan preview otherwise.
+    pub(super) fn pan_paint(&self) -> Option<PaintFrame> {
+        let frame = self.cached_frame.as_ref()?;
+        let overlay_image = frame.overlay_image.as_ref().map(Arc::clone);
+        let Some(anchor) = self.pan_anchor.as_ref() else {
+            return Some(PaintFrame {
+                primary: frame.primary.clone(),
+                overlay_image,
+                preview: self.pan_preview(),
+                axes: None,
+            });
+        };
+        let layout = self.last_layout.as_ref()?;
+        let pending = self.session.view_bounds_snapshot().visible_bounds;
+        // A raster whose plot area has the anchor's size slides into the
+        // anchor's frame exactly; one whose margins moved cannot, so the
+        // anchor's own content stays until the drag ends.
+        let (content, view) = match frame.view.as_ref() {
+            Some(view) if same_plot_area_size(view, &anchor.view) => (&frame.primary, view),
+            _ => (&anchor.primary, &anchor.view),
+        };
+        let preview = preview_translation_onto(
+            view,
+            pending,
+            anchor.view.plot_area,
+            anchor.view.axis_inset_px,
+            layout.content_bounds,
+            layout.frame_size_px,
+            true,
+        );
+        match preview {
+            Some(preview) => Some(PaintFrame {
+                primary: content.clone(),
+                overlay_image,
+                preview: Some(preview),
+                axes: Some(anchor.primary.clone()),
+            }),
+            // Not a pure pan any more (a zoom landed): fall back to the frame.
+            None => Some(PaintFrame {
+                primary: frame.primary.clone(),
+                overlay_image,
+                preview: self.pan_preview(),
+                axes: None,
+            }),
+        }
     }
 
     /// The GPU translation that shows the session's pending view with the
@@ -804,6 +919,20 @@ impl SurfaceUploadState {
         )?;
         Ok(pixel_buffer)
     }
+}
+
+/// Whether two frames lay out their plot area with the same size (within
+/// half a frame pixel), so one's content can be shown inside the other's axes.
+pub(super) fn same_plot_area_size(a: &FrameView, b: &FrameView) -> bool {
+    let (aw, ah) = (
+        a.plot_area.max.x - a.plot_area.min.x,
+        a.plot_area.max.y - a.plot_area.min.y,
+    );
+    let (bw, bh) = (
+        b.plot_area.max.x - b.plot_area.min.x,
+        b.plot_area.max.y - b.plot_area.min.y,
+    );
+    (aw - bw).abs() <= 0.5 && (ah - bh).abs() <= 0.5
 }
 
 #[cfg(all(feature = "gpu", target_os = "macos"))]

--- a/adapters/gpui/src/platform_impl/presentation.rs
+++ b/adapters/gpui/src/platform_impl/presentation.rs
@@ -300,13 +300,18 @@ impl RuvizPlot {
         let Some(anchor) = self.pan_anchor.take() else {
             return;
         };
-        if let PrimaryFrame::Image(image) = anchor.primary {
-            let still_shown = self.cached_frame.as_ref().is_some_and(|frame| {
-                matches!(&frame.primary, PrimaryFrame::Image(current) if Arc::ptr_eq(current, &image))
-            });
-            if !still_shown {
-                cx.drop_image(image, None);
+        match anchor.primary {
+            PrimaryFrame::Image(image) => {
+                let still_shown = self.cached_frame.as_ref().is_some_and(|frame| {
+                    matches!(&frame.primary, PrimaryFrame::Image(current) if Arc::ptr_eq(current, &image))
+                });
+                if !still_shown {
+                    cx.drop_image(image, None);
+                }
             }
+            // A surface is released with the anchor; nothing else holds it.
+            #[cfg(all(feature = "gpu", target_os = "macos"))]
+            PrimaryFrame::Surface(_) => {}
         }
     }
 

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -1434,6 +1434,9 @@ struct OverlayFrameCache {
 struct GeometrySnapshot {
     key: InteractiveFrameKey,
     plot_area: tiny_skia::Rect,
+    /// Frame pixels inside the plot-area edge that belong to the axes
+    /// (spine and inward ticks) rather than to the data.
+    axis_inset_px: f32,
     x_bounds: (f64, f64),
     y_bounds: (f64, f64),
     x_scale: AxisScale,
@@ -2715,6 +2718,16 @@ impl InteractivePlotSession {
     }
 
     /// Returns the current interactive viewport state.
+    /// Frame pixels along the inside of the displayed plot-area edge that the
+    /// axes own (spine plus inward tick marks). An embedder that slides the
+    /// plot area of a cached frame keeps this band with the axes.
+    pub fn axis_inset_px(&self) -> Result<f32> {
+        let geometry = self
+            .displayed_geometry()
+            .or_else(|_| self.geometry_snapshot())?;
+        Ok(geometry.axis_inset_px)
+    }
+
     pub fn viewport_snapshot(&self) -> Result<InteractiveViewportSnapshot> {
         self.repair_poisoned_session();
         let geometry = self
@@ -4672,6 +4685,7 @@ fn sanitize_scale_factor(scale_factor: f32) -> f32 {
 
 struct ComputedSessionLayout {
     plot_area_rect: tiny_skia::Rect,
+    axis_inset_px: f32,
     annotation_theme: Theme,
     annotation_font_family: FontFamily,
     annotation_render_scale: RenderScale,
@@ -4697,6 +4711,7 @@ fn geometry_snapshot_for_state(
     Ok(GeometrySnapshot {
         key,
         plot_area: layout.plot_area_rect,
+        axis_inset_px: layout.axis_inset_px,
         x_bounds: (visible.x_min, visible.x_max),
         y_bounds: (visible.y_min, visible.y_max),
         x_scale: plot.layout.x_scale,
@@ -4866,8 +4881,24 @@ fn compute_plot_layout_from_frame(
         position: None,
     })?;
 
+    // Inward tick marks and the axis spine sit just inside the plot area;
+    // a translated preview must leave that band to the frame's own axes.
+    let tick_inward_logical = match layout_plot.layout.tick_config.direction {
+        crate::core::plot::config::TickDirection::Inside => 5.0,
+        crate::core::plot::config::TickDirection::InOut => 2.5,
+        crate::core::plot::config::TickDirection::Outside => 0.0,
+    };
+    let axis_inset_px = layout_plot
+        .render_scale()
+        .logical_pixels_to_pixels(tick_inward_logical)
+        + layout_plot
+            .render_scale()
+            .points_to_pixels(layout_plot.display.config.lines.axis_width)
+        + 1.0;
+
     Ok(ComputedSessionLayout {
         plot_area_rect,
+        axis_inset_px,
         annotation_theme: layout_plot.display.theme.clone(),
         annotation_font_family: layout_plot.display.config.typography.family.clone(),
         annotation_render_scale: layout_plot.render_scale(),

--- a/src/core/plot/interactive_session.rs
+++ b/src/core/plot/interactive_session.rs
@@ -666,6 +666,10 @@ pub struct StampedInteractiveLayers {
     pub stats: FrameStats,
     /// Base-image generation used by the frame's interaction geometry.
     pub base_generation: u64,
+    /// Render target the layers were produced for.
+    pub target: RenderTargetKind,
+    /// Whether a surface presenter may upload the base layer directly.
+    pub surface_capability: SurfaceCapability,
     render_stamp: InteractiveRenderStamp,
 }
 
@@ -723,6 +727,8 @@ impl RenderOutcome {
             layer_state: self.layer_state,
             stats: self.stats,
             base_generation: self.base_generation,
+            target: self.target,
+            surface_capability: self.surface_capability,
             render_stamp: self.render_stamp,
         }
     }
@@ -2601,6 +2607,30 @@ impl InteractivePlotSession {
     pub fn render_layers_stamped(&self, target: ImageTarget) -> Result<StampedInteractiveLayers> {
         self.render_to_target(
             RenderTargetKind::Image,
+            ComposeLayers::No,
+            target.size_px,
+            target.scale_factor,
+            target.time_seconds,
+        )
+        .map(RenderOutcome::into_stamped_layers)
+    }
+
+    /// Render for a surface presenter and hand the layers over untouched.
+    ///
+    /// The surface counterpart of [`render_layers_stamped`]: the base layer
+    /// keeps the renderer's native (premultiplied) bytes so a presenter that
+    /// converts into its own pixel format — a YCbCr `CVPixelBuffer`, say —
+    /// reads them once instead of paying the full-frame straight-alpha divide
+    /// first. `target` and `surface_capability` on the result say whether the
+    /// fast path applies to this frame.
+    ///
+    /// [`render_layers_stamped`]: Self::render_layers_stamped
+    pub fn render_surface_layers_stamped(
+        &self,
+        target: SurfaceTarget,
+    ) -> Result<StampedInteractiveLayers> {
+        self.render_to_target(
+            RenderTargetKind::Surface,
             ComposeLayers::No,
             target.size_px,
             target.scale_factor,


### PR DESCRIPTION
Two fixes for panning in GPUI apps, found with xraytsubaki on a 1440×932 Retina window.

**1. Pans died after one move (14e29cc).** `pointer_base_generation_is_current` reset the drag whenever the session's displayed base generation ran ahead of the cached frame — exactly what happens while the view's own render of that pan is in flight — and `RenderScheduler::finish` dropped in-flight frames once a newer request queued. A pending render of our own now keeps the pointer state; in-flight frames install when they match the latest request's frame contract.

**2. Pans waited for a raster.** Every rendered frame now records the view it shows; when the pending view is a pure translation of it, the plot area of the cached frame is repainted on the GPU at the implied offset (content-masked, margins/axes untouched), rasters are throttled to 32 ms during the drag with a trailing one on release, and the landing frame replaces the preview without a jump. The surface upload reads the native premultiplied base layer via the new `render_surface_layers_stamped` and un-premultiplies inline, skipping the full-frame straight-alpha copy.

Measured in xraytsubaki (μ(E) view, ~80 pointer events/s synthetic pan): raster 8–11 ms → 4–5 ms, rasters 30/s (throttled), pointer→paint ≈30 ms → 8–11 ms, view follows every frame (screenshot diffs ≈23k px per 0.6 s vs 0 before fix 1).

Tests: adapter 67 (`--features gpu`) / 62 (default), root `--lib` 1888, `make clippy-gpui`, root clippy `--all-features -D warnings`, fmt.
