### PR TITLE
Fix ghost spectra during GPUI pans; release 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.1] - 2026-09-06
+
+### Fixed
+
+- GPUI pan previews remove stale traces from the areas uncovered by a fast
+  drag. Image and macOS surface presentation share the corrected composition;
+  opaque plots add only a background quad, while translucent plots exclude
+  the old interior and avoid blending the background twice. Axes stay fixed
+  and the existing render scheduler and raster interval are unchanged.
+- Pixel regression coverage includes horizontal, vertical and diagonal pans,
+  direction reversals, shifts larger than the plot, identity previews, and
+  light, dark, translucent-panel and transparent-figure backgrounds.
+
 ## [0.13.0] - 2026-09-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5361,7 +5361,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "anyhow",
  "approx",
@@ -5421,7 +5421,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-py"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "image",
  "numpy",
@@ -5432,7 +5432,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-web"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ resolver = "2"
 
 [package]
 name = "ruviz"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.92"
 authors = ["Ruviz Contributors"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ bindings. Every figure in it is real ruviz output.
 
 ```toml
 [dependencies]
-ruviz = "0.13.0"
+ruviz = "0.13.1"
 ```
 
 ## Hello, plot

--- a/adapters/gpui/Cargo.lock
+++ b/adapters/gpui/Cargo.lock
@@ -5121,7 +5121,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64",
  "bytemuck",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-gpui"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "arboard",
  "core-foundation 0.10.0",

--- a/adapters/gpui/Cargo.toml
+++ b/adapters/gpui/Cargo.toml
@@ -24,7 +24,7 @@ gpui = { git = "https://github.com/zed-industries/zed", rev = "3060e4170ea5ef0e6
 
 [package]
 name = "ruviz-gpui"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -45,7 +45,7 @@ gpu = ["ruviz/gpu"]
 "3d-gpu" = ["3d", "gpu"]
 
 [dependencies]
-ruviz = { version = "0.13.0", path = "../.." }
+ruviz = { version = "0.13.1", path = "../.." }
 image = "0.25"
 smallvec = "1.15"
 futures = "0.3"

--- a/adapters/gpui/README.md
+++ b/adapters/gpui/README.md
@@ -10,8 +10,8 @@ own the window, layout tree, and surrounding application shell.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["3d"] }
-ruviz-gpui = { version = "0.13.0", features = ["3d"] }
+ruviz = { version = "0.13.1", features = ["3d"] }
+ruviz-gpui = { version = "0.13.1", features = ["3d"] }
 ```
 
 ## What This Crate Provides

--- a/adapters/gpui/src/lib.rs
+++ b/adapters/gpui/src/lib.rs
@@ -49,8 +49,8 @@
 //!
 //! ```toml
 //! [dependencies]
-//! ruviz = "0.13.0"
-//! ruviz-gpui = "0.13.0"
+//! ruviz = "0.13.1"
+//! ruviz-gpui = "0.13.1"
 //! ```
 //!
 //! Then build a normal `ruviz::Plot` or `PreparedPlot` and hand it to the GPUI
@@ -77,6 +77,7 @@ compile_error!("ruviz-gpui currently supports macOS, Linux, and Windows only.");
 #[cfg(any(target_os = "macos", target_os = "linux", target_os = "windows"))]
 mod platform_impl {
     mod interaction;
+    mod pan;
     mod presentation;
     #[cfg(feature = "3d")]
     mod three_d;
@@ -130,6 +131,7 @@ mod platform_impl {
     };
 
     use self::interaction::*;
+    use self::pan::{PanLayer, paint_pan_layers};
     use self::presentation::*;
     #[cfg(feature = "3d")]
     pub use self::three_d::*;
@@ -576,6 +578,7 @@ mod platform_impl {
         /// Frame pixels inside the plot-area edge owned by the axes (spine
         /// and inward ticks); a translated preview leaves them untouched.
         axis_inset_px: f64,
+        background: [ruviz::render::Color; 2],
         x_scale: AxisScale,
         y_scale: AxisScale,
     }
@@ -587,6 +590,8 @@ mod platform_impl {
     struct PanPreview {
         offset: Point<Pixels>,
         mask: Bounds<Pixels>,
+        plot_bounds: Bounds<Pixels>,
+        background: [ruviz::render::Color; 2],
     }
 
     /// The frame on screen when a pan drag started. Its margins and axes are
@@ -1495,30 +1500,33 @@ mod platform_impl {
                         let fitted_bounds = image_fit
                             .into_gpui()
                             .get_bounds(bounds, primary_size(&image.primary));
-                        // During a pan drag the anchor frame supplies the margins
-                        // and axes; otherwise the frame paints itself whole.
-                        paint_primary(
-                            window,
-                            fitted_bounds,
-                            image.axes.as_ref().unwrap_or(&image.primary),
-                        );
                         if let Some(preview) = image.preview {
-                            // A pan is pending a raster: repaint the plot area of
-                            // the content frame shifted to where the pending view
-                            // puts it, clipped to the plot area of the frame
-                            // whose axes are showing.
-                            let shifted = Bounds::new(
-                                fitted_bounds.origin + preview.offset,
-                                fitted_bounds.size,
-                            );
-                            window.with_content_mask(
-                                Some(ContentMask {
-                                    bounds: preview.mask,
-                                }),
-                                |window| paint_primary(window, shifted, &image.primary),
-                            );
+                            paint_pan_layers(fitted_bounds, preview, |layer, placement, mask| {
+                                window.with_content_mask(
+                                    Some(ContentMask { bounds: mask }),
+                                    |window| match layer {
+                                        PanLayer::Anchor => paint_primary(
+                                            window,
+                                            placement,
+                                            image.axes.as_ref().unwrap_or(&image.primary),
+                                        ),
+                                        PanLayer::Content => {
+                                            paint_primary(window, placement, &image.primary)
+                                        }
+                                        PanLayer::Background(color) => {
+                                            window.paint_quad(gpui::fill(
+                                                placement,
+                                                rgba(u32::from_be_bytes([
+                                                    color.r, color.g, color.b, color.a,
+                                                ])),
+                                            ))
+                                        }
+                                    },
+                                );
+                            });
                             return;
                         }
+                        paint_primary(window, fitted_bounds, &image.primary);
                         if let Some(overlay_image) = image.overlay_image {
                             let _ = window.paint_image(
                                 fitted_bounds,
@@ -1793,17 +1801,39 @@ mod platform_impl {
             ),
             size(px((mask_w * scale_x) as f32), px((mask_h * scale_y) as f32)),
         );
-        Some(PanPreview { offset, mask })
+        let plot_bounds = Bounds::new(
+            point(
+                content_bounds.origin.x + px((dest_min_x * scale_x) as f32),
+                content_bounds.origin.y + px((dest_min_y * scale_y) as f32),
+            ),
+            size(
+                px(((dest_max_x - dest_min_x).max(0.0) * scale_x) as f32),
+                px(((dest_max_y - dest_min_y).max(0.0) * scale_y) as f32),
+            ),
+        );
+        Some(PanPreview {
+            offset,
+            mask,
+            plot_bounds,
+            background: view.background,
+        })
     }
 
     /// The view of the frame the session just rendered.
     fn frame_view_from_session(session: &InteractivePlotSession) -> Option<FrameView> {
         let snapshot = session.viewport_snapshot().ok()?;
         let scales = session.view_bounds_snapshot();
+        let theme = session.prepared_plot().plot().get_theme();
         Some(FrameView {
             visible: snapshot.visible_bounds,
             plot_area: snapshot.plot_area,
             axis_inset_px: f64::from(session.axis_inset_px().unwrap_or(0.0)),
+            background: [
+                theme.background,
+                theme
+                    .panel_background
+                    .unwrap_or(ruviz::render::Color::TRANSPARENT),
+            ],
             x_scale: scales.x_scale,
             y_scale: scales.y_scale,
         })
@@ -4580,9 +4610,13 @@ mod platform_impl {
             });
         }
 
-        fn unit_frame_view() -> FrameView {
+        pub(super) fn unit_frame_view() -> FrameView {
             FrameView {
                 axis_inset_px: 0.0,
+                background: [
+                    ruviz::render::Color::WHITE,
+                    ruviz::render::Color::TRANSPARENT,
+                ],
                 visible: ViewportRect::from_points(
                     ViewportPoint::new(0.0, 0.0),
                     ViewportPoint::new(1.0, 1.0),
@@ -4613,7 +4647,7 @@ mod platform_impl {
             assert!((f64::from(preview.offset.y) - 20.0).abs() < 1e-4);
             // The mask is the plot area intersected with where the shifted
             // frame's plot area lands: the strip the pan uncovers is left to
-            // the frame underneath instead of showing the shifted margins.
+            // the plot background instead of showing stale data or shifted margins.
             assert_window_points_close(preview.mask.origin, point(px(40.0), px(60.0)));
             assert!((f64::from(preview.mask.size.width) - 90.0).abs() < 1e-4);
             assert!((f64::from(preview.mask.size.height) - 80.0).abs() < 1e-4);

--- a/adapters/gpui/src/platform_impl/pan.rs
+++ b/adapters/gpui/src/platform_impl/pan.rs
@@ -1,0 +1,205 @@
+//! Shared paint composition for image and macOS surface pan previews.
+
+use super::*;
+use ruviz::render::Color;
+
+#[derive(Clone, Copy)]
+pub(super) enum PanLayer {
+    Anchor,
+    Background(Color),
+    Content,
+}
+
+/// Emit placements and clips without reading or copying a frame's pixels.
+/// Keeping this shared by both presentation backends also lets the pixel
+/// regression exercise exactly the composition used by the window painter.
+pub(super) fn paint_pan_layers(
+    frame: Bounds<Pixels>,
+    preview: PanPreview,
+    mut paint: impl FnMut(PanLayer, Bounds<Pixels>, Bounds<Pixels>),
+) {
+    let [figure, panel] = preview.background;
+    let [r, g, b, a] = source_over_straight_rgba(
+        [figure.r, figure.g, figure.b, figure.a],
+        [panel.r, panel.g, panel.b, panel.a],
+    );
+    let background = PanLayer::Background(Color::from_rgba(r, g, b, a));
+    if a == 255 {
+        // The usual opaque plot needs just one extra quad: erase the old
+        // data across the ENTIRE interior before placing the shifted frame.
+        paint(PanLayer::Anchor, frame, frame);
+        paint(background, preview.plot_bounds, preview.plot_bounds);
+    } else {
+        // Blending a translucent background over the anchor cannot erase its
+        // data. Exclude the anchor's interior, and fill only uncovered strips
+        // so the shifted frame's own background is also composited just once.
+        for_each_outside(frame, preview.plot_bounds, |mask| {
+            paint(PanLayer::Anchor, frame, mask);
+        });
+        for_each_outside(preview.plot_bounds, preview.mask, |mask| {
+            paint(background, mask, mask);
+        });
+    }
+    if preview.mask.size.width > px(0.0) && preview.mask.size.height > px(0.0) {
+        paint(
+            PanLayer::Content,
+            Bounds::new(frame.origin + preview.offset, frame.size),
+            preview.mask,
+        );
+    }
+}
+
+/// Disjoint positive-area rectangles covering `outer` minus `inner`.
+/// Intersect first: a fast pan can put the (empty) preview mask completely
+/// outside the plot, in which case the whole plot needs its background.
+fn for_each_outside(
+    outer: Bounds<Pixels>,
+    inner: Bounds<Pixels>,
+    mut visit: impl FnMut(Bounds<Pixels>),
+) {
+    let left = outer.left().max(inner.left());
+    let right = outer.right().min(inner.right());
+    let top = outer.top().max(inner.top());
+    let bottom = outer.bottom().min(inner.bottom());
+    if outer.size.width <= px(0.0) || outer.size.height <= px(0.0) {
+        return;
+    }
+    if right <= left || bottom <= top {
+        visit(outer);
+        return;
+    }
+    for (x0, y0, x1, y1) in [
+        (outer.left(), outer.top(), outer.right(), top),
+        (outer.left(), bottom, outer.right(), outer.bottom()),
+        (outer.left(), top, left, bottom),
+        (right, top, outer.right(), bottom),
+    ] {
+        if x1 > x0 && y1 > y0 {
+            visit(Bounds::new(point(x0, y0), size(x1 - x0, y1 - y0)));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const WIDTH: usize = 120;
+    const HOST: [u8; 4] = [30, 40, 50, 255];
+    const TRACE: [u8; 4] = [230, 40, 70, 255];
+
+    fn contains(bounds: Bounds<Pixels>, x: usize, y: usize) -> bool {
+        let p = point(px(x as f32 + 0.5), px(y as f32 + 0.5));
+        p.x >= bounds.left() && p.x < bounds.right() && p.y >= bounds.top() && p.y < bounds.bottom()
+    }
+
+    fn composite(preview: PanPreview, source: &[[u8; 4]]) -> Vec<[u8; 4]> {
+        let mut output = vec![HOST; WIDTH * WIDTH];
+        let frame = Bounds::new(point(px(0.0), px(0.0)), size(px(120.0), px(120.0)));
+        paint_pan_layers(frame, preview, |layer, placement, mask| {
+            for y in 0..WIDTH {
+                for x in 0..WIDTH {
+                    if !contains(mask, x, y) || !contains(placement, x, y) {
+                        continue;
+                    }
+                    let pixel = match layer {
+                        PanLayer::Background(c) => [c.r, c.g, c.b, c.a],
+                        PanLayer::Anchor | PanLayer::Content => {
+                            let sx = (x as f32 - f32::from(placement.origin.x)) as usize;
+                            let sy = (y as f32 - f32::from(placement.origin.y)) as usize;
+                            source[sy * WIDTH + sx]
+                        }
+                    };
+                    output[y * WIDTH + x] = source_over_straight_rgba(output[y * WIDTH + x], pixel);
+                }
+            }
+        });
+        output
+    }
+
+    #[test]
+    fn pan_pixels_never_retain_the_unshifted_trace() {
+        // A cross reaches all four uncovered edges. Big deltas and reversals
+        // model input arriving before the next raster, including zero overlap.
+        for background in [
+            [Color::WHITE, Color::TRANSPARENT],
+            [Color::from_rgb(25, 25, 25), Color::TRANSPARENT],
+            [Color::WHITE, Color::from_rgba(120, 160, 200, 128)],
+            [Color::TRANSPARENT, Color::from_rgba(120, 160, 200, 128)],
+        ] {
+            let mut view = super::super::tests::unit_frame_view();
+            view.background = background;
+            view.axis_inset_px = 2.0;
+            let base = source_over_straight_rgba(
+                [
+                    background[0].r,
+                    background[0].g,
+                    background[0].b,
+                    background[0].a,
+                ],
+                [
+                    background[1].r,
+                    background[1].g,
+                    background[1].b,
+                    background[1].a,
+                ],
+            );
+            let mut source = vec![base; WIDTH * WIDTH];
+            for y in 10..110 {
+                for x in 10..110 {
+                    if x == 60 || y == 60 {
+                        source[y * WIDTH + x] = TRACE;
+                    }
+                }
+            }
+            let frame = Bounds::new(point(px(0.0), px(0.0)), size(px(120.0), px(120.0)));
+            for (dx, dy) in [
+                (30, 0),
+                (-30, 0),
+                (0, 30),
+                (0, -30),
+                (70, 70),
+                (-70, -70),
+                (130, 0),
+                (0, -130),
+                (0, 0),
+            ] {
+                let pending = ViewportRect::from_points(
+                    ViewportPoint::new(-f64::from(dx) / 100.0, f64::from(dy) / 100.0),
+                    ViewportPoint::new(1.0 - f64::from(dx) / 100.0, 1.0 + f64::from(dy) / 100.0),
+                );
+                let preview = preview_translation_onto(
+                    &view,
+                    pending,
+                    view.plot_area,
+                    view.axis_inset_px,
+                    frame,
+                    (120, 120),
+                    true,
+                )
+                .unwrap();
+                let output = composite(preview, &source);
+                for y in 0..WIDTH {
+                    for x in 0..WIDTH {
+                        let expected = if contains(preview.plot_bounds, x, y) {
+                            if contains(preview.mask, x, y) {
+                                let sx = (x as i32 - dx) as usize;
+                                let sy = (y as i32 - dy) as usize;
+                                source_over_straight_rgba(HOST, source[sy * WIDTH + sx])
+                            } else {
+                                source_over_straight_rgba(HOST, base)
+                            }
+                        } else {
+                            source_over_straight_rgba(HOST, source[y * WIDTH + x])
+                        };
+                        assert_eq!(
+                            output[y * WIDTH + x],
+                            expected,
+                            "pan ({dx}, {dy}) pixel ({x}, {y}) background {background:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/adapters/gui/Cargo.lock
+++ b/adapters/gui/Cargo.lock
@@ -5203,7 +5203,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "base64",
  "bytemuck",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-egui"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "eframe",
  "egui",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-iced"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "arboard",
  "async-channel",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "ruviz-slint"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "arboard",
  "i-slint-backend-testing",

--- a/adapters/gui/Cargo.toml
+++ b/adapters/gui/Cargo.toml
@@ -5,7 +5,7 @@ members = ["ruviz-egui", "ruviz-iced", "ruviz-slint"]
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"

--- a/adapters/gui/ruviz-egui/Cargo.toml
+++ b/adapters/gui/ruviz-egui/Cargo.toml
@@ -22,7 +22,7 @@ gpu = ["ruviz/gpu"]
 egui = { version = "0.35", default-features = false, features = ["default_fonts"] }
 pollster = "0.4"
 rfd = "0.15"
-ruviz = { version = "=0.13.0", path = "../../.." }
+ruviz = { version = "=0.13.1", path = "../../.." }
 
 [dev-dependencies]
 eframe = { version = "0.35", default-features = false, features = ["default_fonts", "glow", "wayland", "x11"] }

--- a/adapters/gui/ruviz-iced/Cargo.toml
+++ b/adapters/gui/ruviz-iced/Cargo.toml
@@ -33,7 +33,7 @@ async-channel = "2"
 bytes = "1.9"
 arboard = "3.6.1"
 rfd = "0.15"
-ruviz = { version = "=0.13.0", path = "../../.." }
+ruviz = { version = "=0.13.1", path = "../../.." }
 
 [dev-dependencies]
 # `default-features = false` drops iced's default renderer set, so `wgpu` and

--- a/adapters/gui/ruviz-iced/README.md
+++ b/adapters/gui/ruviz-iced/README.md
@@ -98,7 +98,7 @@ to enable it:
 ```toml
 [dependencies]
 iced = { version = "0.14", features = ["wgpu", "crisp"] }
-ruviz-iced = "0.13.0"
+ruviz-iced = "0.13.1"
 ```
 
 - `wgpu` — GPU presentation. Without it Iced falls back to the `tiny-skia` CPU

--- a/adapters/gui/ruviz-slint/Cargo.toml
+++ b/adapters/gui/ruviz-slint/Cargo.toml
@@ -29,7 +29,7 @@ gpu = ["ruviz/gpu"]
 "3d-gpu" = ["3d", "gpu"]
 
 [dependencies]
-ruviz = { version = "=0.13.0", path = "../../.." }
+ruviz = { version = "=0.13.1", path = "../../.." }
 slint = { version = "~1.17", default-features = false, features = ["std", "compat-1-2"] }
 arboard = "3.6.1"
 rfd = "0.15"

--- a/adapters/gui/ruviz-slint/README.md
+++ b/adapters/gui/ruviz-slint/README.md
@@ -41,7 +41,7 @@ module support:
 
 ```toml
 [dependencies]
-ruviz-slint = "0.13.0"
+ruviz-slint = "0.13.1"
 slint = { version = "~1.17", default-features = false, features = [
     "std", "compat-1-2", "backend-winit", "renderer-femtovg"
 ] }

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-py"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 description = "Python bindings and notebook widget support for ruviz"
@@ -20,7 +20,7 @@ crate-type = ["cdylib"]
 numpy = "0.24"
 pollster = "0.4"
 pyo3 = { version = "0.24", features = ["abi3-py310"] }
-ruviz = { path = "../..", version = "0.13.0", default-features = false, features = ["3d", "parallel", "pdf", "svg"] }
+ruviz = { path = "../..", version = "0.13.1", default-features = false, features = ["3d", "parallel", "pdf", "svg"] }
 
 [dev-dependencies]
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "ruviz"
-version = "0.13.0"
+version = "0.13.1"
 description = "Python bindings and notebook widget support for ruviz"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/bindings/python/uv.lock
+++ b/bindings/python/uv.lock
@@ -2154,7 +2154,7 @@ wheels = [
 
 [[package]]
 name = "ruviz"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },

--- a/bindings/wasm/Cargo.toml
+++ b/bindings/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruviz-web"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2024"
 rust-version = "1.92"
 license = "MIT OR Apache-2.0"
@@ -32,7 +32,7 @@ default = ["embedded-font"]
 "3d-gpu" = ["3d", "ruviz/gpu", "dep:wgpu", "dep:wasm-bindgen-futures"]
 
 [dependencies]
-ruviz = { version = "0.13.0", path = "../..", default-features = false }
+ruviz = { version = "0.13.1", path = "../..", default-features = false }
 js-sys = "0.3.92"
 wasm-bindgen = "0.2.105"
 console_error_panic_hook = "0.1.7"

--- a/bindings/wasm/README.md
+++ b/bindings/wasm/README.md
@@ -21,7 +21,7 @@ Add the bridge crate to your Cargo manifest:
 
 ```toml
 [dependencies]
-ruviz-web = "0.13.0"
+ruviz-web = "0.13.1"
 ```
 
 Build for `wasm32-unknown-unknown` and generate bindings with your preferred

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -2,17 +2,12 @@
 
 Get started with ruviz in less than 5 minutes!
 
-## What's New in v0.13.0
+## What's New in v0.13.1
 
-- Panning an interactive GPUI plot is smooth at any drag speed: the plot
-  content translates on the GPU every frame while the axes, ticks and margins
-  stay anchored, rasters run on a throttle with one in flight, and the final
-  raster lands exactly under the preview on release.
-- A pan no longer stalls after its first move when the adapter's own render is
-  pending, and compatible in-flight frames install instead of being dropped
-  under continuous input.
-- The macOS GPU surface upload converts rows in place without materialising a
-  straight-alpha copy of the frame, roughly halving the per-raster cost.
+- Fast GPUI pan previews erase stale data in uncovered plot areas, preventing
+  a stationary copy of a spectrum from appearing beside the moving trace.
+- Axes stay anchored, transparent backgrounds are composited once, and the
+  existing asynchronous rendering and 32 ms pan raster pacing are preserved.
 
 See full details:
 
@@ -30,7 +25,7 @@ cd my_plot
 2. **Add ruviz to your `Cargo.toml`**:
 ```toml
 [dependencies]
-ruviz = "0.13.0"
+ruviz = "0.13.1"
 ```
 
 3. **Write your first plot** in `src/main.rs`:
@@ -69,8 +64,8 @@ an embedded interactive plot view:
 
 ```toml
 [dependencies]
-ruviz = "0.13.0"
-ruviz-gpui = "0.13.0"
+ruviz = "0.13.1"
+ruviz-gpui = "0.13.1"
 ```
 
 `ruviz-gpui` is supported on Linux, macOS, and Windows. On Windows, prefer the
@@ -98,7 +93,7 @@ If you want publication-style math in labels and titles, enable Typst text rende
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["typst-math"] }
+ruviz = { version = "0.13.1", features = ["typst-math"] }
 ```
 
 `.typst(true)` is only available when `typst-math` is enabled. The configured
@@ -117,7 +112,7 @@ If you want Typst to stay optional in your own crate, forward a local feature fi
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", default-features = false }
+ruviz = { version = "0.13.1", default-features = false }
 
 [features]
 default = []
@@ -369,7 +364,7 @@ Plot::new()
 ### With polars (requires `polars_support` feature)
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["polars_support"] }
+ruviz = { version = "0.13.1", features = ["polars_support"] }
 polars = "0.50"
 ```
 
@@ -397,7 +392,7 @@ Plot::new()
 only when you have benchmarked a path that benefits from the extra SIMD support:
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["performance"] }
+ruviz = { version = "0.13.1", features = ["performance"] }
 ```
 
 ### Large Dataset Export

--- a/docs/guide/02_installation.md
+++ b/docs/guide/02_installation.md
@@ -62,14 +62,14 @@ Add ruviz to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-ruviz = "0.13.0"
+ruviz = "0.13.1"
 ```
 
 Or with specific features:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.13.1", features = ["ndarray_support", "parallel"] }
 ```
 
 ## Feature Flags
@@ -79,7 +79,7 @@ ruviz uses feature flags to enable optional functionality. Choose based on your 
 ### Default Features
 
 ```toml
-ruviz = "0.13.0"  # Includes: ndarray_support, parallel
+ruviz = "0.13.1"  # Includes: ndarray_support, parallel
 ```
 
 **Enabled by default**:
@@ -110,40 +110,40 @@ SVG export is available without an extra feature flag. The legacy `svg` feature 
 
 ```toml
 # High performance (parallel + SIMD)
-ruviz = { version = "0.13.0", features = ["performance"] }
+ruviz = { version = "0.13.1", features = ["performance"] }
 
 # Maximum capability (all features)
-ruviz = { version = "0.13.0", features = ["full"] }
+ruviz = { version = "0.13.1", features = ["full"] }
 
 # Minimal (no default features)
-ruviz = { version = "0.13.0", default-features = false }
+ruviz = { version = "0.13.1", default-features = false }
 ```
 
 ### Feature Combinations
 
 **Scientific Computing**:
 ```toml
-ruviz = { version = "0.13.0", features = ["ndarray_support", "parallel"] }
+ruviz = { version = "0.13.1", features = ["ndarray_support", "parallel"] }
 ```
 
 **Data Analysis**:
 ```toml
-ruviz = { version = "0.13.0", features = ["polars_support", "performance"] }
+ruviz = { version = "0.13.1", features = ["polars_support", "performance"] }
 ```
 
 **Publication Quality**:
 ```toml
-ruviz = { version = "0.13.0", features = ["serde", "pdf"] }
+ruviz = { version = "0.13.1", features = ["serde", "pdf"] }
 ```
 
 **Real-time Visualization**:
 ```toml
-ruviz = { version = "0.13.0", features = ["interactive-gpu"] }
+ruviz = { version = "0.13.1", features = ["interactive-gpu"] }
 ```
 
 **Large Datasets**:
 ```toml
-ruviz = { version = "0.13.0", features = ["parallel", "simd", "gpu"] }
+ruviz = { version = "0.13.1", features = ["parallel", "simd", "gpu"] }
 ```
 
 ## Verification
@@ -189,7 +189,7 @@ Test specific features:
 **ndarray**:
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["ndarray_support"] }
+ruviz = { version = "0.13.1", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -282,7 +282,7 @@ rustup update
 
 ### Feature Conflicts
 
-**Problem**: `error: package ruviz v0.13.0 cannot be built because it requires rustc 1.92 or newer`
+**Problem**: `error: package ruviz v0.13.1 cannot be built because it requires rustc 1.92 or newer`
 
 **Solution**: Update Rust:
 ```bash
@@ -306,7 +306,7 @@ vulkaninfo
 
 Or disable GPU features:
 ```toml
-ruviz = { version = "0.13.0", default-features = false, features = ["parallel"] }
+ruviz = { version = "0.13.1", default-features = false, features = ["parallel"] }
 ```
 
 ### Memory Issues (Large Datasets)

--- a/docs/guide/03_first_plot.md
+++ b/docs/guide/03_first_plot.md
@@ -166,7 +166,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = "0.13.0"
+ruviz = "0.13.1"
 ```
 
 ## Customization Basics
@@ -304,7 +304,7 @@ Plot::new()
 Add to `Cargo.toml`:
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["ndarray_support"] }
+ruviz = { version = "0.13.1", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 

--- a/docs/guide/04_plot_types.md
+++ b/docs/guide/04_plot_types.md
@@ -776,7 +776,7 @@ Use `performance` only after benchmarking a path that benefits from SIMD support
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["simd"] }
+ruviz = { version = "0.13.1", features = ["simd"] }
 ```
 
 ### Very Large Datasets (> 100K points)

--- a/docs/guide/07_backends.md
+++ b/docs/guide/07_backends.md
@@ -132,7 +132,7 @@ not a guarantee that a public `render()` call will take a SIMD path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["simd"] }
+ruviz = { version = "0.13.1", features = ["simd"] }
 ```
 
 ## What `save()` actually does
@@ -201,7 +201,7 @@ path.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["gpu"] }
+ruviz = { version = "0.13.1", features = ["gpu"] }
 ```
 
 ```rust
@@ -237,7 +237,7 @@ dependency for you.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["interactive"] }
+ruviz = { version = "0.13.1", features = ["interactive"] }
 tokio = { version = "1", features = ["rt", "macros"] }
 ```
 

--- a/docs/guide/08_performance.md
+++ b/docs/guide/08_performance.md
@@ -48,7 +48,7 @@ at `t`.
 
 ```toml
 [dependencies]
-ruviz = "0.13.0"
+ruviz = "0.13.1"
 ```
 
 Useful opt-in features:

--- a/docs/guide/09_data_integration.md
+++ b/docs/guide/09_data_integration.md
@@ -64,7 +64,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["ndarray_support"] }
+ruviz = { version = "0.13.1", features = ["ndarray_support"] }
 ndarray = "0.17"
 ```
 
@@ -183,7 +183,7 @@ Plot::new()
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["nalgebra_support"] }
+ruviz = { version = "0.13.1", features = ["nalgebra_support"] }
 nalgebra = "0.32"
 ```
 
@@ -231,7 +231,7 @@ synthetic absorbed-energy style example.
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["polars_support"] }
+ruviz = { version = "0.13.1", features = ["polars_support"] }
 polars = { version = "0.50", features = ["lazy", "rolling_window"] }
 ```
 
@@ -491,7 +491,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
 ```toml
 [dependencies]
-ruviz = "0.13.0"
+ruviz = "0.13.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 ```

--- a/docs/guide/10_export.md
+++ b/docs/guide/10_export.md
@@ -539,7 +539,7 @@ Plot::new()
 ### PDF Export
 
 ```rust
-// Requires: ruviz = { version = "0.13.0", features = ["pdf"] }
+// Requires: ruviz = { version = "0.13.1", features = ["pdf"] }
 use ruviz::prelude::*;
 
 Plot::new()

--- a/docs/guide/12_3d.md
+++ b/docs/guide/12_3d.md
@@ -5,7 +5,7 @@ feature name `3d`:
 
 ```toml
 [dependencies]
-ruviz = { version = "0.13.0", features = ["3d"] }
+ruviz = { version = "0.13.1", features = ["3d"] }
 ```
 
 The canonical entry points are deliberately small:

--- a/docs/migration/makie-3d.md
+++ b/docs/migration/makie-3d.md
@@ -3,7 +3,7 @@
 Enable Ruviz's exact `3d` feature:
 
 ```toml
-ruviz = { version = "0.13.0", features = ["3d"] }
+ruviz = { version = "0.13.1", features = ["3d"] }
 ```
 
 The closest API mappings are:

--- a/docs/migration/matplotlib-3d.md
+++ b/docs/migration/matplotlib-3d.md
@@ -3,7 +3,7 @@
 Enable Ruviz's exact `3d` feature:
 
 ```toml
-ruviz = { version = "0.13.0", features = ["3d"] }
+ruviz = { version = "0.13.1", features = ["3d"] }
 ```
 
 The closest API mappings are:

--- a/docs/migration/matplotlib.md
+++ b/docs/migration/matplotlib.md
@@ -416,7 +416,7 @@ let viridis_like = Theme::builder()
 ## Migration Checklist
 
 - [ ] Install Rust and cargo
-- [ ] Add `ruviz = "0.13.0"` to `Cargo.toml`
+- [ ] Add `ruviz = "0.13.1"` to `Cargo.toml`
 - [ ] Convert numpy arrays to `Vec<f64>` or `ndarray`
 - [ ] Replace `plt.plot()` with `Plot::new().line()`
 - [ ] Change `plt.savefig()` to `.save()?`

--- a/docs/releases/v0.13.1.md
+++ b/docs/releases/v0.13.1.md
@@ -1,0 +1,19 @@
+# ruviz 0.13.1
+
+Fast drags in GPUI plots now remove the stationary trace that could remain
+visible behind the moving spectrum. The preview fills uncovered plot areas
+with the configured background while preserving the axis frame. New data for
+those areas appears when the next asynchronous raster arrives.
+
+The correction applies to image and macOS surface presentation. Opaque plots
+need one additional background quad, without an extra raster or pixel copy.
+Transparent plots use disjoint clips so neither old data nor a twice-blended
+background shows through. Existing pan pacing and in-flight frame handling
+are retained.
+
+Regression coverage checks the resulting pixels across drag directions,
+reversals, shifts beyond the viewport, identity previews, and four background
+configurations. The existing interaction tests cover final-frame replacement,
+anchored axes, zoom fallback, and in-flight rendering.
+
+Fixes [#184](https://github.com/Ameyanagi/ruviz/issues/184).

--- a/packages/ruviz/package.json
+++ b/packages/ruviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruviz",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Browser-first JS/TS SDK for ruviz WebAssembly rendering",
   "type": "module",
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
Fast GPUI pans can display a stationary spectrum beside the moving preview because the old frame remains visible in newly uncovered areas. Fill the entire plot interior before translating opaque frames; for translucent backgrounds, clip the anchor out of the interior and fill only uncovered strips so each background is blended once. Both image and macOS surface presentation use this composition.

The normal opaque path adds one background quad, without a full raster or pixel copy. Axes, the 32 ms raster interval, asynchronous scheduling, and final-frame replacement retain their existing behavior. Coordinate package versions, install snippets, and release notes for 0.13.1.

Validation:
- New pixel regression failed with the previous composition: pan (+30, 0), pixel (12, 60) contained the old red trace instead of white background.
- The regression passes across horizontal/vertical/diagonal shifts, reversals, shifts beyond the viewport, identity previews, and light/dark/translucent/transparent backgrounds.
- All 67 default GPUI tests and all 90 all-feature GPUI tests pass on macOS, including existing anchor, in-flight render, zoom, and release behavior tests.
- Pre-commit formatting, root and Python Clippy, locked metadata for all workspaces, documentation examples and repository structure checks pass.

Closes #184.
